### PR TITLE
Fixed indexing problem when reducing number of monte carlo runs

### DIFF
--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_funcs.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_funcs.cpp
@@ -108,8 +108,8 @@ void Trick::MonteCarlo::set_num_runs(unsigned int in_num_runs) {
         runs.push_back(new Trick::MonteRun(this->num_runs++));
     }
     while ( (this->num_runs > in_num_runs) && !runs.empty() ) {
-        delete runs.front();
-        runs.pop_front();
+        delete runs.back();
+        runs.pop_back();
         --this->num_runs;
     }
     update_actual_num_runs();


### PR DESCRIPTION
When runs reduced via successive calls to set_num_runs, instead of using
pop_front() and front(), use pop_back() and back()

Refs #304