### PR TITLE
Fixes #347 on Mac OS X Sierra

### DIFF
--- a/configure
+++ b/configure
@@ -2620,7 +2620,7 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 PATH="/opt/rh/devtoolset-3/root/usr/bin:${PATH}"
-XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include"
+XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/libxml2/include/libxml2"
 CFLAGS="$CFLAGS $XTRAINCPATHS"
 CPPFLAGS="$CPPFLAGS $XTRAINCPATHS"
 

--- a/trick_source/data_products/DPX/APPS/GXPLOT/makefile
+++ b/trick_source/data_products/DPX/APPS/GXPLOT/makefile
@@ -7,7 +7,7 @@ CPP = c++
 
 DPX_DIR = ../..
 
-INCDIRS = -I${DPX_DIR} -I../../.. -I${TRICK_HOME}/include -I/usr/include/libxml2 $(MOTIF_INCDIR)
+INCDIRS = -I${DPX_DIR} -I../../.. -I${TRICK_HOME}/include -I/usr/include/libxml2 -I/usr/local/opt/libxml2/include/libxml2 $(MOTIF_INCDIR)
 
 CFLAGS = -g -Wall $(UDUNITS_INCLUDES)
 

--- a/trick_source/data_products/DPX/DPC/makefile
+++ b/trick_source/data_products/DPX/DPC/makefile
@@ -7,7 +7,7 @@ CPP = c++
 
 DPX_DIR  = ..
 
-INCLUDE_DIRS = -I${DPX_DIR} -I../.. -I${TRICK_HOME}/include -I/usr/include/libxml2
+INCLUDE_DIRS = -I${DPX_DIR} -I../.. -I${TRICK_HOME}/include -I/usr/include/libxml2 -I/usr/local/opt/libxml2/include/libxml2
 
 CFLAGS = -g -Wall $(UDUNITS_INCLUDES)
 

--- a/trick_source/data_products/DPX/DPM/makefile
+++ b/trick_source/data_products/DPX/DPM/makefile
@@ -7,7 +7,7 @@ CPP = c++
 
 DPX_DIR = ..
 
-INCLUDE_DIRS = -I${DPX_DIR} -I../.. -I${TRICK_HOME}/include -I/usr/include/libxml2
+INCLUDE_DIRS = -I${DPX_DIR} -I../.. -I${TRICK_HOME}/include -I/usr/include/libxml2 -I/usr/local/opt/libxml2/include/libxml2
 
 CFLAGS = -g -Wall $(UDUNITS_INCLUDES)
 


### PR DESCRIPTION
I also had to `brew install libxml2`, but it may be possible to use one of the pre-installed frameworks.