### PR TITLE
Add M_SIGN macro

### DIFF
--- a/include/trick/trick_math.h
+++ b/include/trick/trick_math.h
@@ -11,6 +11,10 @@
 #define M_ABS(x) ((x) < 0 ? -(x) : (x))
 #endif
 
+#ifndef M_SIGN
+#define M_SIGN(x) (((x) > 0) - ((x) < 0))
+#endif
+
 #if ( __ghs )
 #ifndef M_PI
 #define M_PI     3.141592653589793238460


### PR DESCRIPTION
The standard math.h library does not contain a sign function. Adding
a simple macro to trick to output (-1, 0, 1) based on the sign of the
input expression. This can evaluate sign for C++ signed types.

```
    void test_M_SIGN() {
        printf("50.0   %d\n", M_SIGN(50.0));
        printf("-13    %d\n", M_SIGN(-13));
        printf("0      %d\n", M_SIGN(0));
        printf("0.0    %d\n", M_SIGN(0.0));
        printf("-0     %d\n", M_SIGN(-0));
        printf("-0.0   %d\n", M_SIGN(-0.0));
        printf("inf    %d\n", M_SIGN(std::numeric_limits<double>::infinity()));
        printf("-inf   %d\n", M_SIGN(-std::numeric_limits<double>::infinity()));
    }
```

```
50.0   1
-13    -1
0      0
0.0    0
-0     0
-0.0   0
inf    1
-inf   -1
```