### PR TITLE
Re-add '-std=c++11' in ICG CXXFLAGS when Clang version >= 3.5

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/makefile
+++ b/trick_source/codegen/Interface_Code_Gen/makefile
@@ -44,6 +44,7 @@ endif
 ifeq ($(TRICK_HOST_TYPE),Linux)
 CLANGLIBS += $(shell $(LLVM_HOME)/bin/llvm-config --libs)
 ifeq ($(CLANG_MINOR_GTEQ5),1)
+CXXFLAGS += -std=c++11
 # Fedora 21 adds -ledit as a system lib, but it isn't installed, or required.
 CLANGLIBS += $(filter-out -ledit,$(shell $(LLVM_HOME)/bin/llvm-config --system-libs))
 endif


### PR DESCRIPTION
Fixes #424