### PR TITLE
Port Hammen doxygen documentation fix to Trick 17

### DIFF
--- a/include/trick/ClassicCheckPointAgent.hh
+++ b/include/trick/ClassicCheckPointAgent.hh
@@ -52,15 +52,15 @@ namespace Trick {
 
          @param address Address of the variable.
          @param attr ATTRIBUTES of the variable.
-         @param curr_dim
-         @param offset
+         @param curr_dim Dimensions of the array
+         @param offset Offset into the array
          */
         void assign_rvalue( std::ostream& chkpnt_os, void* address, ATTRIBUTES* attr, int curr_dim, int offset);
 
         /**
          Restore memory allocations from a checkpoint stream.
          @param checkpoint_stream Input stream from which the checkpoint is read.
-         @return
+         @return 0/1 success flag
          */
         int restore( std::istream* checkpoint_stream);
 
@@ -72,7 +72,6 @@ namespace Trick {
          @param address - address of the object within which we are checking for nil values.
          @param attr - attr describing the object at the address.
          @param curr_dim - dimension of the sub-element being checked.
-         @param offset - offset of the sub-element
          @param offset - if the object specified by @b address and @b attr is arrayed, then this
                          parameter specifies where, within the array, the sub-object to be
                          checked, is located.
@@ -86,7 +85,7 @@ namespace Trick {
          The pointer must be an address that is being managed by MM (the MemoryManager) or a
          character string (char* or wchar_t*).
 
-         @param pointer
+         @param pointer Pointer to be converted.
          @param attr ATTRIBUTES of the pointer.
          @param curr_dim current dimension.
          @return text expression that represents the pointer.

--- a/include/trick/IntegLoopManager.hh
+++ b/include/trick/IntegLoopManager.hh
@@ -84,7 +84,7 @@ class IntegLoopScheduler;
          * Designate the specified sim object as integrated by the specified
          * scheduler.
          * @param sim_object  Simulation object.
-         * @param scheduler  Integration loop scheduler.
+         * @param integrator  Integration loop scheduler.
          */
         void set_integrated_by (
             Trick::SimObject * sim_object,

--- a/include/trick/IntegLoopScheduler.hh
+++ b/include/trick/IntegLoopScheduler.hh
@@ -114,7 +114,7 @@ namespace Trick {
 
             /**
              * Non-default constructor.
-             * @param cycle      The time interval at which the loop's integrate
+             * @param in_cycle   The time interval at which the loop's integrate
              *                   function will be called.
              * @param parent_so  The Trick simulation object that contains this
              *                   IntegLoopScheduler object.

--- a/include/trick/JobData.hh
+++ b/include/trick/JobData.hh
@@ -179,7 +179,7 @@ namespace Trick {
 
             /**
              * Sets/Resets the static time_tic value
-             * @param time_tic_value - number of tics per second
+             * @param in_time_tic_value - number of tics per second
              * @return always 0
              */
             static int set_time_tic_value(long long in_time_tic_value) ;
@@ -187,7 +187,6 @@ namespace Trick {
             /**
              * Sets/Resets the job cycle rate
              * @param rate - desired cycle rate in seconds
-             * @param time_tic_value - number of tics per second
              * @return always 0
              */
             virtual int set_cycle(double rate) ;
@@ -214,10 +213,10 @@ namespace Trick {
 
             /**
              * Adds another job as a dependency to this job
-             * @param depend - JobData instance of depends_on job
+             * @param in_tag - JobData instance of depends_on job
              * @return always 0
              */
-            virtual int add_tag( std::string ) ;
+            virtual int add_tag( std::string in_tag) ;
 
             /**
              * Adds another job as a dependency to this job

--- a/include/trick/MemoryManager.hh
+++ b/include/trick/MemoryManager.hh
@@ -305,7 +305,7 @@ namespace Trick {
 
             /**
              Forget about the variable with the given name and deallocate the memory associated with it.
-             @param address - the address of the variable.
+             @param var_name - the address of the variable.
              @return 0 = SUCCESS, 1 = FAILURE
              */
             int delete_var(const char* var_name);
@@ -321,7 +321,7 @@ namespace Trick {
             /**
              Forget about the external variable with the given name. DOES NOT attempt to deallocate the
              memory at the given address.
-             @param address - the address of the external variable.
+             @param var_name - the address of the external variable.
              @return 0 = SUCCESS, 1 = FAILURE
              */
             int delete_extern_var(const char* var_name);
@@ -334,35 +334,35 @@ namespace Trick {
 
             /**
              Checkpoint all allocations known to the MemoryManager to a file.
-             @param filename
+             @param filename  Name of file to be written.
              */
             void write_checkpoint( const char* filename);
 
             /**
              Checkpoint the named variable (allocation) and it dependencies to the given stream.
              @param out_s output stream.
-             @param var_name
+             @param var_name  Variable name.
              */
             void write_checkpoint( std::ostream& out_s, const char* var_name);
 
             /**
              Checkpoint the named variable (allocation) and it dependencies to a file.
-             @param filename
-             @param var_name
+             @param filename  Checkpoint file.
+             @param var_name  Variable name.
              */
             void write_checkpoint( const char* filename, const char* var_name);
 
             /**
              Checkpoint the named variables and their dependencies to a stream.
              @param out_s output stream.
-             @param var_name_list
+             @param var_name_list List of variable names.
              */
             void write_checkpoint( std::ostream& out_s, std::vector<const char*>& var_name_list);
 
             /**
              Checkpoint the named variables and their dependencies to a file.
-             @param filename
-             @param var_name_list
+             @param filename output file name.
+             @param var_name_list List of variable names.
              */
             void write_checkpoint( const char* filename, std::vector<const char*>& var_name_list);
 
@@ -521,13 +521,13 @@ namespace Trick {
 
             /**
              Return the number of array elements in the allocation.
-             @param ptr address.
+             @param addr Address.
              */
             int get_size(void *addr);
 
             /**
              Return the number of array elements in the allocation following ptr.
-             @param ptr - pointer.
+             @param addr Address.
              */
             int get_truncated_size(void *addr);
 
@@ -565,7 +565,7 @@ namespace Trick {
 
             /**
              Opens a handle to the shared library file.  The handles are used to look for io_src functions.
-             @param name The name of the file to open.
+             @param file_name The name of the file to open.
              */
             int add_shared_library_symbols( const char * file_name );
 
@@ -609,7 +609,7 @@ namespace Trick {
             Write the contents of the variable with the given name to the given stream.
             In other words, checkpoint a single variable to a file.
             @param out_s - output stream.
-            @param address - address of the variable.
+            @param var_name - Name of the variable.
              */
             void write_var( std::ostream& out_s, const char* var_name );
 
@@ -798,16 +798,13 @@ namespace Trick {
 
             /**
              Call the default destructor for one or more instances of the named class.
-             @param class_name The name of the class to allocate.
-             @param num The number of instances to allocate.
-             @return The address of the allocation, or NULL on failure.
+             @param alloc_info The alloc_info struct that contains the address and type to delete.
              */
             void io_src_destruct_class(ALLOC_INFO * alloc_info);
 
             /**
              Call the proper class/struct delete for the address given in the ALLOC_INFO struct.
-             @alloc_info The alloc_info struct that contains the address and type to delete.
-             @return none.
+             @param alloc_info The alloc_info struct that contains the address and type to delete.
              */
             void io_src_delete_class(ALLOC_INFO * alloc_info);
 

--- a/include/trick/ScheduledJobQueue.hh
+++ b/include/trick/ScheduledJobQueue.hh
@@ -71,7 +71,7 @@ namespace Trick {
 
             /**
              * @brief Sets the curr_index to value.
-             * @param value - Value of index.
+             * @param ii - Value of index.
              * @return always 0.
              */
             int set_curr_index( unsigned int ii ) ;
@@ -122,8 +122,6 @@ namespace Trick {
              * @brief Adds the incoming instrumentation job before target job if specified, or all jobs in list.
              * Will reallocate list to accommodate additional instrumentation jobs.
              * @param instrumentation_job  - name of the instrument job
-             * @param target_job - name of the target job, empty string means all jobs are to be instrumented
-             * @param in_event - instrumentation data to be stored with instrument job
              * @return number of insertions made
              */
             int instrument_before(JobData * instrumentation_job) ;
@@ -132,8 +130,6 @@ namespace Trick {
              * @brief Adds the incoming instrumentation job after target job if specified, or all jobs in the list.
              * Will reallocate list to accommodate additional instrumentation jobs.
              * @param instrumentation_job - name of the instrument job
-             * @param target_job - name of the target job, empty string means all jobs are to be instrumented
-             * @param in_event - instrumentation data to be stored with instrument job
              * @return number of insertions made
              */
             int instrument_after(JobData * instrumentation_job) ;
@@ -142,7 +138,6 @@ namespace Trick {
              * @brief Removes all jobs in the list that match the name job_name.
              * If in_event is specified, only remove this event's instrument job.
              * @param job_name - name of the instrument job
-             * @param in_event - instrumentation data to be stored with instrument job
              * @return always 0
              */
             int instrument_remove(std::string job_name) ;

--- a/include/trick/Scheduler.hh
+++ b/include/trick/Scheduler.hh
@@ -85,8 +85,6 @@ namespace Trick {
              * otherwise adds in_job before each job in the initialization and scheduled queues.
              * Requirement [@ref r_exec_instrument_0]
              * @param instrument_job - the instrument job
-             * @param target_job - name of the target job, empty string means all jobs are to be instrumented
-             * @param in_event - instrumentation data to be stored with instrument job
              * @return always 0
              */
             virtual int instrument_job_before(Trick::JobData * instrument_job ) = 0 ;
@@ -96,8 +94,6 @@ namespace Trick {
              * otherwise adds in_job after each job in the initialization and scheduled queues.
              * Requirement [@ref r_exec_instrument_2]
              * @param instrument_job - the instrument job
-             * @param target_job - name of the target job, empty string means all jobs are to be instrumented
-             * @param in_event - instrumentation data to be stored with instrument job
              * @return always 0
              */
             virtual int instrument_job_after(Trick::JobData * instrument_job ) = 0 ;
@@ -106,7 +102,6 @@ namespace Trick {
              * Removes an instrumentation job with the name in_job in the initialization and scheduled queues.
              * Requirement [@ref r_exec_instrument_3]
              * @param in_job - name of the instrument job
-             * @param in_event - instrumentation data to be searched for
              * @return always 0
              */
             virtual int instrument_job_remove(std::string in_job ) = 0 ;

--- a/include/trick/SimObject.hh
+++ b/include/trick/SimObject.hh
@@ -65,7 +65,7 @@ namespace Trick {
              * @param name - name of lower level SimObject
              * @return always 0
              */
-            int add_pre_component_object(SimObject *, std::string name) ;
+            int add_pre_component_object(SimObject * in_object, std::string name) ;
 
             /**
              * Includes a lower level SimObject where the lower level jobs are called after this SimObject
@@ -73,7 +73,7 @@ namespace Trick {
              * @param name - name of lower level SimObject
              * @return always 0
              */
-            int add_post_component_object(SimObject *, std::string name) ;
+            int add_post_component_object(SimObject * in_object, std::string name) ;
 
             /**
              * Adds a job to the sim_object.  This call is typically in the S_source.cpp file

--- a/include/trick/message_type.h
+++ b/include/trick/message_type.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 /**
- * @class Trick::MessagePublisher::MESSAGE_TYPE message_proto.h
+ * @enum Trick::MessagePublisher::MESSAGE_TYPE
  * The MESSAGE_TYPE enumeration represents types of messages to publish, which corresponds to the displayed color of the message.
  */
     typedef enum {

--- a/include/trick/parameter_types.h
+++ b/include/trick/parameter_types.h
@@ -11,7 +11,6 @@ extern "C" {
 #endif
 
 /**
- * @class Trick::MemoryManager::TRICK_TYPE parameter_types.h
  * The TRICK_TYPE enumeration represents the Trick data types.
  */
     typedef enum {

--- a/include/trick/sim_mode.h
+++ b/include/trick/sim_mode.h
@@ -7,7 +7,7 @@ PROGRAMMERS:
 */
 
 /**
- * @class SIM_COMMAND sim_mode.h
+ * @enum SIM_COMMAND
  * The SIM_COMMAND enumeration represents the TRICK simulation commmands.
  */
 
@@ -24,7 +24,7 @@ typedef enum {
 } SIM_COMMAND;
 
 /**
- * @class SIM_MODE sim_mode.h
+ * @enum SIM_MODE
  * The SIM_MODE enumeration represents the TRICK simulation modes.
  */
 

--- a/trick_source/er7_utils/integration/beeman/src/beeman_integrator_constructor.cc
+++ b/trick_source/er7_utils/integration/beeman/src/beeman_integrator_constructor.cc
@@ -24,7 +24,7 @@ Purpose: ()
 // Integration includes
 #include "er7_utils/integration/core/include/integrator_constructor_utils.hh"
 #include "er7_utils/integration/core/include/priming_integration_controls.hh"
-#include "er7_utils/integration/rk2_heun/include/rk2_heun_integrator_constructor.hh"
+#include "er7_utils/integration/rk2_heun/include/rk2_heun_first_order_ode_integrator.hh"
 
 // Model includes
 #include "../include/beeman_integrator_constructor.hh"

--- a/trick_source/er7_utils/integration/core/include/generalized_position_derivative.hh
+++ b/trick_source/er7_utils/integration/core/include/generalized_position_derivative.hh
@@ -68,7 +68,7 @@ public:
       const double * ER7_UTILS_RESTRICT position,
       const double * ER7_UTILS_RESTRICT velocity,
       const double * ER7_UTILS_RESTRICT acceleration,
-      double * ER7_UTILS_RESTRICT position_second_derivative);
+      double * ER7_UTILS_RESTRICT position_2nd_derivative);
 
 
    // Constructors and destructor
@@ -106,13 +106,17 @@ public:
 
    // Member data
 
-   FirstDerivative first_deriv_fun; /**< trick_io(**) @n
-      Function that computes the first time derivative of
-      generalized position. */
+   /**
+    * Function that computes the first time derivative of
+    * generalized position.
+    */
+   FirstDerivative first_deriv_fun; //!< trick_io(**)
 
-   SecondDerivative second_deriv_fun; /**< trick_io(**) @n
-      Function that computes the second time derivative of
-      generalized position. */
+   /**
+    * Function that computes the second time derivative of
+    * generalized position.
+    */
+   SecondDerivative second_deriv_fun; //!< trick_io(**)
 
 };
 

--- a/trick_source/er7_utils/integration/core/include/integration_controls.hh
+++ b/trick_source/er7_utils/integration/core/include/integration_controls.hh
@@ -228,7 +228,7 @@ protected:
     * IntegrationControls copy constructor.
     * @param[in] source  The IntegrationControls to be copied.
     */
-   IntegrationControls (const IntegrationControls &);
+   IntegrationControls (const IntegrationControls & source);
 
    /**
     * IntegrationControls non-default constructor.

--- a/trick_source/er7_utils/integration/rkn4/include/rkn4_second_order_ode_integrator.hh
+++ b/trick_source/er7_utils/integration/rkn4/include/rkn4_second_order_ode_integrator.hh
@@ -77,7 +77,7 @@ protected:
     * for a simple second order ODE, one in which generalized velocity
     * is time derivative of generalized position.
     * @param[in]     size                State size
-    * @param[in,out] controls_in         Integration controls
+    * @param[in,out] controls            Integration controls
     */
    RKNystrom4SecondOrderODEIntegrator (
       unsigned int size,

--- a/trick_source/er7_utils/interface/include/alloc.hh
+++ b/trick_source/er7_utils/interface/include/alloc.hh
@@ -173,7 +173,6 @@ namespace er7_utils {
        * Destruct and deallocate a previously allocated object.
        * @tparam T Type of the object to be deallocated.
        * @param obj Object to be destructed, as a reference to a pointer.
-       * @return Array of allocated objects.
        */
       template <typename T>
       inline void delete_object (T*& obj) {
@@ -540,7 +539,7 @@ namespace er7_utils {
 
       /**
        * Deallocate an array of some primitive type
-       * @tparam T
+       * @tparam T    Array type.
        * @param arr   Array to be deallocated.
        */
       template<typename T>
@@ -632,7 +631,7 @@ namespace er7_utils {
        * Allocate contents of a 2D array, where the array is declared as
        * @code T ** array @endcode
        * @tparam        T     Array type
-       * @tparam        outer Array outer dimension
+       * @param         outer Array outer dimension
        * @param         inner Array inner dimension
        * @return Allocated 2D array.
        */
@@ -680,7 +679,6 @@ namespace er7_utils {
 
       /**
        * Specialization of replicate_2D_array for double.
-       * @tparam        T     Array type
        * @tparam        M     Array outer dimension
        * @param[in]     size  Array inner dimension
        * @param[in]     src   Source 2D array
@@ -752,7 +750,6 @@ namespace er7_utils {
 
       /**
        * Specialization of deallocate_2D_array for double.
-       * @tparam        T     Array type
        * @tparam        M     Array outer dimension
        * @param[in,out] arr   Array to be deallocated
        */
@@ -768,12 +765,11 @@ namespace er7_utils {
       /**
        * Deallocate a 2D array.
        * @tparam        T     Array type
-       * @tparam        outer Array outer dimension
        * @param[in,out] arr   Array to be deallocated
        */
       template<typename T>
       inline void deallocate_2D_array (
-         unsigned int outer ER7_UTILS_UNUSED,
+         unsigned int,
          T **& arr)
       {
          if (arr != NULL) {

--- a/trick_source/er7_utils/interface/include/type_traits.hh
+++ b/trick_source/er7_utils/interface/include/type_traits.hh
@@ -163,7 +163,8 @@ namespace er7_utils {
           * uses dynamic_cast.
           * @tparam T Type to be deduced.
           *   This parameter is a polymorphic class in this base implementation.
-          * @tparam is_class True if T is a polymorphic class, false otherwise.
+          * @tparam is_polymorphic True if T is a polymorphic class,
+          *   false otherwise.
           *   This parameter is true in this base implementation.
           */
          template <typename T, bool is_polymorphic>

--- a/trick_source/er7_utils/math/include/n_choose_m.hh
+++ b/trick_source/er7_utils/math/include/n_choose_m.hh
@@ -76,7 +76,7 @@ public:
    /**
     * Resize the triangle if the current number of rows is less than the
     * specified size.
-    * @param new_triangle_nrows Requested number of rows in the triangle.
+    * @param new_size Requested number of rows in the triangle.
     * @throw std::overflow_error if new_triangle_nrows > 68.
     */
    void resize (unsigned int new_size);

--- a/trick_source/er7_utils/math/include/ratio128.hh
+++ b/trick_source/er7_utils/math/include/ratio128.hh
@@ -410,12 +410,12 @@ public:
    // Comparison operators.
 
    /**
-    * Returns a<b.
+    * Returns a&lt;b.
     */
    friend bool operator< (const Ratio128 & a, const Ratio128 & b);
 
    /**
-    * Returns a<b.
+    * Returns a&lt;b.
     */
    template<typename T>
    friend bool operator< (T a, const Ratio128 & b)
@@ -424,7 +424,7 @@ public:
    }
 
    /**
-    * Returns a<b.
+    * Returns a&lt;b.
     */
    template<typename T>
    friend bool operator< (const Ratio128 & a, T b)


### PR DESCRIPTION
Apply the Hammen docs patches to the appropriate files in master.

All this took was
```sh
git format-patch -1 bbdf0f83784e635512d9bdc8d6e039efcb0ec885
git checkout master
git am 0001-Compile-clean-with-clang-Wdocumentation.patch
git am --abort
sed -e 's!trick_source/sim_services/[^/]*/include/!include/trick/!g' 0001-Compile-clean-with-clang-Wdocumentation.patch > 0001-Compile-clean-with-clang-Wdocumentation--fixed.patch
git am 0001-Compile-clean-with-clang-Wdocumentation--fixed.patch
git format-patch -1 ed335ff92695a2584655648abdb99d452792f995
git am 0001-Fixed-a-code-bug-and-a-comment-bug-in-er7_utils-most.patch
```

This preserves the author / commit message while applying it to the (slightly changed) paths.

Resolves #512 