### PR TITLE
Fixes #468

### DIFF
--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -90,7 +90,8 @@ my $class_def   = qr/(?:class|struct)\s*                   # keyword class or st
              /sx ;
 my $template_def   = qr/template\s*                        # keyword template
             <[^>]+>\s*                                     # template parameters
-            class\s*[_A-Za-z]\w*\s*                        # keyword class and class name
+            (class|struct)                                 # keyword class or struct
+            \s+[_A-Za-z]\w*\s*                             # class name
                /sx ;
 my $template_var_def  = qr/(?:\:\:)?[_A-Za-z][:\w]*\s*     # template name
             <[\w\s\*,:<>]*>\s*                             # template parameters


### PR DESCRIPTION
Fixes issue https://github.com/nasa/trick/issues/468.

This is not a complete fix. Template template parameters (e.g., `template< template<class> class T> class Foo ...`) aren't parsed correctly.