### PR TITLE
Fix incorrect initialization of units in trick-qp.

### DIFF
--- a/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductColumn.java
+++ b/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductColumn.java
@@ -34,6 +34,9 @@ public class ProductColumn {
     private static final int FORMAT_INDEX                 = 0;
 
     private String label;
+    // The <units> element is OPTIONAL. It specifies the units
+    // to which the user wants the recorded data to be converted.
+    // The default value of units should be null, NOT "--".
     private String units;
     private ProductVar var;
     private String format;
@@ -46,7 +49,7 @@ public class ProductColumn {
      */
     public ProductColumn() {
         this.setLabel( "Column" );
-        this.setUnits( "--" );
+        this.setUnits(null);
         this.dataReader = null;
     }
 
@@ -58,7 +61,7 @@ public class ProductColumn {
      */
     public ProductColumn(ProductVar var) {
         this.setLabel( "Column" );
-        this.setUnits( "--" );
+        this.setUnits(null);
         this.setVar( var );
         this.dataReader = null;
     }

--- a/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductMeasurement.java
+++ b/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductMeasurement.java
@@ -32,6 +32,9 @@ public class ProductMeasurement {
     //  Private Data
     //========================================
     private String name;
+    // The <units> element is OPTIONAL. It specifies the units
+    // to which the user wants the recorded data to be converted.
+    // The default value of units should be null, NOT "--".
     private String units;
 
     private static final int UNITS_INDEX = 0;
@@ -47,7 +50,7 @@ public class ProductMeasurement {
      */
     public ProductMeasurement(String name) {
         this.name = name;
-        this.setUnits( "--" );
+        this.setUnits(null);
     }
 
     //========================================

--- a/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductVar.java
+++ b/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductVar.java
@@ -286,7 +286,9 @@ public class ProductVar {
     private String name;
     // The label of the variable
     private String label;
-    // The units of the variable
+    // The <units> element is OPTIONAL. It specifies the units
+    // to which the user wants the recorded data to be converted.
+    // The default value of units should be null, NOT "--".
     private String units;
     // The units from which needs to be converted.
     // Only needed when the data recording data doesn't provide the units for this variable.
@@ -323,7 +325,7 @@ public class ProductVar {
         // If the label is entered by a user from GUI, that entered text
         // will be displayed and fxplot will not show the default label.
         //this.setLabel( name );
-        setUnits("--");
+        setUnits(null);
         
     }
 

--- a/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductXMLCreator.java
+++ b/trick_source/java/src/trick/dataproducts/trickqp/utils/ProductXMLCreator.java
@@ -163,8 +163,13 @@ public class ProductXMLCreator extends XMLCreator {
 			    Element measurementElem = dom.createElement("measurement");
 				// <var>...</var>
 				createChildElement(measurementElem, "var", eachOutput.getName());
-				// <units> ... </units>
-				createChildElement(measurementElem, "units", eachOutput.getUnits());
+
+                                // The units element is OPTIONAL and can be null,
+                                // indicating that the user doesn't want units conversion.
+                                String outPutUnits  = eachOutput.getUnits();
+                                if (outPutUnits != null)  {
+				    createChildElement(measurementElem, "units", outPutUnits);
+                                }
 				outputsElem.appendChild(measurementElem);
 			}
 		}
@@ -440,7 +445,13 @@ public class ProductXMLCreator extends XMLCreator {
 	private Element createColumnElement(ProductColumn column) {
 		Element columnElem = dom.createElement("column");
 		createChildElement(columnElem, "label", column.getLabel());
-		createChildElement(columnElem, "units", column.getUnits());
+                
+                // The units element is OPTIONAL and can be null,
+                // indicating that the user doesn't want units conversion.
+                String columnUnits = column.getUnits();
+                if (columnUnits != null) {
+		    createChildElement(columnElem, "units", columnUnits);
+                }
 		
 		columnElem.appendChild(createVarElement(column.getVar()));
 		

--- a/trick_source/java/src/trick/dataproducts/trickqp/utils/TrickQPActionController.java
+++ b/trick_source/java/src/trick/dataproducts/trickqp/utils/TrickQPActionController.java
@@ -1676,7 +1676,6 @@ public class TrickQPActionController {
 
         // also need to add this newly generated output var to var list
         LogVar newOutVar = new LogVar(var.getName());
-        newOutVar.setUnits("--");
         application.varList.addData(newOutVar);
     }
 


### PR DESCRIPTION
Trick-qp initialized units elements to "--" which is incorrect.
The <units> element optionally specifies units to which the recorded should be converted.
When non-null a <units> specification should be generated. When null the <units> element should not be generated. The bogus <units> -- <\units> was causing the fermi tape generation tool to crash because it was attempting to convert "m/s2" etc. to "--". 
