### PR TITLE
Trick View: use fixed width for binary format

### DIFF
--- a/trick_source/java/src/trick/tv/TVByte.java
+++ b/trick_source/java/src/trick/tv/TVByte.java
@@ -37,7 +37,8 @@ public class TVByte extends VSByte implements TrickViewFluent<TVByte.Format> {
 
         Binary {
             public String format(byte value, boolean unsigned) {
-                return Integer.toBinaryString(value & 0xFF);
+                String result = Integer.toBinaryString(value & 0xFF);
+                return "00000000".substring(result.length()) + result;
             }
 
             public byte parse(String value) {

--- a/trick_source/java/src/trick/tv/TVInteger.java
+++ b/trick_source/java/src/trick/tv/TVInteger.java
@@ -32,12 +32,14 @@ public class TVInteger extends VSInteger implements TrickViewFluent<TVInteger.Fo
 
         Decimal {
             public String format(int value, boolean unsigned) {
+                String result;
                 if (unsigned && value < 0) {
-                    return Long.toString(value + 4294967296L);
+                    result = Long.toString(value + 4294967296L);
                 }
                 else {
-                    return Integer.toString(value);
+                    result = Integer.toString(value);
                 }
+                return "00000000000000000000000000000000".substring(result.length()) + result;
             }
 
             public int parse(String value) {

--- a/trick_source/java/src/trick/tv/TVLong.java
+++ b/trick_source/java/src/trick/tv/TVLong.java
@@ -22,7 +22,9 @@ public class TVLong extends VSLong implements TrickViewFluent<TVLong.Format> {
 
         Binary {
             public String format(long value, boolean unsigned) {
-                return Long.toBinaryString(value);
+                String result = Long.toBinaryString(value);
+                return "0000000000000000000000000000000000000000000000000000000000000000"
+                    .substring(result.length()) + result;
             }
 
             public long parse(String value) {

--- a/trick_source/java/src/trick/tv/TVShort.java
+++ b/trick_source/java/src/trick/tv/TVShort.java
@@ -22,7 +22,8 @@ public class TVShort extends VSShort implements TrickViewFluent<TVShort.Format> 
 
         Binary {
             public String format(short value, boolean unsigned) {
-                return Integer.toBinaryString(value & 0xFFFF);
+                String result = Integer.toBinaryString(value & 0xFFFF);
+                return "0000000000000000".substring(result.length()) + result;
             }
 
             public short parse(String value) {


### PR DESCRIPTION
Approach stolen from http://javadevnotes.com/java-integer-to-fixed-length-string

Closes #661 
