### PR TITLE
Modified unit tests to account for new logic.

### DIFF
--- a/trick_source/sim_services/MonteCarlo/test/MonteCarlo_exceptions.cpp
+++ b/trick_source/sim_services/MonteCarlo/test/MonteCarlo_exceptions.cpp
@@ -65,22 +65,6 @@ TEST_F(MonteCarloTest, MonteVarFile_BadFileException) {
     EXPECT_EQ(got_exception, true);
 }
 
-TEST_F(MonteCarloTest, MonteVarFile_FileException) {
-    bool got_exception = false;
-
-    try {
-        Trick::MonteVarFile var("time_to_fire_1", "M_jet_firings_inline", 1) ;
-        var.get_next_value();
-        var.input_file_stream->close();
-        var.get_next_value();
-        var.get_next_value();
-    } catch (Trick::ExecutiveException &e) {
-        std::cout << e.message << std::endl;
-        got_exception = true;
-    }
-    EXPECT_EQ(got_exception, true);
-}
-
 TEST_F(MonteCarloTest, TestMonteVarRandom_Exception) {
     bool got_exception = false;
 

--- a/trick_source/sim_services/MonteCarlo/test/MonteCarlo_test.cpp
+++ b/trick_source/sim_services/MonteCarlo/test/MonteCarlo_test.cpp
@@ -327,7 +327,7 @@ TEST_F(MonteCarloTest, MonteVarFile) {
     Trick::MonteVarFile var0("time_to_fire_1", "M_jet_firings_inline", 2) ;
     EXPECT_EQ(exec.variables.size(), 0) ;
     exec.add_variable(&var0) ;
-    EXPECT_EQ(var0.get_next_value(), "time_to_fire_1 = 1") ;
+    EXPECT_EQ(var0.get_next_value(), "time_to_fire_1 = 1.0000") ;
     EXPECT_EQ(exec.variables.size(), 1) ;
 }
 


### PR DESCRIPTION
A change I had made to how the get_next_value() function returns values invalidated this unit test. This error stemmed from the changes I made in c8f916e8182dc9b4d9c13b187442e295e67c9290 that allowed non numerical values to be used in the data file. 

Originally, trailing 0s were being stripped before the value was returned.
Now, the value present in the data file is the exact value returned by get_next_value().

I have modified the unit test to reflect this new behavior.