### PR TITLE
Replace unreliable 'divide-by-zero' way of generating NaNs with math.h NAN in *deuler* routines.

### DIFF
--- a/trick_source/trick_utils/math/src/deuler_123.c
+++ b/trick_source/trick_utils/math/src/deuler_123.c
@@ -120,13 +120,12 @@ int euler123(
                 /* Error: Out of normal range and beyond tolerance
                    for asin function */
                 else {
-                        double zero = 0.0;
                         ret = TM_ANG_NAN;
                         if ( error_flag[4] == 0 ) {
                             tm_print_error(ret);
                             error_flag[4]=1;
                         }
-                        angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                        angle[0] = angle[1] = angle[2] = NAN;
                 }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_123_quat.c
+++ b/trick_source/trick_utils/math/src/deuler_123_quat.c
@@ -116,13 +116,12 @@ int euler123_quat(
        /* Error: Out of normal range and beyond tolerance
           for asin function */
        else {
-               double zero = 0.0;
                ret = TM_ANG_NAN;
                if ( error_flag[4] == 0 ) {
         	   tm_print_error(ret);
         	   error_flag[4]=1;
                }
-               angle[0] = angle[1] = angle[2] = 0.0 / zero;
+               angle[0] = angle[1] = angle[2] = NAN;
        }
 #undef TOLERANCE
    } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_132.c
+++ b/trick_source/trick_utils/math/src/deuler_132.c
@@ -137,13 +137,12 @@ int euler132(
                  * for asin function
                  */
                 else {
-                        double zero = 0.0;
                         ret = TM_ANG_NAN;
                         if ( error_flag[4] == 0 ) {
                             tm_print_error(ret);
                             error_flag[4]=1;
                         }
-                        angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                        angle[0] = angle[1] = angle[2] = NAN;
                 }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_132_quat.c
+++ b/trick_source/trick_utils/math/src/deuler_132_quat.c
@@ -117,13 +117,12 @@ int euler132_quat(
         * for asin function
         */
        else {
-               double zero = 0.0;
                ret = TM_ANG_NAN;
                if ( error_flag[4] == 0 ) {
         	   tm_print_error(ret);
         	   error_flag[4]=1;
                }
-               angle[0] = angle[1] = angle[2] = 0.0 / zero;
+               angle[0] = angle[1] = angle[2] = NAN;
        }
 #undef TOLERANCE
    } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_213.c
+++ b/trick_source/trick_utils/math/src/deuler_213.c
@@ -124,13 +124,12 @@ int euler213(double angle[3],   /* In:  r  Method=0, 0=PITCH , 1=ROLL , 2=YAW */
                 /* Error: Out of normal range & beyond tolerance
                    for asin func */
                 else {
-                        double zero = 0.0;
                         ret = TM_ANG_NAN;
                         if ( error_flag[4] == 0 ) {
                             tm_print_error(ret);
                             error_flag[4]=1;
                         }
-                        angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                        angle[0] = angle[1] = angle[2] = NAN;
                 }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_213_quat.c
+++ b/trick_source/trick_utils/math/src/deuler_213_quat.c
@@ -114,13 +114,12 @@ int euler213_quat(
         /* Error: Out of normal range & beyond tolerance
            for asin func */
         else {
-                double zero = 0.0;
                 ret = TM_ANG_NAN;
                 if ( error_flag[4] == 0 ) {
                     tm_print_error(ret);
                     error_flag[4]=1;
                 }
-                angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                angle[0] = angle[1] = angle[2] = NAN;
         }
 #undef TOLERANCE
    } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_231.c
+++ b/trick_source/trick_utils/math/src/deuler_231.c
@@ -120,13 +120,12 @@ int euler231( /* Return: --   None. */
                 }
                 /* Error: Out of normal range & beyond tolerance for asin func*/
                 else {
-                        double zero = 0.0;
                         ret = TM_ANG_NAN;
                         if ( error_flag[4] == 0 ) {
                             tm_print_error(ret);
                             error_flag[4]=1;
                         }
-                        angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                        angle[0] = angle[1] = angle[2] = NAN;
                 }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_231_quat.c
+++ b/trick_source/trick_utils/math/src/deuler_231_quat.c
@@ -112,13 +112,12 @@ int euler231_quat(
        }
        /* Error: Out of normal range & beyond tolerance for asin func*/
        else {
-               double zero = 0.0;
                ret = TM_ANG_NAN;
                if ( error_flag[4] == 0 ) {
         	   tm_print_error(ret);
         	   error_flag[4]=1;
                }
-               angle[0] = angle[1] = angle[2] = 0.0 / zero;
+               angle[0] = angle[1] = angle[2] = NAN;
        }
 #undef TOLERANCE
    } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_312.c
+++ b/trick_source/trick_utils/math/src/deuler_312.c
@@ -118,13 +118,12 @@ int euler312(
                 }
                 /* Error: Out of normal range & beyond tolerance for asin func*/
                 else {
-                        double zero = 0.0;
                         ret = TM_ANG_NAN;
                         if ( error_flag[4] == 0 ) {
                             tm_print_error(ret);
                             error_flag[4]=1;
                         }
-                        angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                        angle[0] = angle[1] = angle[2] = NAN;
                 }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_312_quat.c
+++ b/trick_source/trick_utils/math/src/deuler_312_quat.c
@@ -112,13 +112,12 @@ int euler312_quat(
        }
        /* Error: Out of normal range & beyond tolerance for asin func*/
        else {
-               double zero = 0.0;
                ret = TM_ANG_NAN;
                if ( error_flag[4] == 0 ) {
         	   tm_print_error(ret);
         	   error_flag[4]=1;
                }
-               angle[0] = angle[1] = angle[2] = 0.0 / zero;
+               angle[0] = angle[1] = angle[2] = NAN;
        }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_321.c
+++ b/trick_source/trick_utils/math/src/deuler_321.c
@@ -120,13 +120,12 @@ int euler321(
                 }
                 /* Error: Out of normal range & beyond tolerance for asin func*/
                 else {
-                        double zero = 0.0;
                         ret = TM_ANG_NAN;
                         if ( error_flag[4] == 0 ) {
                             tm_print_error(ret);
                             error_flag[4]=1;
                         }
-                        angle[0] = angle[1] = angle[2] = 0.0 / zero;
+                        angle[0] = angle[1] = angle[2] = NAN;
                 }
 #undef TOLERANCE
         } else if (method == 2) {

--- a/trick_source/trick_utils/math/src/deuler_321_quat.c
+++ b/trick_source/trick_utils/math/src/deuler_321_quat.c
@@ -112,13 +112,12 @@ int euler321_quat(
        }
        /* Error: Out of normal range & beyond tolerance for asin func*/
        else {
-           double zero = 0.0;
            ret = TM_ANG_NAN;
            if ( error_flag[4] == 0 ) {
                tm_print_error(ret);
                error_flag[4]=1;
            }
-           angle[0] = angle[1] = angle[2] = 0.0 / zero;
+           angle[0] = angle[1] = angle[2] = NAN;
        }
 #undef TOLERANCE
    } else if (method == 2) {


### PR DESCRIPTION
Previous code generated FP div by zero error.
This fix returns NaNs in each of the angle elements.