### PR TITLE
Configure fixes

### DIFF
--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -188,6 +188,21 @@ dnl look for programs we need to compile and run
 AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_CXX
+AC_DEFUN([AX_GCC_VERSION], [
+  GCC_VERSION=""
+  AS_IF([test "x$GCC" = "xyes"],[
+    AS_IF([test "x$ax_gcc_version_option" != "xno"],[
+      AC_CACHE_CHECK([gcc version],[ax_cv_gcc_version],[
+        ax_cv_gcc_version="`$CC -dumpversion`"
+        AS_IF([test "x$ax_cv_gcc_version" = "x"],[
+          ax_cv_gcc_version=""
+        ])
+      ])
+      GCC_VERSION=$ax_cv_gcc_version
+    ])
+  ])
+  AC_SUBST([GCC_VERSION])
+])
 AX_GCC_VERSION
 dnl if the compiler is gcc, test for gcc >= 4.8
 AS_IF([test "x$GCC_VERSION" = "x"],[],

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -269,6 +269,25 @@ AC_PATH_PROG(CLANG, clang, noclang, "$LLVM_BIN_DIR:/bin:/usr/bin:/usr/local/bin:
 AS_IF([test "$ac_cv_path_CLANG" = "noclang"],AC_MSG_ERROR([could not find clang]),[])
 AC_SUBST([LLVM_HOME])
 
+AC_DEFUN([AX_CLANG_VERSION], [
+  CLANG_VERSION=""
+  ax_cv_clang_version="`$CLANG --version | grep "version" | sed "s/.*version \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/"`"
+  AS_IF([test "x$ax_cv_clang_version" = "x"],[
+    ax_cv_clang_version=""
+  ])
+  CLANG_VERSION=$ax_cv_clang_version
+  AC_SUBST([CLANG_VERSION])
+])
+AX_CLANG_VERSION
+dnl if llvm/clang, test for version >= 3.4.2
+AS_IF([test "x$CLANG_VERSION" = "x"],[],
+ [AC_MSG_CHECKING([clang version >= 3.4.2])
+  AX_COMPARE_VERSION([$CLANG_VERSION],[ge],[3.4.2], [AC_MSG_RESULT([yes])],
+   [AC_MSG_RESULT([no])
+    AC_MSG_ERROR([Trick requires llvm/clang version >= 3.4.2])
+   ])
+])
+
 AX_CHECK_ZLIB([],AC_MSG_ERROR([could not find zlib]))
 
 dnl look for udunits in /usr/include and /usr/include/udunits2

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -1,6 +1,9 @@
 dnl To generate a new top level configure script from this autoconf directory
 dnl 1.  aclocal
 dnl 2.  autoconf -o ../configure
+dnl If you run into "configure.ac:15: error: possibly undefined macro: AC_MSG_ERROR",
+dnl try:
+dnl     autoreconf -fi
 
 AC_INIT([Trick],[17+])
 AC_LANG(C++)
@@ -206,6 +209,8 @@ AC_PROG_LEX
 AS_IF([test "x$LEX" = "x:"],AC_MSG_ERROR([could not find flex]),[])
 AC_PATH_PROG(BISON, bison, nobison)
 AS_IF([test "$ac_cv_path_BISON" = "nobison"],AC_MSG_ERROR([could not find bison]),[])
+AC_PATH_PROG(CURL, curl, nocurl)
+AS_IF([test "$ac_cv_path_CURL" = "nocurl"],AC_MSG_ERROR([could not find curl]),[])
 AC_PATH_PROG(PERL, perl, noperl)
 AS_IF([test "$ac_cv_path_PERL" = "noperl"],AC_MSG_ERROR([could not find perl]),[])
 AC_PATH_PROG(PYTHON, python${PYTHON_VERSION}, nopython)

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -177,17 +177,6 @@ AC_DEFUN([AX_JSC_DIRS],[
     AC_SUBST([MOTIF_HOME])
 ])
 
-dnl add extra paths to find gcc on RHEL 6 systems
-PATH="/opt/rh/devtoolset-3/root/usr/bin:${PATH}"
-dnl add extra paths to find xml headers and X headers on the mac.
-XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include"
-CFLAGS="$CFLAGS $XTRAINCPATHS"
-CPPFLAGS="$CPPFLAGS $XTRAINCPATHS"
-
-dnl look for programs we need to compile and run
-AC_PROG_AWK
-AC_PROG_CC
-AC_PROG_CXX
 AC_DEFUN([AX_GCC_VERSION], [
   GCC_VERSION=""
   AS_IF([test "x$GCC" = "xyes"],[
@@ -203,7 +192,32 @@ AC_DEFUN([AX_GCC_VERSION], [
   ])
   AC_SUBST([GCC_VERSION])
 ])
-AX_GCC_VERSION
+
+dnl get the host_os.
+AC_CANONICAL_HOST
+
+dnl add extra paths to find gcc on RHEL 6 systems
+PATH="/opt/rh/devtoolset-3/root/usr/bin:${PATH}"
+dnl add extra paths to find xml headers and X headers on the mac.
+XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include"
+CFLAGS="$CFLAGS $XTRAINCPATHS"
+CPPFLAGS="$CPPFLAGS $XTRAINCPATHS"
+
+dnl look for programs we need to compile and run
+AC_PROG_AWK
+AC_PROG_CC
+AC_PROG_CXX
+
+dnl do not test gcc version on mac.  clang as gcc will return version and it's not >= 4.8
+TEST_GCC=yes
+case "${host_os}" in
+    darwin*)
+        TEST_GCC=no
+        ;;
+    *)
+        ;;
+esac
+AS_IF([test "$TEST_GCC" = "yes"],[AX_GCC_VERSION],[])
 dnl if the compiler is gcc, test for gcc >= 4.8
 AS_IF([test "x$GCC_VERSION" = "x"],[],
  [AC_MSG_CHECKING([gcc version >= 4.8])

--- a/configure
+++ b/configure
@@ -631,11 +631,12 @@ UDUNITS_EXCLUDE
 UDUNITS_LDFLAGS
 UDUNITS_INCLUDES
 UDUNITS_HOME
+CLANG_VERSION
 LLVM_HOME
 CLANG
 LLVM_CONFIG
-PYTHON_EXTRA_LIBS
 PYTHON_EXTRA_LDFLAGS
+PYTHON_EXTRA_LIBS
 PYTHON_SITE_PKG
 PYTHON_LIBS
 PYTHON_CPPFLAGS
@@ -671,12 +672,14 @@ GNUPLOT
 SWIG
 PYTHON
 PERL
+CURL
 BISON
 LEXLIB
 LEX_OUTPUT_ROOT
 LEX
 LD
 TEE
+GCC_VERSION
 ac_ct_CXX
 CXXFLAGS
 CXX
@@ -3488,7 +3491,36 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-AX_GCC_VERSION
+
+
+  GCC_VERSION=""
+  if test "x$GCC" = "xyes"; then :
+
+    if test "x$ax_gcc_version_option" != "xno"; then :
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking gcc version" >&5
+$as_echo_n "checking gcc version... " >&6; }
+if ${ax_cv_gcc_version+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+        ax_cv_gcc_version="`$CC -dumpversion`"
+        if test "x$ax_cv_gcc_version" = "x"; then :
+
+          ax_cv_gcc_version=""
+
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_version" >&5
+$as_echo "$ax_cv_gcc_version" >&6; }
+      GCC_VERSION=$ax_cv_gcc_version
+
+fi
+
+fi
+
+
 if test "x$GCC_VERSION" = "x"; then :
 
 else
@@ -3833,6 +3865,50 @@ fi
 
 if test "$ac_cv_path_BISON" = "nobison"; then :
   as_fn_error $? "could not find bison" "$LINENO" 5
+fi
+# Extract the first word of "curl", so it can be a program name with args.
+set dummy curl; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_CURL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $CURL in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_CURL="$CURL" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_CURL="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_CURL" && ac_cv_path_CURL="nocurl"
+  ;;
+esac
+fi
+CURL=$ac_cv_path_CURL
+if test -n "$CURL"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CURL" >&5
+$as_echo "$CURL" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+if test "$ac_cv_path_CURL" = "nocurl"; then :
+  as_fn_error $? "could not find curl" "$LINENO" 5
 fi
 # Extract the first word of "perl", so it can be a program name with args.
 set dummy perl; ac_word=$2
@@ -6123,13 +6199,13 @@ $as_echo "$PYTHON_SITE_PKG" >&6; }
 	#
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra libraries" >&5
 $as_echo_n "checking python extra libraries... " >&6; }
-	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
-	   PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
+	if test -z "$PYTHON_EXTRA_LIBS"; then
+	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
                 conf = distutils.sysconfig.get_config_var; \
                 print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
 	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LDFLAGS" >&5
-$as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
+$as_echo "$PYTHON_EXTRA_LIBS" >&6; }
 
 
 	#
