### PR TITLE
Removing a stray line in configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -3488,7 +3488,6 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-AX_GCC_VERSION
 if test "x$GCC_VERSION" = "x"; then :
 
 else


### PR DESCRIPTION
Fixing this error in the configure script:

```
$ ./configure
...
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
./configure: line 3491: AX_GCC_VERSION: command not found
checking for tee... /usr/bin/tee
checking for ld... /usr/bin/ld
checking for flex... flex
...
```