### PR TITLE
Non-numerical values can now be used in Monte Carlo data files.

### DIFF
--- a/include/trick/MonteVarFile.hh
+++ b/include/trick/MonteVarFile.hh
@@ -73,9 +73,6 @@ namespace Trick {
         /** The input file stream. */
         std::ifstream *input_file_stream; /**< \n trick_units(--) */
 
-        /** A character buffer. */
-        char *buffer;                     /**< \n trick_units(--) */
-
         public:
         /**
          * Constructs a MonteVarFile with the specified name, file name, column, and units.

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -8,8 +8,7 @@
 #include "trick/message_proto.h"
 #include "trick/exec_proto.h"
 
-Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) :
-    input_file_stream(NULL)
+Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) : input_file_stream(NULL)
 {
     this->name = in_name;
     this->column = in_column;
@@ -19,7 +18,8 @@ Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name,
     buffer = new char[4096];
 }
 
-Trick::MonteVarFile::~MonteVarFile() {
+Trick::MonteVarFile::~MonteVarFile()
+{
     delete input_file_stream;
     delete buffer;
 }
@@ -30,7 +30,7 @@ std::string Trick::MonteVarFile::describe_variable()
     std::stringstream ss;
 
     ss << "#NAME:\t\t" << this->name << "\n"
-       << "#TYPE:\t\tFILE\n" 
+       << "#TYPE:\t\tFILE\n"
        << "#UNIT:\t\t" << this->unit << "\n"
        << "#FILE:\t\t" << this->file_name << "\n"
        << "#COLUMN:\t" << this->column << "\n";
@@ -38,56 +38,70 @@ std::string Trick::MonteVarFile::describe_variable()
     return ss.str();
 }
 
-std::string Trick::MonteVarFile::get_next_value() {
-    if (input_file_stream->good()) {
-        double file_value;
-        char *current_position = buffer;
-        do {
+std::string Trick::MonteVarFile::get_next_value()
+{
+    if (input_file_stream->good())
+    {
+        // Skip the comments and empty lines in the data file.
+        do
+        {
             input_file_stream->getline(buffer, 4096);
-            file_value = strtold(buffer, &current_position);
-            if (input_file_stream->eof()) {
+
+            if(input_file_stream->eof())
+            {
                 input_file_stream->close();
                 return "EOF";
             }
-        } while (file_value == 0 && current_position == buffer && input_file_stream->good());
+        }
+        while(buffer[0] == '#' || buffer[0] == '\0');
 
-        //  Count the number of columns in the input file
-        char* token;
+        // Count the number of columns in the input file.
+        char *token;
         unsigned int ntokens = 0;
         char temp_str[4096];
-        strcpy(temp_str, buffer) ;
-        token = strtok( temp_str, " \t" );
-        while ( token != NULL ) {
-            token = strtok( NULL, " \t" );
+        strcpy(temp_str, buffer);
+        token = strtok(temp_str, " \t");
+        while (token != NULL)
+        {
+            token = strtok(NULL, " \t");
             ntokens++;
         }
 
-        // Verify the input column number is valid
-        if ( (column == 0) || (column > ntokens) ) {
+        // Verify the input column number is valid.
+        if ((column == 0) || (column > ntokens))
+        {
             char string[100];
             sprintf(string, "Trick:MonteVarFile An invalid column number %d, valid column numbers are 1 - %d", column, ntokens);
             exec_terminate_with_return(-1, __FILE__, __LINE__, string);
         }
 
-        if (current_position != buffer) {
-            for (unsigned int i = 1; i < column; ++i) {
-                file_value = strtold(current_position, &current_position);
-            }
+        // Get the next value.
+        strcpy(temp_str, buffer);
+        token = strtok(temp_str, " \t");
 
-            std::stringstream string_stream;
-            string_stream.precision(std::numeric_limits<double>::digits10);
-            string_stream << file_value ;
-            value = string_stream.str();
-            string_stream.str("");
-            if (unit.empty()) {
-                string_stream << name << " = " << file_value ;
+        for(unsigned int i = 1; i < column; i++)
+        {
+            // Iterate through each token in the temp_str.
+            if(token != NULL)
+            {
+                token = strtok(NULL, " \t");
             }
-            else {
-                string_stream << name << " = " << "trick.attach_units(\"" << unit << "\", " << file_value
-                  << ")";
-            }
-            return string_stream.str() ;
         }
+
+        // Return the value as a string.
+        this->value = token;
+        std::stringstream ss;
+
+        if(unit.empty())
+        {
+            ss << this->name << " = " << token;
+        }
+        else
+        {
+            ss << this->name << " = " << "trick.attach_units(\"" << unit << "\", " << token << ")";
+        }
+
+        return ss.str();
     }
     char string[100];
     sprintf(string, "Trick:MonteVarFile the input file \"%s\" is not open for reading", file_name.c_str());
@@ -96,22 +110,24 @@ std::string Trick::MonteVarFile::get_next_value() {
     return NULL;
 }
 
-void Trick::MonteVarFile::set_file_name(std::string in_file_name) {
+void Trick::MonteVarFile::set_file_name(std::string in_file_name)
+{
     delete input_file_stream;
 
     input_file_stream = new std::ifstream(in_file_name.c_str(), std::ifstream::in);
-    if (input_file_stream->fail()) {
+    if (input_file_stream->fail())
+    {
         std::stringstream string_stream;
 
         string_stream << "Error: " << strerror(errno) << std::endl
-                      << "       Trick:MonteVarFile input file \"" << in_file_name <<  "\" failed to open";
+                      << "       Trick:MonteVarFile input file \"" << in_file_name << "\" failed to open";
 
         exec_terminate_with_return(-1, __FILE__, __LINE__, string_stream.str().c_str());
     }
     this->file_name = in_file_name;
 }
 
-void Trick::MonteVarFile::set_column(unsigned int in_column) {
+void Trick::MonteVarFile::set_column(unsigned int in_column)
+{
     this->column = in_column;
 }
-

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -15,13 +15,11 @@ Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name,
     this->unit = in_unit;
 
     set_file_name(in_file_name);
-    buffer = new char[4096];
 }
 
 Trick::MonteVarFile::~MonteVarFile()
 {
     delete input_file_stream;
-    delete buffer;
 }
 
 // Composite the various properties of this MonteVarFile.
@@ -42,10 +40,11 @@ std::string Trick::MonteVarFile::get_next_value()
 {
     if (input_file_stream->good())
     {
+        std::string line;
         // Skip the comments and empty lines in the data file.
         do
         {
-            input_file_stream->getline(buffer, 4096);
+            std::getline(*input_file_stream, line);
 
             if(input_file_stream->eof())
             {
@@ -53,13 +52,12 @@ std::string Trick::MonteVarFile::get_next_value()
                 return "EOF";
             }
         }
-        while(buffer[0] == '#' || buffer[0] == '\0');
+        while(line[0] == '#' || line[0] == '\0');
 
         // Count the number of columns in the input file.
         char *token;
         unsigned int ntokens = 0;
-        char temp_str[4096];
-        strcpy(temp_str, buffer);
+        char* temp_str = strdup(line.c_str());
         token = strtok(temp_str, " \t");
         while (token != NULL)
         {
@@ -76,7 +74,7 @@ std::string Trick::MonteVarFile::get_next_value()
         }
 
         // Get the next value.
-        strcpy(temp_str, buffer);
+        temp_str = strdup(line.c_str());
         token = strtok(temp_str, " \t");
 
         for(unsigned int i = 1; i < column; i++)

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -8,8 +8,7 @@
 #include "trick/message_proto.h"
 #include "trick/exec_proto.h"
 
-Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) : input_file_stream(NULL)
-{
+Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) : input_file_stream(NULL) {
     this->name = in_name;
     this->column = in_column;
     this->unit = in_unit;
@@ -17,14 +16,12 @@ Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name,
     set_file_name(in_file_name);
 }
 
-Trick::MonteVarFile::~MonteVarFile()
-{
+Trick::MonteVarFile::~MonteVarFile() {
     delete input_file_stream;
 }
 
 // Composite the various properties of this MonteVarFile.
-std::string Trick::MonteVarFile::describe_variable()
-{
+std::string Trick::MonteVarFile::describe_variable() {
     std::stringstream ss;
 
     ss << "#NAME:\t\t" << this->name << "\n"
@@ -36,18 +33,14 @@ std::string Trick::MonteVarFile::describe_variable()
     return ss.str();
 }
 
-std::string Trick::MonteVarFile::get_next_value()
-{
-    if (input_file_stream->good())
-    {
+std::string Trick::MonteVarFile::get_next_value() {
+    if (input_file_stream->good()) {
         std::string line;
         // Skip the comments and empty lines in the data file.
-        do
-        {
+        do {
             std::getline(*input_file_stream, line);
 
-            if(input_file_stream->eof())
-            {
+            if(input_file_stream->eof()) {
                 input_file_stream->close();
                 return "EOF";
             }
@@ -59,15 +52,13 @@ std::string Trick::MonteVarFile::get_next_value()
         unsigned int ntokens = 0;
         char* temp_str = strdup(line.c_str());
         token = strtok(temp_str, " \t");
-        while (token != NULL)
-        {
+        while (token != NULL) {
             token = strtok(NULL, " \t");
             ntokens++;
         }
 
         // Verify the input column number is valid.
-        if ((column == 0) || (column > ntokens))
-        {
+        if ((column == 0) || (column > ntokens)) {
             char string[100];
             sprintf(string, "Trick:MonteVarFile An invalid column number %d, valid column numbers are 1 - %d", column, ntokens);
             exec_terminate_with_return(-1, __FILE__, __LINE__, string);
@@ -77,13 +68,10 @@ std::string Trick::MonteVarFile::get_next_value()
         temp_str = strdup(line.c_str());
         token = strtok(temp_str, " \t");
 
-        for(unsigned int i = 1; i < column; i++)
-        {
+        for(unsigned int i = 1; i < column; i++) {
             // Iterate through each token in the temp_str.
             if(token != NULL)
-            {
                 token = strtok(NULL, " \t");
-            }
         }
 
         // Return the value as a string.
@@ -91,13 +79,9 @@ std::string Trick::MonteVarFile::get_next_value()
         std::stringstream ss;
 
         if(unit.empty())
-        {
             ss << this->name << " = " << token;
-        }
         else
-        {
             ss << this->name << " = " << "trick.attach_units(\"" << unit << "\", " << token << ")";
-        }
 
         return ss.str();
     }
@@ -108,13 +92,11 @@ std::string Trick::MonteVarFile::get_next_value()
     return NULL;
 }
 
-void Trick::MonteVarFile::set_file_name(std::string in_file_name)
-{
+void Trick::MonteVarFile::set_file_name(std::string in_file_name) {
     delete input_file_stream;
 
     input_file_stream = new std::ifstream(in_file_name.c_str(), std::ifstream::in);
-    if (input_file_stream->fail())
-    {
+    if (input_file_stream->fail()) {
         std::stringstream string_stream;
 
         string_stream << "Error: " << strerror(errno) << std::endl
@@ -125,7 +107,6 @@ void Trick::MonteVarFile::set_file_name(std::string in_file_name)
     this->file_name = in_file_name;
 }
 
-void Trick::MonteVarFile::set_column(unsigned int in_column)
-{
+void Trick::MonteVarFile::set_column(unsigned int in_column) {
     this->column = in_column;
 }

--- a/trick_source/sim_services/MonteCarlo/MonteVarFixed.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFixed.cpp
@@ -14,9 +14,10 @@ std::string Trick::MonteVarFixed::describe_variable()
 {
     std::stringstream ss;
 
-    ss << "#NAME:\t" << this->name << "\n"
-       << "#TYPE:\tFIXED\n" 
-       << "#UNIT:\t" << this->unit << "\n";
+    ss << "#NAME:\t\t" << this->name << "\n"
+       << "#TYPE:\t\tFIXED\n" 
+       << "#UNIT:\t\t" << this->unit << "\n"
+       << "#VALUE:\t\t" << this->value << "\n";
 
     return ss.str();
 }


### PR DESCRIPTION
This pull request is in response to #316.

By converting data file traversal from strtold to strtok, it is possible to accept non numerical values in data files. If sending a string, it may be necessary to surround the string with "quotations". Non_numerical values  can also not contain spaces or tabs.