@@ -6137,13 +6213,13 @@ $as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }
 	#
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra linking flags" >&5
 $as_echo_n "checking python extra linking flags... " >&6; }
-	if test -z "$PYTHON_EXTRA_LIBS"; then
-		PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
 			conf = distutils.sysconfig.get_config_var; \
 			print (conf('LINKFORSHARED'))"`
 	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
-$as_echo "$PYTHON_EXTRA_LIBS" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LDFLAGS" >&5
+$as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }
 
 
 	#
@@ -6574,6 +6650,66 @@ if test "$ac_cv_path_CLANG" = "noclang"; then :
   as_fn_error $? "could not find clang" "$LINENO" 5
 fi
 
+
+
+
+  CLANG_VERSION=""
+  ax_cv_clang_version="`$CLANG --version | grep "version" | sed "s/.*version \(0-9*\.0-9*\.0-9*\).*/\1/"`"
+  if test "x$ax_cv_clang_version" = "x"; then :
+
+    ax_cv_clang_version=""
+
+fi
+  CLANG_VERSION=$ax_cv_clang_version
+
+
+if test "x$CLANG_VERSION" = "x"; then :
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking clang version >= 3.4.2" >&5
+$as_echo_n "checking clang version >= 3.4.2... " >&6; }
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "$CLANG_VERSION" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "3.4.2" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/true/;s/x${ax_compare_version_B}/false/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    else { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    as_fn_error $? "Trick requires llvm/clang version >= 3.4.2" "$LINENO" 5
+
+  fi
+
+
+fi
 
 #
 # Handle user hints

--- a/configure
+++ b/configure
@@ -635,8 +635,8 @@ CLANG_VERSION
 LLVM_HOME
 CLANG
 LLVM_CONFIG
-PYTHON_EXTRA_LDFLAGS
 PYTHON_EXTRA_LIBS
+PYTHON_EXTRA_LDFLAGS
 PYTHON_SITE_PKG
 PYTHON_LIBS
 PYTHON_CPPFLAGS
@@ -647,14 +647,6 @@ PTHREAD_CC
 ax_pthread_config
 CPP
 SED
-host_os
-host_vendor
-host_cpu
-host
-build_os
-build_vendor
-build_cpu
-build
 LIBXML
 MOTIF_HOME
 X_LIB_DIR
@@ -691,6 +683,14 @@ LDFLAGS
 CFLAGS
 CC
 AWK
+host_os
+host_vendor
+host_cpu
+host
+build_os
+build_vendor
+build_cpu
+build
 target_alias
 host_alias
 build_alias
@@ -2398,6 +2398,80 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 
+
+
+# Make sure we can run config.sub.
+$SHELL "$ac_aux_dir/config.sub" sun4 >/dev/null 2>&1 ||
+  as_fn_error $? "cannot run $SHELL $ac_aux_dir/config.sub" "$LINENO" 5
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
+$as_echo_n "checking build system type... " >&6; }
+if ${ac_cv_build+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_build_alias=$build_alias
+test "x$ac_build_alias" = x &&
+  ac_build_alias=`$SHELL "$ac_aux_dir/config.guess"`
+test "x$ac_build_alias" = x &&
+  as_fn_error $? "cannot guess build type; you must specify one" "$LINENO" 5
+ac_cv_build=`$SHELL "$ac_aux_dir/config.sub" $ac_build_alias` ||
+  as_fn_error $? "$SHELL $ac_aux_dir/config.sub $ac_build_alias failed" "$LINENO" 5
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
+$as_echo "$ac_cv_build" >&6; }
+case $ac_cv_build in
+*-*-*) ;;
+*) as_fn_error $? "invalid value of canonical build" "$LINENO" 5;;
+esac
+build=$ac_cv_build
+ac_save_IFS=$IFS; IFS='-'
+set x $ac_cv_build
+shift
+build_cpu=$1
+build_vendor=$2
+shift; shift
+# Remember, the first character of IFS is used to create $*,
+# except with old shells:
+build_os=$*
+IFS=$ac_save_IFS
+case $build_os in *\ *) build_os=`echo "$build_os" | sed 's/ /-/g'`;; esac
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
+$as_echo_n "checking host system type... " >&6; }
+if ${ac_cv_host+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "x$host_alias" = x; then
+  ac_cv_host=$ac_cv_build
+else
+  ac_cv_host=`$SHELL "$ac_aux_dir/config.sub" $host_alias` ||
+    as_fn_error $? "$SHELL $ac_aux_dir/config.sub $host_alias failed" "$LINENO" 5
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
+$as_echo "$ac_cv_host" >&6; }
+case $ac_cv_host in
+*-*-*) ;;
+*) as_fn_error $? "invalid value of canonical host" "$LINENO" 5;;
+esac
+host=$ac_cv_host
+ac_save_IFS=$IFS; IFS='-'
+set x $ac_cv_host
+shift
+host_cpu=$1
+host_vendor=$2
+shift; shift
+# Remember, the first character of IFS is used to create $*,
+# except with old shells:
+host_os=$*
+IFS=$ac_save_IFS
+case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+
+
+
 PATH="/opt/rh/devtoolset-3/root/usr/bin:${PATH}"
 XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include"
 CFLAGS="$CFLAGS $XTRAINCPATHS"
