### PR TITLE
MonteCarlo add_variable duplicate protection and get_variable functionality

### DIFF
--- a/include/trick/MonteCarlo.hh
+++ b/include/trick/MonteCarlo.hh
@@ -14,6 +14,11 @@
 #include "trick/RemoteShell.hh"
 #include "trick/tc.h"
 
+#ifdef SWIG
+// This instructs SWIG to use dynamic_cast and return one of the derived type for the get_variable function.
+%factory(Trick::MonteVar * Trick::MonteCarlo::get_variable, Trick::MonteVarCalculated, Trick::MonteVarFile, Trick::MonteVarFixed, Trick::MonteVarRandom) ;
+#endif
+
 namespace Trick {
 
     /**
@@ -621,6 +626,13 @@ namespace Trick {
          * @see @ref MonteCarloVariables "Adding Variables"
          */
         void add_variable(Trick::MonteVar *variable);
+
+        /**
+         * Gets the specified variable.
+         *
+         * @param variable name to get
+         */
+        Trick::MonteVar * get_variable(std::string variable_name);
 
         /**
          * Adds a new slave with the specified machine name.

--- a/include/trick/MonteVarCalculated.hh
+++ b/include/trick/MonteVarCalculated.hh
@@ -13,6 +13,20 @@
 #include "trick/MonteVar.hh"
 #include "trick/reference.h"
 
+// This block of code disowns the pointer on the python side so you can reassign 
+// python variables without freeing the C++ class underneath
+#ifdef SWIG
+%feature("compactdefaultargs","0") ;
+%feature("shadow") Trick::MonteVarCalculated::MonteVarCalculated(std::string name) %{
+    def __init__(self, *args):
+        this = $action(*args)
+        try: self.this.append(this)
+        except: self.this = this
+        this.own(0)
+        self.this.own(0)
+%}
+#endif
+
 namespace Trick {
 
     /**

--- a/include/trick/MonteVarFile.hh
+++ b/include/trick/MonteVarFile.hh
@@ -14,6 +14,20 @@
 
 #include "trick/MonteVar.hh"
 
+// This block of code disowns the pointer on the python side so you can reassign 
+// python variables without freeing the C++ class underneath
+#ifdef SWIG
+%feature("compactdefaultargs","0") ;
+%feature("shadow") Trick::MonteVarFile::MonteVarFile(std::string name, std::string file_name, unsigned int column) %{
+    def __init__(self, *args):
+        this = $action(*args)
+        try: self.this.append(this)
+        except: self.this = this
+        this.own(0) 
+        self.this.own(0)
+%}
+#endif
+
 namespace Trick {
 
     /**

--- a/include/trick/MonteVarFixed.hh
+++ b/include/trick/MonteVarFixed.hh
@@ -12,6 +12,20 @@
 
 #include "trick/MonteVar.hh"
 
+// This block of code disowns the pointer on the python side so you can reassign 
+// python variables without freeing the C++ class underneath
+#ifdef SWIG
+%feature("compactdefaultargs","0") ;
+%feature("shadow") Trick::MonteVarFixed::MonteVarFixed(std::string name, double value) %{
+    def __init__(self, *args):
+        this = $action(*args)
+        try: self.this.append(this)
+        except: self.this = this
+        this.own(0)
+        self.this.own(0)
+%}
+#endif
+
 namespace Trick {
 
     /**

--- a/include/trick/MonteVarRandom.hh
+++ b/include/trick/MonteVarRandom.hh
@@ -14,6 +14,20 @@
 #include "trick/rand_generator.h"
 #include "trick/StlRandomGenerator.hh"
 
+// This block of code disowns the pointer on the python side so you can reassign 
+// python variables without freeing the C++ class underneath
+#ifdef SWIG
+%feature("compactdefaultargs","0") ;
+%feature("shadow") Trick::MonteVarRandom::MonteVarRandom(std::string name, Distribution distribution) %{
+    def __init__(self, *args):
+        this = $action(*args)
+        try: self.this.append(this)
+        except: self.this = this
+        this.own(0)
+        self.this.own(0)
+%}
+#endif
+
 namespace Trick {
 
     /**

--- a/include/trick/swig/trick_swig.i
+++ b/include/trick/swig/trick_swig.i
@@ -4,6 +4,7 @@
 %include "std_map.i"
 %include "std_string.i"
 %include "std_vector.i"
+%include "factory.i"
 
 %include "trick/swig/swig_extend_str.i"
 %include "trick/swig/swig_class_typedef.i"

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_funcs.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_funcs.cpp
@@ -153,7 +153,29 @@ void Trick::MonteCarlo::get_ranges(std::vector<MonteRange *> &ranges) {
 }
 
 void Trick::MonteCarlo::add_variable(Trick::MonteVar *variable) {
+    for (std::vector<Trick::MonteVar *>::const_iterator i = variables.begin(); i != variables.end(); ++i) {
+        if ( (*i)->name.compare(variable->name) == 0 ) {
+            message_publish(MSG_WARNING, "Monte WARNING: Cannot add new MonteVar \"%s\", variable of that name already exists.\n",
+                    variable->name.c_str() );
+            return;
+        }
+    }
     variables.push_back(variable);
+}
+
+/** 
+ * @par Detailed Design:
+ * Get a pointer to a MonteVar by name. Note this is used in conjunction with 
+ * %factory so that swig produces methods returning all derived types
+ */
+Trick::MonteVar * Trick::MonteCarlo::get_variable(std::string variable_name) {
+
+    for (std::vector<Trick::MonteVar *>::const_iterator i = variables.begin(); i != variables.end(); ++i) {
+        if ( (*i) and (*i)->name.compare(variable_name) == 0 ) {
+            return (*i); 
+        } 
+    }
+    return (NULL);
 }
 
 void Trick::MonteCarlo::add_slave(std::string in_machine_name) {


### PR DESCRIPTION
Added duplicate name protection on add_variable and get_variable
mechanism for getting MonteVar * derived types so that those dispersion
settings can be changed once they go out of scope.