### PR TITLE
Reduced size of generated argument list for simulation library creation

### DIFF
--- a/bin/pm/make_makefile.pm
+++ b/bin/pm/make_makefile.pm
@@ -772,7 +772,8 @@ clean_obj: clean_model_c_obj clean_model_cpp_obj clean_model_io_obj clean_lex_ya
     print MAKEFILE "\$(LIB_DIR)/lib_${sim_dir_name}.a : \$(OBJECTS) \$(IO_OBJECTS) \$(DEFAULT_DATA_OBJECTS)\n" ;
     print MAKEFILE "\t@ echo \"[36mCreating libraries...[00m\"\n" ;
     print MAKEFILE "\t\@ rm -rf \$\@\n" ;
-    print MAKEFILE "\tar crs \$\@ \$(LIB_DIR)/*.o || touch \$\@\n\n" ;
+    print MAKEFILE "\tcd \$(LIB_DIR) \; ar crs \$\@ *.o || touch \$\@\n\n" ;
+
 
     # print out the sim directory libraries
     foreach my $l ( @{$$sim_ref{sim_libraries}} ) {


### PR DESCRIPTION
Change the way the simulation object library is generated to eliminate long paths at the beginning of each file going into the argument list for the ar command. The make command on macOS is sensitive to the length of the argument list, and the ar command would fail when the argument list gets north of 200,000 characters.