@@ -3492,6 +3566,15 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
+TEST_GCC=yes
+case "${host_os}" in
+    darwin*)
+        TEST_GCC=no
+        ;;
+    *)
+        ;;
+esac
+if test "$TEST_GCC" = "yes"; then :
 
   GCC_VERSION=""
   if test "x$GCC" = "xyes"; then :
@@ -3521,6 +3604,7 @@ fi
 fi
 
 
+fi
 if test "x$GCC_VERSION" = "x"; then :
 
 else
@@ -5028,77 +5112,6 @@ else
 fi
 
 
-# Make sure we can run config.sub.
-$SHELL "$ac_aux_dir/config.sub" sun4 >/dev/null 2>&1 ||
-  as_fn_error $? "cannot run $SHELL $ac_aux_dir/config.sub" "$LINENO" 5
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
-$as_echo_n "checking build system type... " >&6; }
-if ${ac_cv_build+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_build_alias=$build_alias
-test "x$ac_build_alias" = x &&
-  ac_build_alias=`$SHELL "$ac_aux_dir/config.guess"`
-test "x$ac_build_alias" = x &&
-  as_fn_error $? "cannot guess build type; you must specify one" "$LINENO" 5
-ac_cv_build=`$SHELL "$ac_aux_dir/config.sub" $ac_build_alias` ||
-  as_fn_error $? "$SHELL $ac_aux_dir/config.sub $ac_build_alias failed" "$LINENO" 5
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
-$as_echo "$ac_cv_build" >&6; }
-case $ac_cv_build in
-*-*-*) ;;
-*) as_fn_error $? "invalid value of canonical build" "$LINENO" 5;;
-esac
-build=$ac_cv_build
-ac_save_IFS=$IFS; IFS='-'
-set x $ac_cv_build
-shift
-build_cpu=$1
-build_vendor=$2
-shift; shift
-# Remember, the first character of IFS is used to create $*,
-# except with old shells:
-build_os=$*
-IFS=$ac_save_IFS
-case $build_os in *\ *) build_os=`echo "$build_os" | sed 's/ /-/g'`;; esac
-
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
-$as_echo_n "checking host system type... " >&6; }
-if ${ac_cv_host+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test "x$host_alias" = x; then
-  ac_cv_host=$ac_cv_build
-else
-  ac_cv_host=`$SHELL "$ac_aux_dir/config.sub" $host_alias` ||
-    as_fn_error $? "$SHELL $ac_aux_dir/config.sub $host_alias failed" "$LINENO" 5
-fi
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
-$as_echo "$ac_cv_host" >&6; }
-case $ac_cv_host in
-*-*-*) ;;
-*) as_fn_error $? "invalid value of canonical host" "$LINENO" 5;;
-esac
-host=$ac_cv_host
-ac_save_IFS=$IFS; IFS='-'
-set x $ac_cv_host
-shift
-host_cpu=$1
-host_vendor=$2
-shift; shift
-# Remember, the first character of IFS is used to create $*,
-# except with old shells:
-host_os=$*
-IFS=$ac_save_IFS
-case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
-
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for a sed that does not truncate output" >&5
 $as_echo_n "checking for a sed that does not truncate output... " >&6; }
 if ${ac_cv_path_SED+:} false; then :
