### PR TITLE
Only left-shift `FieldDescription::io` when `io_found == true`

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
@@ -270,7 +270,7 @@ void FieldDescription::parseComment(std::string comment) {
     if ( chkpnt_io_found == true ) {
         // If a checkpoint I/O spec is found add it to the io field.
         io = (chkpnt_io << 2 ) + ( io & 3 ) ;
-    } else {
+    } else if ( io_found == true ) {
         // else duplicated the io field to the chkpnt io field.
         io |= (io << 2 ) ;
     }


### PR DESCRIPTION
The `io` field of `FieldDescription` takes a default value of 15. In
`FieldDescription::parseComment`, it may be updated as specified in the comment
text. There are 4 possible cases:

1) Neither IO attributes nor checkpoint IO attributes are found in the comment
2) IO attributes are found in the comment, but checkpoint IO attributes are not
3) Checkpoint IO attributes are found in the comment, but IO attributes are not
4) Both IO attributes and checkpoint IO attributes are found in the comment

In case 2, the IO attributes are copied into the checkpoint IO attributes by the
statement `io |= (io << 2)`. However, this also erroneously runs in case 1,
causing the default value of 15 to change to 63.

By testing `io_found == true`, this logic occurs only in case 2.

Fixes #568