### PR TITLE
Replaced socket_init calls with tc_init.

### DIFF
--- a/include/trick/MonteCarlo.hh
+++ b/include/trick/MonteCarlo.hh
@@ -324,9 +324,6 @@ namespace Trick {
         /** Highest level of messages to report. */
         Verbosity verbosity;                            /**< \n trick_units(--) */
 
-        /** Default to false and randomly find port numbers. True, use the user provided port numbers. */
-        bool default_port_flag;                         /**< \n trick_units(--) */
-
         /** Device over which connections are accepted. */
         TCDevice listen_device;                         /**< \n trick_units(--) */
 
@@ -740,13 +737,6 @@ namespace Trick {
 #endif
 
         protected:
-        /**
-         * Initializes sockets.
-         *
-         * @return 0 on success
-         */
-        int socket_init(TCDevice *listen_device);
-
         /**
          * Initializes the master.
          *

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo.cpp
@@ -11,7 +11,6 @@ Trick::MonteCarlo::MonteCarlo() :
     timeout(120),
     max_tries(2),
     verbosity(INFORMATIONAL),
-    default_port_flag(1),
     num_runs(0),
     actual_num_runs(0),
     num_results(0),
@@ -29,8 +28,8 @@ Trick::MonteCarlo::MonteCarlo() :
     memset(&listen_device, 0, sizeof(TCDevice)) ;
     memset(&connection_device, 0, sizeof(TCDevice)) ;
 
-    listen_device.port = 7200;
-    connection_device.port = 7200;
+    listen_device.port = 0;
+    connection_device.port = 0;
 
     listen_device.disable_handshaking = TC_COMM_TRUE;
     connection_device.disable_handshaking = TC_COMM_TRUE;

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_funcs.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_funcs.cpp
@@ -300,14 +300,6 @@ int Trick::MonteCarlo::shutdown() {
     return 0;
 }
 
-/** @par Detailed Design: */
-int Trick::MonteCarlo::socket_init(TCDevice *in_listen_device) {
-    if (default_port_flag) {
-        in_listen_device->port = 0;
-    }
-    return tc_init(in_listen_device);
-}
-
 void Trick::MonteCarlo::handle_retry(MonteSlave& slave, MonteRun::ExitStatus exit_status) {
     if (max_tries <= 0 || slave.current_run->num_tries < max_tries) {
         // Add the run to the retry queue.
@@ -529,14 +521,12 @@ void Trick::MonteCarlo::set_current_run(int run_num) {
 
 void Trick::MonteCarlo::set_listen_device_port(int port_number) {
         listen_device.port = port_number ;
-        default_port_flag = false ;
 }
 
 void Trick::MonteCarlo::set_connection_device_port(int port_number) {
     // This port is passed to slave as an argument, do not override
     if (is_master()) {
         connection_device.port = port_number ;
-        default_port_flag = false ;
     }
 }
 

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_initialize_sockets.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_initialize_sockets.cpp
@@ -15,7 +15,7 @@ int Trick::MonteCarlo::initialize_sockets() {
     tc_error(&connection_device, 0);
 
     /** <ul><li> Initialize the sockets for communication with slaves. */
-    int return_value = socket_init(&listen_device);
+    int return_value = tc_init(&listen_device);
     if (return_value != TC_SUCCESS) {
         if (verbosity >= ERROR) {
             message_publish(MSG_ERROR, "Monte [Master] Failed to initialize status communication socket.\n") ;

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_slave_init.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_slave_init.cpp
@@ -29,7 +29,7 @@ int Trick::MonteCarlo::slave_init() {
     /** <li> Initialize the sockets. */
     tc_error(&listen_device, 0);
     tc_error(&connection_device, 0);
-    socket_init(&listen_device);
+    tc_init(&listen_device);
     listen_device.disable_handshaking = TC_COMM_TRUE;
 
     /** <li> Connect to the master and write the port over which we are listening for new runs. */


### PR DESCRIPTION
Some classes were still calling socket_init which had been removed. Replaced those calls with tc_init.

Make compiled and make test successfully ran all tests. Jenkins should be happy now.

This pull requests references the following issue: #398 