### PR TITLE
Configure script now checks for curl. #492

### DIFF
--- a/configure
+++ b/configure
@@ -671,6 +671,7 @@ GNUPLOT
 SWIG
 PYTHON
 PERL
+CURL
 BISON
 LEXLIB
 LEX_OUTPUT_ROOT
@@ -3834,6 +3835,50 @@ fi
 if test "$ac_cv_path_BISON" = "nobison"; then :
   as_fn_error $? "could not find bison" "$LINENO" 5
 fi
+
+# Extract the first word of "curl", so it can be a program name with args.
+set dummy curl; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_CURL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $CURL in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_CURL="$CURL" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_CURL="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_CURL" && ac_cv_path_CURL="nocurl"
+  ;;
+esac
+fi
+CURL=$ac_cv_path_CURL
+if test -n "$CURL"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CURL" >&5
+$as_echo "$CURL" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+if test "$ac_cv_path_CURL" = "nocurl"; then :
+  as_fn_error $? "could not find curl" "$LINENO" 5
+fi
+
 # Extract the first word of "perl", so it can be a program name with args.
 set dummy perl; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5


### PR DESCRIPTION
```
$ ./configure
...
checking lex library... none needed
checking whether yytext is a pointer... no
checking for bison... /usr/bin/bison
checking for curl... /usr/bin/curl
checking for perl... /usr/bin/perl
checking for python... /usr/bin/python
checking for swig... /usr/local/bin/swig
...
```