### PR TITLE
Warning fixes

### DIFF
--- a/trick_source/sim_services/MemoryManager/adef_parser.l
+++ b/trick_source/sim_services/MemoryManager/adef_parser.l
@@ -18,6 +18,10 @@
 #include "trick/ADefParseContext.hh"
 #include "adef_parser.tab.h"
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
 #define YY_EXTRA_TYPE Trick::ADefParseContext*
 
 #define YY_USER_ACTION yylloc->first_line = yylineno;

--- a/trick_source/sim_services/MemoryManager/adef_parser.y
+++ b/trick_source/sim_services/MemoryManager/adef_parser.y
@@ -21,6 +21,8 @@
 #include "trick/ADefParseContext.hh"
 #include "adef_parser.tab.h"
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
     using namespace std;
 
     int ADEF_lex( YYSTYPE* lvalp, YYLTYPE* llocp, void* scanner );

--- a/trick_source/sim_services/MemoryManager/ref_parser.l
+++ b/trick_source/sim_services/MemoryManager/ref_parser.l
@@ -19,6 +19,10 @@
 #include "trick/RefParseContext.hh"
 #include "ref_parser.tab.h"
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
 #define YY_EXTRA_TYPE RefParseContext*
 
 #define YY_USER_ACTION yylloc->first_line = yylineno;

--- a/trick_source/sim_services/MemoryManager/ref_parser.y
+++ b/trick_source/sim_services/MemoryManager/ref_parser.y
@@ -21,6 +21,8 @@
 #include "trick/var.h"
 #include "ref_parser.tab.h"
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
     using namespace std;
 
     int REF_lex( YYSTYPE* lvalp, YYLTYPE* llocp, void* scanner );

--- a/trick_source/sim_services/Message/MessageThreadedCout.cpp
+++ b/trick_source/sim_services/Message/MessageThreadedCout.cpp
@@ -74,6 +74,7 @@ void * Trick::MessageThreadedCout::thread_body() {
         write_pending_messages() ;
         RELEASE() ;
     }
+    return (void*)0;
 }
 
 void Trick::MessageThreadedCout::write_pending_messages() {


### PR DESCRIPTION
Bison and Flex both generate warnings from generated code. The code is fine.

void * Trick::MessageThreadedCout::thread_body() needs to return a value, specifically NULL;