### PR TITLE
Retry curl operations to avoid transient failures.

### DIFF
--- a/libexec/trick/java/lib/Makefile
+++ b/libexec/trick/java/lib/Makefile
@@ -21,23 +21,23 @@ EXTERNAL_JARS = \
 external_jars : ${EXTERNAL_JARS}
 
 bsaf-1.9.2.jar :
-	curl -O http://repo.maven.apache.org/maven2/org/jdesktop/bsaf/bsaf/1.9.2/bsaf-1.9.2.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/org/jdesktop/bsaf/bsaf/1.9.2/bsaf-1.9.2.jar
 itext-2.1.7.jar :
-	curl -O http://repo.maven.apache.org/maven2/com/lowagie/itext/2.1.7/itext-2.1.7.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/com/lowagie/itext/2.1.7/itext-2.1.7.jar
 jcommon-1.0.23.jar :
-	curl -O http://repo.maven.apache.org/maven2/org/jfree/jcommon/1.0.23/jcommon-1.0.23.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/org/jfree/jcommon/1.0.23/jcommon-1.0.23.jar
 jfreechart-1.0.19.jar :
-	curl -O http://repo.maven.apache.org/maven2/org/jfree/jfreechart/1.0.19/jfreechart-1.0.19.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/org/jfree/jfreechart/1.0.19/jfreechart-1.0.19.jar
 jfreesvg-2.1.jar :
-	curl -O http://repo.maven.apache.org/maven2/org/jfree/jfreesvg/2.1/jfreesvg-2.1.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/org/jfree/jfreesvg/2.1/jfreesvg-2.1.jar
 jopt-simple-4.8.jar :
-	curl -O http://repo.maven.apache.org/maven2/net/sf/jopt-simple/jopt-simple/4.8/jopt-simple-4.8.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/net/sf/jopt-simple/jopt-simple/4.8/jopt-simple-4.8.jar
 junit-4.12.jar:
-	curl -O http://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar
+	curl --retry 4 -O http://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar
 swingx-1.6.1.jar :
-	curl -O http://repo.maven.apache.org/maven2/org/swinglabs/swingx/1.6.1/swingx-1.6.1.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/org/swinglabs/swingx/1.6.1/swingx-1.6.1.jar
 hamcrest-core-1.3.jar :
-	curl -O http://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+	curl --retry 4 -O http://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
 
 clean:
 	rm -f ${EXTERNAL_JARS}


### PR DESCRIPTION
Curl can fail transiently. Have it retry a few times before giving up.

```
make[2]: Entering directory '/home/gitlab-runner/builds/272e0b41/0/path/to/trick/libexec/trick/java/lib'
curl -O http://repo.maven.apache.org/maven2/org/jdesktop/bsaf/bsaf/1.9.2/bsaf-1.9.2.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0curl: (6) Could not resolve host: repo.maven.apache.org
Makefile:24: recipe for target 'bsaf-1.9.2.jar' failed
make[2]: *** [bsaf-1.9.2.jar] Error 6
make[2]: Leaving directory '/home/gitlab-runner/builds/272e0b41/0/path/to/trick/libexec/trick/java/lib'
makefile:49: recipe for target 'external_jars' failed
make[1]: *** [external_jars] Error 2
make[1]: Leaving directory '/home/gitlab-runner/builds/272e0b41/0/path/to/trick/trick_source/java'
Makefile:223: recipe for target 'java' failed
make: *** [java] Error 2
make: *** Waiting for unfinished jobs....
```