### PR TITLE
Capped the maximum throttle value to 1000.

### DIFF
--- a/trick_source/java/src/trick/simcontrol/utils/SimControlActionController.java
+++ b/trick_source/java/src/trick/simcontrol/utils/SimControlActionController.java
@@ -193,13 +193,11 @@ public class SimControlActionController {
 					public void actionPerformed(ActionEvent e) {
 						// CTLaChance - 05-22-17
 						// Cap the maximum possible value to 1000.
-						if(Double.valueOf(maxField.getText()) > 1000)
-						{
+						if(Double.valueOf(maxField.getText()) > 1000) {
 							maxField.setText(Double.toString(1000));
 							slider.setDoubleMaximum(1000);
 						}
-						else
-						{
+						else {
 							slider.setDoubleMaximum(Double.valueOf(maxField.getText()));
 						}
 					}

--- a/trick_source/java/src/trick/simcontrol/utils/SimControlActionController.java
+++ b/trick_source/java/src/trick/simcontrol/utils/SimControlActionController.java
@@ -191,7 +191,17 @@ public class SimControlActionController {
 		maxField.addActionListener( 
 				new ActionListener() {
 					public void actionPerformed(ActionEvent e) {
-						slider.setDoubleMaximum(Double.valueOf(maxField.getText()));
+						// CTLaChance - 05-22-17
+						// Cap the maximum possible value to 1000.
+						if(Double.valueOf(maxField.getText()) > 1000)
+						{
+							maxField.setText(Double.toString(1000));
+							slider.setDoubleMaximum(1000);
+						}
+						else
+						{
+							slider.setDoubleMaximum(Double.valueOf(maxField.getText()));
+						}
 					}
 				});
 		


### PR DESCRIPTION
Entering extremely large values into the maximum value field of the throttle GUI caused the GUI to freeze. Imposing a cap of 1000 to the maximum value prevents the GUI from freezing.