@@ -6199,13 +6212,13 @@ $as_echo "$PYTHON_SITE_PKG" >&6; }
 	#
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra libraries" >&5
 $as_echo_n "checking python extra libraries... " >&6; }
-	if test -z "$PYTHON_EXTRA_LIBS"; then
-	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+	   PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
                 conf = distutils.sysconfig.get_config_var; \
                 print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
 	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
-$as_echo "$PYTHON_EXTRA_LIBS" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LDFLAGS" >&5
+$as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }
 
 
 	#
@@ -6213,13 +6226,13 @@ $as_echo "$PYTHON_EXTRA_LIBS" >&6; }
 	#
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra linking flags" >&5
 $as_echo_n "checking python extra linking flags... " >&6; }
-	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
-		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
+	if test -z "$PYTHON_EXTRA_LIBS"; then
+		PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
 			conf = distutils.sysconfig.get_config_var; \
 			print (conf('LINKFORSHARED'))"`
 	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LDFLAGS" >&5
-$as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
+$as_echo "$PYTHON_EXTRA_LIBS" >&6; }
 
 
 	#


### PR DESCRIPTION
This fixes 3 known issues with the configure/configure.ac scripts. For the version checks, I went with the given versions in the Install Guide.

I'm not sure why the order of PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS swapped. Anyone know a way to avoid that?