### PR TITLE
Added MonteVar setters where appropriate

### DIFF
--- a/include/trick/MonteVar.hh
+++ b/include/trick/MonteVar.hh
@@ -35,6 +35,12 @@ namespace Trick {
 
         /** Destructor. */
         virtual ~MonteVar() {};
+        /**
+         * Sets the unit
+         *
+         * @param in_unit this variable's units
+         */
+        void set_unit(std::string in_unit) { this->unit = in_unit; }
 
         /** Class MonteCarlo is a friend so it can use the get_next_value method.
          *  The get_next_value method needs to be protected so users cannot use it in the input file

--- a/include/trick/MonteVarFile.hh
+++ b/include/trick/MonteVarFile.hh
@@ -87,6 +87,22 @@ namespace Trick {
          */
         MonteVarFile(std::string name, std::string file_name, unsigned int column, std::string unit = "");
 
+        /** Destructor. */
+        virtual ~MonteVarFile();
+        /**
+         * Sets the file name 
+         *
+         * @param in_file_name the name of the file containing this variable's values
+         */
+        void set_file_name(std::string in_file_name);
+
+        /**
+         * Sets the column
+         *
+         * @param in_column the column (starting at 1)  within the file corresponding to this variable
+         */
+        void set_column(unsigned int in_column);
+
         protected:
         virtual std::string get_next_value();
 

--- a/include/trick/MonteVarFixed.hh
+++ b/include/trick/MonteVarFixed.hh
@@ -49,6 +49,8 @@ namespace Trick {
          */
         MonteVarFixed(std::string name, double value, std::string unit = "");
 
+        void set_value(double in_value);
+
         protected:
         virtual std::string get_next_value();
 

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -7,19 +7,21 @@
 #include "trick/message_proto.h"
 #include "trick/exec_proto.h"
 
-Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) {
+Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) :
+    input_file_stream(NULL)
+{
     this->name = in_name;
-    this->file_name = in_file_name;
     this->column = in_column;
     this->unit = in_unit;
-
-    input_file_stream = new std::ifstream(file_name.c_str(), std::ifstream::in);
-    if (input_file_stream->fail()) { 
-        char string[100];
-        sprintf(string, "Trick:MonteVarFile the input file \"%s\" failed to open", file_name.c_str());
-        exec_terminate_with_return(-1, __FILE__, __LINE__, string);
-   }
+  
+    set_file_name(in_file_name);
     buffer = new char[4096];
+
+}
+
+Trick::MonteVarFile::~MonteVarFile() {
+    delete input_file_stream;
+    delete buffer;
 }
 
 std::string Trick::MonteVarFile::get_next_value() {
@@ -79,3 +81,20 @@ std::string Trick::MonteVarFile::get_next_value() {
 
     return NULL;
 }
+
+void Trick::MonteVarFile::set_file_name(std::string in_file_name) {
+    delete input_file_stream;
+
+    input_file_stream = new std::ifstream(in_file_name.c_str(), std::ifstream::in);
+    if (input_file_stream->fail()) {
+        std::stringstream string_stream;
+        string_stream << "Trick:MonteVarFile the input file \"" << in_file_name <<  "\" failed to open";
+        exec_terminate_with_return(-1, __FILE__, __LINE__, string_stream.str().c_str());
+    }
+    this->file_name = in_file_name;
+}
+
+void Trick::MonteVarFile::set_column(unsigned int in_column) {
+    this->column = in_column;
+}
+

--- a/trick_source/sim_services/MonteCarlo/MonteVarFixed.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFixed.cpp
@@ -5,11 +5,16 @@
 
 Trick::MonteVarFixed::MonteVarFixed(std::string in_name, double in_value, std::string in_unit) {
     this->name = in_name;
+    set_value(in_value);
+    this->unit = in_unit;
+}
+
+void Trick::MonteVarFixed::set_value(double in_value) {
     std::ostringstream string_stream;
     string_stream << std::setprecision(15) << in_value ;
     this->value = string_stream.str();
-    this->unit = in_unit;
 }
+
 
 std::string Trick::MonteVarFixed::get_next_value() {
     std::ostringstream string_stream;


### PR DESCRIPTION
Added set_unit mechanism to MonteVar baseclass. Added MonteVar's derived
classes setters where appropriate to facilitate changing inputs after
the instance of MonteVar has already been constructed. Fleshed out
MonteVarFile destructor to remove memory leaks.