### PR TITLE
Implemented a fix for multiple concurrent file handles.

### DIFF
--- a/include/trick/MonteVarFile.hh
+++ b/include/trick/MonteVarFile.hh
@@ -73,6 +73,10 @@ namespace Trick {
         /** The input file stream. */
         std::ifstream *input_file_stream; /**< \n trick_units(--) */
 
+        private:
+        // Used to store the current position of the stream for file opening and closing.
+        std::streampos stream_position;
+
         public:
         /**
          * Constructs a MonteVarFile with the specified name, file name, column, and units.

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -9,9 +9,9 @@
 #include "trick/exec_proto.h"
 
 Trick::MonteVarFile::MonteVarFile(std::string in_name, std::string in_file_name, unsigned int in_column, std::string in_unit) : input_file_stream(NULL) {
-    this->name = in_name;
-    this->column = in_column;
-    this->unit = in_unit;
+    name = in_name;
+    column = in_column;
+    unit = in_unit;
 
     set_file_name(in_file_name);
 }
@@ -24,26 +24,19 @@ Trick::MonteVarFile::~MonteVarFile() {
 std::string Trick::MonteVarFile::describe_variable() {
     std::stringstream ss;
 
-    ss << "#NAME:\t\t" << this->name << "\n"
+    ss << "#NAME:\t\t" << name << "\n"
        << "#TYPE:\t\tFILE\n"
-       << "#UNIT:\t\t" << this->unit << "\n"
-       << "#FILE:\t\t" << this->file_name << "\n"
-       << "#COLUMN:\t" << this->column << "\n";
+       << "#UNIT:\t\t" << unit << "\n"
+       << "#FILE:\t\t" << file_name << "\n"
+       << "#COLUMN:\t" << column << "\n";
 
     return ss.str();
 }
 
 std::string Trick::MonteVarFile::get_next_value() {
-
-    // Reopen the file if not open.
-    if(!input_file_stream->is_open()) {
-        input_file_stream->open(this->file_name.c_str(), std::ifstream::in);
-
-        // If the stream position has been set, re-open file to this position.
-        if(this->stream_position != 0) {
-            input_file_stream->seekg(this->stream_position);
-        }
-    }
+    // Open the file and seek to the previous position.
+    input_file_stream->open(file_name.c_str(), std::ifstream::in);
+    input_file_stream->seekg(stream_position);
 
     if (input_file_stream->good()) {
         std::string line;
@@ -59,7 +52,7 @@ std::string Trick::MonteVarFile::get_next_value() {
         while(line[0] == '#' || line[0] == '\0');
 
         // Store the current stream position and close the file.
-        this->stream_position = input_file_stream->tellg();
+        stream_position = input_file_stream->tellg();
         input_file_stream->close();
 
         // Count the number of columns in the input file.
@@ -90,13 +83,13 @@ std::string Trick::MonteVarFile::get_next_value() {
         }
 
         // Return the value as a string.
-        this->value = token;
+        value = token;
         std::stringstream ss;
 
         if(unit.empty())
-            ss << this->name << " = " << token;
+            ss << name << " = " << token;
         else
-            ss << this->name << " = " << "trick.attach_units(\"" << unit << "\", " << token << ")";
+            ss << name << " = " << "trick.attach_units(\"" << unit << "\", " << token << ")";
 
         return ss.str();
     }
@@ -119,9 +112,9 @@ void Trick::MonteVarFile::set_file_name(std::string in_file_name) {
 
         exec_terminate_with_return(-1, __FILE__, __LINE__, string_stream.str().c_str());
     }
-    this->file_name = in_file_name;
+    file_name = in_file_name;
 }
 
 void Trick::MonteVarFile::set_column(unsigned int in_column) {
-    this->column = in_column;
+    column = in_column;
 }

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -40,7 +40,7 @@ std::string Trick::MonteVarFile::get_next_value() {
         input_file_stream->open(this->file_name.c_str(), std::ifstream::in);
 
         // If the stream position has been set, re-open file to this position.
-        if(this->stream_position != NULL) {
+        if(this->stream_position != 0) {
             input_file_stream->seekg(this->stream_position);
         }
     }

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -103,7 +103,7 @@ std::string Trick::MonteVarFile::get_next_value() {
 void Trick::MonteVarFile::set_file_name(std::string in_file_name) {
     delete input_file_stream;
 
-    input_file_stream = new std::ifstream(in_file_name.c_str(), std::ifstream::in);
+    input_file_stream = new std::ifstream();
     if (input_file_stream->fail()) {
         std::stringstream string_stream;
 

--- a/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarFile.cpp
@@ -34,6 +34,17 @@ std::string Trick::MonteVarFile::describe_variable() {
 }
 
 std::string Trick::MonteVarFile::get_next_value() {
+
+    // Reopen the file if not open.
+    if(!input_file_stream->is_open()) {
+        input_file_stream->open(this->file_name.c_str(), std::ifstream::in);
+
+        // If the stream position has been set, re-open file to this position.
+        if(this->stream_position != NULL) {
+            input_file_stream->seekg(this->stream_position);
+        }
+    }
+
     if (input_file_stream->good()) {
         std::string line;
         // Skip the comments and empty lines in the data file.
@@ -46,6 +57,10 @@ std::string Trick::MonteVarFile::get_next_value() {
             }
         }
         while(line[0] == '#' || line[0] == '\0');
+
+        // Store the current stream position and close the file.
+        this->stream_position = input_file_stream->tellg();
+        input_file_stream->close();
 
         // Count the number of columns in the input file.
         char *token;


### PR DESCRIPTION
Uses seekg() and tellg() to save and restore the position of the file stream.

This pull request is in response to issue #432.