### PR TITLE
Unit test exit code

### DIFF
--- a/include/trick/UnitTest.hh
+++ b/include/trick/UnitTest.hh
@@ -105,6 +105,10 @@ namespace Trick {
              */
             int set_file_name(std::string in_name) ;
 
+            /**
+             @brief Write output to xml file.
+             @return always 0
+             */
             int write_output() ;
     } ;
 

--- a/include/trick/UnitTest.hh
+++ b/include/trick/UnitTest.hh
@@ -53,6 +53,9 @@ namespace Trick {
             /** Create test xml output.\n*/
             bool enabled ; /**< trick_units(--) */
 
+            /** Send the unit test exit code up the chain to Executive.\n*/
+            bool exit_code_enabled ; /**< trick_units(--) */
+
             /** Name of Unit test\n*/
             std::string name ;
 
@@ -76,6 +79,12 @@ namespace Trick {
              @brief Enable test output.
              */
             bool enable() ;
+
+            /**
+             @brief Enable/Disable exit code return feature.
+             @return always 0
+             */
+            int set_exit_code_enabled( bool in_enable ) ;
 
             /**
              @brief Output message to the file.

--- a/trick_source/sim_services/UnitTest/UnitTest.cpp
+++ b/trick_source/sim_services/UnitTest/UnitTest.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "trick/UnitTest.hh"
+#include "trick/exec_proto.h"
 #include "trick/message_proto.h"
 #include "trick/message_type.h"
 
@@ -55,6 +56,7 @@ void Trick::TestSuite::delete_test_results() {
 Trick::UnitTest::UnitTest() {
     the_unit_test_output = this ;
     enabled = false ;
+    exit_code_enabled = false ;
     file_name = std::string("test_details.xml") ;
     name = std::string("AllTests") ;
 }
@@ -91,6 +93,11 @@ int Trick::UnitTest::add_test_requirements(std::string in_test_suite_name, std::
 bool Trick::UnitTest::enable() {
     enabled = true ;
     return(true) ;
+}
+
+int Trick::UnitTest::set_exit_code_enabled(bool in_enable) {
+    exit_code_enabled = in_enable ;
+    return 0 ;
 }
 
 int Trick::UnitTest::set_test_name(std::string in_name) {
@@ -149,6 +156,10 @@ int Trick::UnitTest::write_output() {
             out << "  </testsuite>" << std::endl  ;
         }
         out << "</testsuites>" << std::endl  ;
+
+        if ( exit_code_enabled && num_failures > 0 ) {
+            exec_terminate_with_return( 1 , __FILE__ , __LINE__ , "Unit Test failure detected." ) ;
+        }
     }
 
     return(0) ;


### PR DESCRIPTION
I noticed that simulation exit codes do not reflect Trick UnitTest status. So, I added the following:

- A new class member flag in the UnitTest class called exit_code_enabled. This is a boolean which is false by default. We are open to make this on by default if this doesn't change expected behavior on the Trick side.
- A new class method which toggles this boolean.
- A new logic block that will call exec_terminate_with_return if two conditions are met: exit_code_enabled is true, num_failures is greater than 0

To demonstrate this in action, apply the following patch to trick_sims/SIM_Ball++_L1/RUN_test/unit_test.py:

```diff
diff --git a/trick_sims/SIM_Ball++_L1/RUN_test/unit_test.py b/trick_sims/SIM_Ball++_L1/RUN_test/unit_test.py
index 7a97255..ec362fe 100644
--- a/trick_sims/SIM_Ball++_L1/RUN_test/unit_test.py
+++ b/trick_sims/SIM_Ball++_L1/RUN_test/unit_test.py
@@ -1,5 +1,6 @@

 import trick
+from trick.unit_test import *

 def main():

@@ -27,6 +28,8 @@ def main():

     trick_utest.unit_tests.enable() ;
     trick_utest.unit_tests.set_file_name( os.getenv("TRICK_HOME") + "/trick_test/SIM_Ball++_L1.xml" ) ;
+    trick_utest.unit_tests.set_exit_code_enabled( True ) ;
+    trick.add_read(299.0, 'TRICK_EXPECT_TRUE( False, "Unit Test Exit Code", "Demonstrate non-zero exit code")')

 if __name__ == "__main__":
     main()
```

When it runs, it will fail as expected and the exit code (accessible with '$?') will be non-zero:

```
$ ./S_main_Linux_5.4_x86_64.exe RUN_test/unit_test.py 
[...]
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|270.000000| time =   270.00 , position =    -7.003818 ,     9.411011
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|280.000000| time =   280.00 , position =     3.944995 ,    -1.666694
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|290.000000| time =   290.00 , position =     1.872986 ,     2.356468
|L   3|2018/03/28,11:04:11|lombok|ball_sim|T 0|299.000000| [  FAILED  ] Unit Test Exit Code:Demonstrate non-zero exit code TRICK_EXPECT_TRUE failed
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|300.000000| time =   300.00 , position =    -7.627512 ,     3.131932
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|300.000000| 
     REALTIME SHUTDOWN STATS:
            ACTUAL INIT TIME:        0.197
         ACTUAL ELAPSED TIME:        0.376
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|300.000000| Total tests: 1 , Failures: 1
|L   0|2018/03/28,11:04:11|lombok|ball_sim|T 0|300.000000| 
SIMULATION TERMINATED IN
  PROCESS: 0
  ROUTINE: Executive_loop_single_thread.cpp:98 then exception caught in UnitTest.cpp:161
  DIAGNOSTIC: Reached termination time then exception Message: Unit Test failure detected.

       SIMULATION START TIME:        0.000
        SIMULATION STOP TIME:      300.000
     SIMULATION ELAPSED TIME:      300.000
        ACTUAL CPU TIME USED:        0.204
       SIMULATION / CPU TIME:     1470.588
     INITIALIZATION CPU TIME:        0.040
$ echo $?
1
```

The xml file is still produced, like before:

```
$ cat ../../trick_test/SIM_Ball++_L1.xml 
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="1" failures="1" disabled="0" errors="0" time="0.0" name="AllTests">
  <testsuite name="Unit Test Exit Code" tests="1" failures="1" disabled="0" errors="0" time="0.0">
    <testcase name="Demonstrate non-zero exit code" status="run" time="0" classname="Unit Test Exit Code" >
       <failure message="TRICK_EXPECT_TRUE failed" type=""/>
    </testcase>
  </testsuite>
</testsuites>
```
