### PR TITLE
Explicitly specify void arg for C functions that take no arguments.

### DIFF
--- a/include/trick/clock_proto.h
+++ b/include/trick/clock_proto.h
@@ -6,12 +6,12 @@
 extern "C" {
 #endif
 
-long long clock_time() ;
-long long clock_wall_time() ;
+long long clock_time(void) ;
+long long clock_wall_time(void) ;
 long long clock_reset(long long ref) ;
 int clock_spin(long long ref) ;
 int clock_set_reference(long long ref) ;
-double clock_get_rt_clock_ratio() ;
+double clock_get_rt_clock_ratio(void) ;
 int clock_set_rt_clock_ratio(double in_rt_clock_ratio) ;
 
 #ifdef __cplusplus

--- a/include/trick/command_line_protos.h
+++ b/include/trick/command_line_protos.h
@@ -22,17 +22,17 @@ extern "C" {
 
 int command_line_args_process_sim_args(int argc , char ** argv) ;
 
-int command_line_args_get_argc() ;
-char ** command_line_args_get_argv() ;
-const char * command_line_args_get_output_dir() ;
-const char * command_line_args_get_user_output_dir() ;
-const char * command_line_args_get_input_file() ;
+int command_line_args_get_argc(void) ;
+char ** command_line_args_get_argv(void) ;
+const char * command_line_args_get_output_dir(void) ;
+const char * command_line_args_get_user_output_dir(void) ;
+const char * command_line_args_get_input_file(void) ;
 
-const char * command_line_args_get_default_dir() ;
-const char * command_line_args_get_cmdline_name() ;
+const char * command_line_args_get_default_dir(void) ;
+const char * command_line_args_get_cmdline_name(void) ;
 
-int output_dir_timestamped_on() ;
-int output_dir_timestamped_off() ;
+int output_dir_timestamped_on(void) ;
+int output_dir_timestamped_off(void) ;
 
 void set_output_dir(const char* output_directory);
 
@@ -42,7 +42,7 @@ void set_output_dir(const char* output_directory);
 
 #ifdef __cplusplus
 #include <string>
-std::string & command_line_args_get_input_file_ref() ;
+std::string & command_line_args_get_input_file_ref(void) ;
 #endif
 
 #endif

--- a/include/trick/data_record_proto.h
+++ b/include/trick/data_record_proto.h
@@ -8,14 +8,14 @@
 extern "C" {
 #endif
 
-int dr_remove_files() ;
-int dr_enable() ;
-int dr_disable() ;
+int dr_remove_files(void) ;
+int dr_enable(void) ;
+int dr_disable(void) ;
 int dr_enable_group( const char * in_name ) ;
 int dr_disable_group( const char * in_name ) ;
 int dr_record_now_group( const char * in_name ) ;
 int dr_set_max_file_size ( uint64_t bytes ) ;
-void remove_all_data_record_groups() ;
+void remove_all_data_record_groups(void) ;
 int set_max_size_record_group (const char * in_name, uint64_t bytes ) ;
 
 

--- a/include/trick/debug_pause_proto.h
+++ b/include/trick/debug_pause_proto.h
@@ -6,9 +6,9 @@
 extern "C" {
 #endif
 
-int debug_pause_on() ;
-int debug_pause_off() ;
-int debug_signal() ;
+int debug_pause_on(void) ;
+int debug_pause_off(void) ;
+int debug_signal(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/echojobs_proto.h
+++ b/include/trick/echojobs_proto.h
@@ -6,8 +6,8 @@
 extern "C" {
 #endif
 
-int echo_jobs_on() ;
-int echo_jobs_off() ;
+int echo_jobs_on(void) ;
+int echo_jobs_off(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/external_application_c_intf.h
+++ b/include/trick/external_application_c_intf.h
@@ -12,31 +12,31 @@ extern "C" {
 // Convenience functions for backwards compatibility that, dolphins willing, will one day be removed.
 
 void sim_control_panel_set_enabled(int enabled);
-int sim_control_panel_get_enabled();
+int sim_control_panel_get_enabled(void);
 void sim_control_panel_auto_exit_set_enabled(int enabled);
 void trick_view_set_enabled(int enabled);
-int trick_view_get_enabled();
+int trick_view_get_enabled(void);
 void malfunctions_trick_view_set_enabled(int enabled);
-int malfunctions_trick_view_get_enabled();
+int malfunctions_trick_view_get_enabled(void);
 void monte_monitor_set_enabled(int enabled);
-int monte_monitor_get_enabled();
+int monte_monitor_get_enabled(void);
 void stripchart_set_enabled(int enabled);
-int stripchart_get_enabled();
+int stripchart_get_enabled(void);
 void sim_control_panel_set_startup_command(const char *command);
-const char *sim_control_panel_get_startup_command();
+const char *sim_control_panel_get_startup_command(void);
 void trick_view_set_startup_command(const char *command);
-const char *trick_view_get_startup_command();
+const char *trick_view_get_startup_command(void);
 void malfunctions_trick_view_set_startup_command(const char *command);
-const char *malfunctions_trick_view_get_startup_command();
+const char *malfunctions_trick_view_get_startup_command(void);
 void monte_monitor_set_startup_command(const char *command);
-const char *monte_monitor_get_startup_command();
+const char *monte_monitor_get_startup_command(void);
 void stripchart_set_startup_command(const char *command);
-const char *stripchart_get_startup_command();
-void sim_control_panel_launch();
-void trick_view_launch();
-void malfunctions_trick_view_launch();
-void monte_monitor_launch();
-void stripchart_launch();
+const char *stripchart_get_startup_command(void);
+void sim_control_panel_launch(void);
+void trick_view_launch(void);
+void malfunctions_trick_view_launch(void);
+void monte_monitor_launch(void);
+void stripchart_launch(void);
 void trick_view_set_cycle_period(double period);
 void trick_view_add_auto_load_file(const char *file);
 

--- a/include/trick/framelog_proto.h
+++ b/include/trick/framelog_proto.h
@@ -6,8 +6,8 @@
 extern "C" {
 #endif
 
-int frame_log_on() ;
-int frame_log_off() ;
+int frame_log_on(void) ;
+int frame_log_off(void) ;
 int frame_log_set_max_samples(int num) ;
 
 #ifdef __cplusplus

--- a/include/trick/master_proto.h
+++ b/include/trick/master_proto.h
@@ -6,8 +6,8 @@
 extern "C" {
 #endif
 
-    int ms_master_enable() ;
-    int ms_master_disable() ;
+    int ms_master_enable(void) ;
+    int ms_master_disable(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/montecarlo_c_intf.h
+++ b/include/trick/montecarlo_c_intf.h
@@ -21,7 +21,7 @@ void mc_set_enabled(int enabled);
  * @relates Trick::MonteCarlo
  * @copydoc get_enabled
  */
-int mc_get_enabled();
+int mc_get_enabled(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -33,13 +33,13 @@ void mc_set_dry_run(int dry_run);
  * @relates Trick::MonteCarlo
  * @copydoc get_dry_run
  */
-int mc_get_dry_run();
+int mc_get_dry_run(void);
 
 /**
  * @relates Trick::MonteCarlo
  * @copydoc is_slave
  */
-int mc_is_slave();
+int mc_is_slave(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -51,7 +51,7 @@ void mc_set_localhost_as_remote(int localhost_as_remote);
  * @relates Trick::MonteCarlo
  * @copydoc get_localhost_as_remote
  */
-int mc_get_localhost_as_remote();
+int mc_get_localhost_as_remote(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -63,7 +63,7 @@ void mc_set_custom_slave_dispatch(int custom_slave_dispatch);
  * @relates Trick::MonteCarlo
  * @copydoc get_custom_slave_dispatch
  */
-int mc_get_custom_slave_dispatch();
+int mc_get_custom_slave_dispatch(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -75,7 +75,7 @@ void mc_set_timeout(double timeout);
  * @relates Trick::MonteCarlo
  * @copydoc get_timeout
  */
-double mc_get_timeout();
+double mc_get_timeout(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -87,7 +87,7 @@ void mc_set_max_tries(unsigned int max_tries);
  * @relates Trick::MonteCarlo
  * @copydoc get_max_tries
  */
-unsigned int mc_get_max_tries();
+unsigned int mc_get_max_tries(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -105,13 +105,13 @@ void mc_set_slave_sim_options(const char *slave_sim_options);
  * @relates Trick::MonteCarlo
  * get #Trick::MonteCarlo::slave_sim_options
  */
-const char *mc_get_slave_sim_options();
+const char *mc_get_slave_sim_options(void);
 
 /**
  * @relates Trick::MonteCarlo
  * @copydoc get_user_cmd_string
  */
-const char *mc_get_user_cmd_string();
+const char *mc_get_user_cmd_string(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -123,7 +123,7 @@ void mc_set_custom_pre_text(const char *custom_pre_text);
  * @relates Trick::MonteCarlo
  * @copydoc get_custom_pre_text
  */
-const char *mc_get_custom_pre_text();
+const char *mc_get_custom_pre_text(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -135,7 +135,7 @@ void mc_set_custom_post_text(const char *custom_post_text);
  * @relates Trick::MonteCarlo
  * @copydoc get_custom_post_text
  */
-const char *mc_get_custom_post_text();
+const char *mc_get_custom_post_text(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -147,7 +147,7 @@ void mc_set_verbosity(int verbosity);
  * @relates Trick::MonteCarlo
  * @copydoc get_verbosity
  */
-int mc_get_verbosity();
+int mc_get_verbosity(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -159,19 +159,19 @@ void mc_set_num_runs(unsigned int num_runs);
  * @relates Trick::MonteCarlo
  * @copydoc get_num_runs
  */
-unsigned int mc_get_num_runs();
+unsigned int mc_get_num_runs(void);
 
 /**
  * @relates Trick::MonteCarlo
  * @copydoc get_num_results
  */
-unsigned int mc_get_num_results();
+unsigned int mc_get_num_results(void);
 
 /**
  * @relates Trick::MonteCarlo
  * @copydoc get_slave_id
  */
-unsigned int mc_get_slave_id();
+unsigned int mc_get_slave_id(void);
 
 /**
  * @relates Trick::MonteCarlo
@@ -213,7 +213,7 @@ void mc_read(char *buffer, int size);
  * @relates Trick::MonteCarlo
  * Gets the current run being processed.
  */
-unsigned int mc_get_current_run() ;
+unsigned int mc_get_current_run(void) ;
 
 /**
  * @relates Trick::MonteCarlo
@@ -237,13 +237,13 @@ void mc_set_connection_device_port(int port_number) ;
  * @relates Trick::MonteCarlo
  * Gets the port for the listen_device.
  */
-int  mc_get_listen_device_port() ;
+int  mc_get_listen_device_port(void) ;
 
 /**
  * @relates Trick::MonteCarlo
  * Gets the port for the connection_device.
  */
-int  mc_get_connection_device_port() ;
+int  mc_get_connection_device_port(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/outdllist.h
+++ b/include/trick/outdllist.h
@@ -32,7 +32,7 @@ typedef struct _DLLIST {
 }DLLIST;
 
 
-DLLIST* DLL_Create();
+DLLIST* DLL_Create(void);
 
 void DLL_Delete(DLLIST*);
 

--- a/include/trick/realtimesync_proto.h
+++ b/include/trick/realtimesync_proto.h
@@ -13,11 +13,11 @@ int real_time_change_timer(Trick::Timer * in_sleep_timer ) ;
 extern "C" {
 #endif
 
-int real_time_enable() ;
-int real_time_disable() ;
+int real_time_enable(void) ;
+int real_time_disable(void) ;
 int real_time_restart(long long ref_time ) ;
-int is_real_time() ;
-const char * real_time_clock_get_name() ;
+int is_real_time(void) ;
+const char * real_time_clock_get_name(void) ;
 int real_time_set_rt_clock_ratio(double in_clock_ratio) ;
 int real_time_lock_memory(int yes_no) ;
 

--- a/include/trick/sie_c_intf.h
+++ b/include/trick/sie_c_intf.h
@@ -3,10 +3,10 @@
 extern "C" {
 #endif
 
-void sie_print_xml() ;
-void sie_class_attr_map_print_xml() ;
-void sie_enum_attr_map_print_xml() ;
-void sie_top_level_objects_print_xml() ;
+void sie_print_xml(void) ;
+void sie_class_attr_map_print_xml(void) ;
+void sie_enum_attr_map_print_xml(void) ;
+void sie_top_level_objects_print_xml(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/simtime_proto.h
+++ b/include/trick/simtime_proto.h
@@ -8,13 +8,13 @@
 extern "C" {
 #endif
 
-double get_rettime() ;
-double get_gmttime() ;
-double get_mettime() ;
+double get_rettime(void) ;
+double get_gmttime(void) ;
+double get_mettime(void) ;
 
-GMTTIME * get_rettime_struct() ;
-GMTTIME * get_gmttime_struct() ;
-GMTTIME * get_mettime_struct() ;
+GMTTIME * get_rettime_struct(void) ;
+GMTTIME * get_gmttime_struct(void) ;
+GMTTIME * get_mettime_struct(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/trick_tests.h
+++ b/include/trick/trick_tests.h
@@ -81,7 +81,7 @@
 extern "C" {
 #endif
 
-int trick_test_enable() ;
+int trick_test_enable(void) ;
 
 int trick_test_set_file_name( const char * in_file_name ) ;
 
@@ -94,7 +94,7 @@ int trick_test_add_parent(const char * in_test_suite_name,
 int add_test_result( const char * in_test_suite_name ,
                      const char * in_test_case ,
                      const char * in_failure_string ) ;
-int call_write_output() ;
+int call_write_output(void) ;
 
 #ifdef __cplusplus
 }

--- a/include/trick/variable_server_proto.h
+++ b/include/trick/variable_server_proto.h
@@ -6,16 +6,16 @@
 extern "C" {
 #endif
 
-const char * var_server_get_hostname() ;
+const char * var_server_get_hostname(void) ;
 
-unsigned short var_server_get_port() ;
+unsigned short var_server_get_port(void) ;
 void var_server_set_port(unsigned short port) ;
 void var_server_set_source_address(const char * address) ;
 
-const char * var_server_get_user_tag() ;
+const char * var_server_get_user_tag(void) ;
 void var_server_set_user_tag(const char * tag) ;
 
-int var_server_get_enabled() ;
+int var_server_get_enabled(void) ;
 void var_server_set_enabled(int on_off) ;
 
 int var_server_create_tcp_socket(const char * address, unsigned short port) ;

--- a/include/trick/wcs_ext.h
+++ b/include/trick/wcs_ext.h
@@ -16,10 +16,10 @@ extern "C" {
 #endif
 
 #if __Lynx__
-int wcs_to_ncs_len ();
-int ncs_to_wcs_len ();
-int wcs_to_ncs ();
-int ncs_to_wcs();
+int wcs_to_ncs_len (void);
+int ncs_to_wcs_len (void);
+int wcs_to_ncs (void);
+int ncs_to_wcs(void);
 #else
 #include <stddef.h>
 #include <wchar.h>

--- a/trick_source/sim_services/Clock/clock_c_intf.cpp
+++ b/trick_source/sim_services/Clock/clock_c_intf.cpp
@@ -4,11 +4,11 @@
 
 extern Trick::Clock * the_clock ;
 
-extern "C" long long clock_time() {
+extern "C" long long clock_time(void) {
     return the_clock->clock_time() ;
 }
 
-extern "C" long long clock_wall_time() {
+extern "C" long long clock_wall_time(void) {
     return the_clock->wall_clock_time() ;
 }
 
@@ -24,7 +24,7 @@ extern "C" int clock_spin(long long ref) {
     return the_clock->clock_spin(ref) ;
 }
 
-extern "C" double clock_get_rt_clock_ratio() {
+extern "C" double clock_get_rt_clock_ratio(void) {
     return the_clock->get_rt_clock_ratio() ;
 }
 

--- a/trick_source/sim_services/CommandLineArguments/command_line_c_intf.cpp
+++ b/trick_source/sim_services/CommandLineArguments/command_line_c_intf.cpp
@@ -28,7 +28,7 @@ extern "C" int command_line_args_process_sim_args(int argc , char **argv) {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_argc()
  */
-extern "C" int command_line_args_get_argc() {
+extern "C" int command_line_args_get_argc(void) {
     return(the_cmd_args->get_argc()) ;
 }
 
@@ -36,7 +36,7 @@ extern "C" int command_line_args_get_argc() {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_argv()
  */
-extern "C" char ** command_line_args_get_argv() {
+extern "C" char ** command_line_args_get_argv(void) {
     return(the_cmd_args->get_argv()) ;
 }
 
@@ -45,7 +45,7 @@ const char * empty_string = "" ;
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_output_dir()
  */
-extern "C" const char * command_line_args_get_output_dir() {
+extern "C" const char * command_line_args_get_output_dir(void) {
     return(the_cmd_args->get_output_dir_ref().c_str()) ;
 }
 
@@ -54,7 +54,7 @@ extern "C" const char * command_line_args_get_output_dir() {
  @copydoc Trick::CommandLineArguments::get_user_output_dir()
  */
 
-extern "C" const char * command_line_args_get_user_output_dir() {
+extern "C" const char * command_line_args_get_user_output_dir(void) {
     return(the_cmd_args->get_user_output_dir_ref().c_str()) ;
 }
 
@@ -62,7 +62,7 @@ extern "C" const char * command_line_args_get_user_output_dir() {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_input_file()
  */
-extern "C" const char * command_line_args_get_input_file() {
+extern "C" const char * command_line_args_get_input_file(void) {
     return(the_cmd_args->get_input_file_ref().c_str()) ;
 }
 
@@ -70,7 +70,7 @@ extern "C" const char * command_line_args_get_input_file() {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_default_dir()
  */
-extern "C" const char * command_line_args_get_default_dir() {
+extern "C" const char * command_line_args_get_default_dir(void) {
     return(the_cmd_args->get_default_dir_ref().c_str()) ;
 }
 
@@ -78,7 +78,7 @@ extern "C" const char * command_line_args_get_default_dir() {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_cmdline_name()
  */
-extern "C" const char * command_line_args_get_cmdline_name() {
+extern "C" const char * command_line_args_get_cmdline_name(void) {
     return(the_cmd_args->get_cmdline_name_ref().c_str()) ;
 }
 
@@ -86,7 +86,7 @@ extern "C" const char * command_line_args_get_cmdline_name() {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::output_dir_timestamped_on()
  */
-extern "C" int output_dir_timestamped_on() {
+extern "C" int output_dir_timestamped_on(void) {
     return(the_cmd_args->output_dir_timestamped_on()) ;
 }
 
@@ -94,7 +94,7 @@ extern "C" int output_dir_timestamped_on() {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::output_dir_timestamped_off()
  */
-extern "C" int output_dir_timestamped_off() {
+extern "C" int output_dir_timestamped_off(void) {
     return(the_cmd_args->output_dir_timestamped_off()) ;
 }
 
@@ -110,7 +110,7 @@ extern "C" void set_output_dir(const char* output_directory) {
  @relates Trick::CommandLineArguments
  @copydoc Trick::CommandLineArguments::get_input_file_ref()
  */
-std::string & command_line_args_get_input_file_ref() {
+std::string & command_line_args_get_input_file_ref(void) {
     return(the_cmd_args->get_input_file_ref()) ;
 }
 

--- a/trick_source/sim_services/DataRecord/data_record_utilities.cpp
+++ b/trick_source/sim_services/DataRecord/data_record_utilities.cpp
@@ -12,14 +12,14 @@ PROGRAMMERS:
 
 extern Trick::DataRecordDispatcher * the_drd  ;
 
-extern "C" int dr_remove_files() {
+extern "C" int dr_remove_files(void) {
     if ( the_drd != NULL ) {
         return the_drd->remove_files() ;
     }
     return -1 ;
 }
 
-extern "C" int dr_enable() {
+extern "C" int dr_enable(void) {
     if ( the_drd != NULL ) {
         return the_drd->enable() ;
     }
@@ -33,7 +33,7 @@ extern "C" int dr_enable_group( const char * in_name ) {
     return -1 ;
 }
 
-extern "C" int dr_disable() {
+extern "C" int dr_disable(void) {
     if ( the_drd != NULL ) {
         return the_drd->disable() ;
     }
@@ -68,7 +68,7 @@ extern "C" int remove_data_record_group( Trick::DataRecordGroup * in_group ) {
     return -1 ;
 }
 
-extern "C" void remove_all_data_record_groups() {
+extern "C" void remove_all_data_record_groups(void) {
     the_drd->remove_all_groups() ;
 }
 

--- a/trick_source/sim_services/DebugPause/DebugPause_c_intf.cpp
+++ b/trick_source/sim_services/DebugPause/DebugPause_c_intf.cpp
@@ -13,7 +13,7 @@ extern Trick::DebugPause * the_debug_pause ;
  * @copydoc Trick::DebugPause::debug_pause_on
  * C wrapper for Trick::DebugPause::debug_pause_on
  */
-extern "C" int debug_pause_on() {
+extern "C" int debug_pause_on(void) {
     if (the_debug_pause != NULL) {
         return the_debug_pause->debug_pause_on() ;
     }
@@ -25,14 +25,14 @@ extern "C" int debug_pause_on() {
  * @copydoc Trick::DebugPause::debug_pause_off
  * C wrapper for Trick::DebugPause::debug_pause_off
  */
-extern "C" int debug_pause_off() {
+extern "C" int debug_pause_off(void) {
     if (the_debug_pause != NULL) {
         return the_debug_pause->debug_pause_off() ;
     }
     return(0) ;
 }
 
-extern "C" int debug_signal() {
+extern "C" int debug_signal(void) {
     if (the_debug_pause != NULL) {
         return the_debug_pause->debug_signal() ;
     }

--- a/trick_source/sim_services/EchoJobs/EchoJobs_c_intf.cpp
+++ b/trick_source/sim_services/EchoJobs/EchoJobs_c_intf.cpp
@@ -13,7 +13,7 @@ extern Trick::EchoJobs * the_ej ;
  * @copydoc Trick::EchoJobs::echojobs_on
  * C wrapper for Trick::EchoJobs::echojobs_on
  */
-extern "C" int echo_jobs_on() {
+extern "C" int echo_jobs_on(void) {
     if (the_ej != NULL) {
         return the_ej->echojobs_on() ;
     }
@@ -25,7 +25,7 @@ extern "C" int echo_jobs_on() {
  * @copydoc Trick::EchoJobs::echojobs_off
  * C wrapper for Trick::EchoJobs::echojobs_off
  */
-extern "C" int echo_jobs_off() {
+extern "C" int echo_jobs_off(void) {
     if (the_ej != NULL) {
         return the_ej->echojobs_off() ;
     }

--- a/trick_source/sim_services/ExternalApplications/ExternalApplication_c_intf.cpp
+++ b/trick_source/sim_services/ExternalApplications/ExternalApplication_c_intf.cpp
@@ -106,27 +106,27 @@ extern "C" void stripchart_set_enabled(int enabled) {
     }
 }
 
-extern "C" int sim_control_panel_get_enabled() {
+extern "C" int sim_control_panel_get_enabled(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
     return getFirstInstanceOfType(typeid(Trick::SimControlPanel)) != NULL;
 }
 
-extern "C" int trick_view_get_enabled() {
+extern "C" int trick_view_get_enabled(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
     return getFirstInstanceOfType(typeid(Trick::TrickView)) != NULL;
 }
 
-extern "C" int malfunctions_trick_view_get_enabled() {
+extern "C" int malfunctions_trick_view_get_enabled(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
     return getFirstInstanceOfType(typeid(Trick::MalfunctionsTrickView)) != NULL;
 }
 
-extern "C" int monte_monitor_get_enabled() {
+extern "C" int monte_monitor_get_enabled(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
     return getFirstInstanceOfType(typeid(Trick::MonteMonitor)) != NULL;
 }
 
-extern "C" int stripchart_get_enabled() {
+extern "C" int stripchart_get_enabled(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
     return getFirstInstanceOfType(typeid(Trick::StripChart)) != NULL;
 }
@@ -196,7 +196,7 @@ extern "C" void stripchart_set_startup_command(const char *startup_command) {
     externalApplication->set_startup_command(startup_command ? std::string(startup_command) : "");
 }
 
-extern "C" const char *sim_control_panel_get_startup_command() {
+extern "C" const char *sim_control_panel_get_startup_command(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::SimControlPanel *externalApplication = (Trick::SimControlPanel *)getFirstInstanceOfType(typeid(Trick::SimControlPanel));
@@ -209,7 +209,7 @@ extern "C" const char *sim_control_panel_get_startup_command() {
     return externalApplication->get_startup_command().c_str();
 }
 
-extern "C" const char *trick_view_get_startup_command() {
+extern "C" const char *trick_view_get_startup_command(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::TrickView *externalApplication = (Trick::TrickView *)getFirstInstanceOfType(typeid(Trick::TrickView));
@@ -222,7 +222,7 @@ extern "C" const char *trick_view_get_startup_command() {
     return externalApplication->get_startup_command().c_str();
 }
 
-extern "C" const char *malfunctions_trick_view_get_startup_command() {
+extern "C" const char *malfunctions_trick_view_get_startup_command(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::MalfunctionsTrickView *externalApplication = (Trick::MalfunctionsTrickView *)getFirstInstanceOfType(typeid(Trick::MalfunctionsTrickView));
@@ -235,7 +235,7 @@ extern "C" const char *malfunctions_trick_view_get_startup_command() {
     return externalApplication->get_startup_command().c_str();
 }
 
-extern "C" const char *monte_monitor_get_startup_command() {
+extern "C" const char *monte_monitor_get_startup_command(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::MonteMonitor *externalApplication = (Trick::MonteMonitor *)getFirstInstanceOfType(typeid(Trick::MonteMonitor));
@@ -248,7 +248,7 @@ extern "C" const char *monte_monitor_get_startup_command() {
     return externalApplication->get_startup_command().c_str();
 }
 
-extern "C" const char *stripchart_get_startup_command() {
+extern "C" const char *stripchart_get_startup_command(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::StripChart *externalApplication = (Trick::StripChart *)getFirstInstanceOfType(typeid(Trick::StripChart));
@@ -261,7 +261,7 @@ extern "C" const char *stripchart_get_startup_command() {
     return externalApplication->get_startup_command().c_str();
 }
 
-extern "C" void sim_control_panel_launch() {
+extern "C" void sim_control_panel_launch(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::SimControlPanel *externalApplication = (Trick::SimControlPanel *)getFirstInstanceOfType(typeid(Trick::SimControlPanel));
@@ -271,7 +271,7 @@ extern "C" void sim_control_panel_launch() {
     }
 }
 
-extern "C" void trick_view_launch() {
+extern "C" void trick_view_launch(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::TrickView *externalApplication = (Trick::TrickView *)getFirstInstanceOfType(typeid(Trick::TrickView));
@@ -281,7 +281,7 @@ extern "C" void trick_view_launch() {
     }
 }
 
-extern "C" void malfunctions_trick_view_launch() {
+extern "C" void malfunctions_trick_view_launch(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::MalfunctionsTrickView *externalApplication = (Trick::MalfunctionsTrickView *)getFirstInstanceOfType(typeid(Trick::MalfunctionsTrickView));
@@ -291,7 +291,7 @@ extern "C" void malfunctions_trick_view_launch() {
     }
 }
 
-extern "C" void monte_monitor_launch() {
+extern "C" void monte_monitor_launch(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::MonteMonitor *externalApplication = (Trick::MonteMonitor *)getFirstInstanceOfType(typeid(Trick::MonteMonitor));
@@ -301,7 +301,7 @@ extern "C" void monte_monitor_launch() {
     }
 }
 
-extern "C" void stripchart_launch() {
+extern "C" void stripchart_launch(void) {
     //printDeprecationMessage(__FILE__, __LINE__, __FUNCTION__);
 
     Trick::StripChart *externalApplication = (Trick::StripChart *)getFirstInstanceOfType(typeid(Trick::StripChart));

--- a/trick_source/sim_services/FrameLog/FrameLog_c_intf.cpp
+++ b/trick_source/sim_services/FrameLog/FrameLog_c_intf.cpp
@@ -13,7 +13,7 @@ extern Trick::FrameLog * the_fl ;
  * @copydoc Trick::FrameLog::framelog_on
  * C wrapper for Trick::FrameLog::framelog_on
  */
-extern "C" int frame_log_on() {
+extern "C" int frame_log_on(void) {
     if (the_fl != NULL) {
         return the_fl->framelog_on() ;
     }
@@ -25,7 +25,7 @@ extern "C" int frame_log_on() {
  * @copydoc Trick::FrameLog::framelog_off
  * C wrapper for Trick::FrameLog::framelog_off
  */
-extern "C" int frame_log_off() {
+extern "C" int frame_log_off(void) {
     if (the_fl != NULL) {
         return the_fl->framelog_off() ;
     }

--- a/trick_source/sim_services/MasterSlave/Master.cpp
+++ b/trick_source/sim_services/MasterSlave/Master.cpp
@@ -640,7 +640,7 @@ int Trick::SlaveInfo::restart_dmtcp_slave() {
  * C binded function to toggle the master/slave synchronization flag to on.
  * @return always 0
  */
-extern "C" int ms_master_enable() {
+extern "C" int ms_master_enable(void) {
     the_ms_master->enable() ;
     return(0) ;
 }
@@ -650,7 +650,7 @@ extern "C" int ms_master_enable() {
  * C binded function to toggle the master/slave synchronization flag to off.
  * @return always 0
  */
-extern "C" int ms_master_disable() {
+extern "C" int ms_master_disable(void) {
     the_ms_master->disable() ;
     return(0) ;
 }

--- a/trick_source/sim_services/MemoryManager/wcs_ext.c
+++ b/trick_source/sim_services/MemoryManager/wcs_ext.c
@@ -272,22 +272,22 @@ size_t ncs_to_wcs(const char *ncs, wchar_t * wcs, size_t w_max_size)
     }
 }
 #else
-int wcs_to_ncs_len()
+int wcs_to_ncs_len(void)
 {
     return (0);
 }
 
-int ncs_to_wcs_len()
+int ncs_to_wcs_len(void)
 {
     return (0);
 }
 
-int wcs_to_ncs()
+int wcs_to_ncs(void)
 {
     return (0);
 }
 
-int ncs_to_wcs()
+int ncs_to_wcs(void)
 {
     return (0);
 }

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_c_intf.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_c_intf.cpp
@@ -12,7 +12,7 @@ extern "C" void mc_set_enabled(int enabled) {
     }
 }
 
-extern "C" int mc_get_enabled() {
+extern "C" int mc_get_enabled(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_enabled();
     }
@@ -25,14 +25,14 @@ extern "C" void mc_set_dry_run(int dry_run) {
     }
 }
 
-extern "C" int mc_get_dry_run() {
+extern "C" int mc_get_dry_run(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_dry_run();
     }
     return 0 ;
 }
 
-extern "C" int mc_is_slave() {
+extern "C" int mc_is_slave(void) {
     if ( the_mc != NULL ) {
         return the_mc->is_slave();
     }
@@ -45,7 +45,7 @@ extern "C" void mc_set_localhost_as_remote(int localhost_as_remote) {
     }
 }
 
-extern "C" int mc_get_localhost_as_remote() {
+extern "C" int mc_get_localhost_as_remote(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_localhost_as_remote();
     }
@@ -58,7 +58,7 @@ extern "C" void mc_set_custom_slave_dispatch(int custom_slave_dispatch) {
     }
 }
 
-extern "C" int mc_get_custom_slave_dispatch() {
+extern "C" int mc_get_custom_slave_dispatch(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_custom_slave_dispatch();
     }
@@ -71,7 +71,7 @@ extern "C" void mc_set_timeout(double timeout) {
     }
 }
 
-extern "C" double mc_get_timeout() {
+extern "C" double mc_get_timeout(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_timeout();
     }
@@ -84,7 +84,7 @@ extern "C" void mc_set_max_tries(unsigned int max_tries) {
     }
 }
 
-extern "C" unsigned int mc_get_max_tries() {
+extern "C" unsigned int mc_get_max_tries(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_max_tries();
     }
@@ -97,7 +97,7 @@ extern "C" void mc_set_user_cmd_string(const char *user_cmd_string) {
     }
 }
 
-extern "C" const char *mc_get_user_cmd_string() {
+extern "C" const char *mc_get_user_cmd_string(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_user_cmd_string().c_str();
     }
@@ -110,7 +110,7 @@ extern "C" void mc_set_slave_sim_options(const char *slave_sim_options) {
     }
 }
 
-extern "C" const char *mc_get_slave_sim_options() {
+extern "C" const char *mc_get_slave_sim_options(void) {
     if ( the_mc != NULL ) {
         return the_mc->slave_sim_options.c_str();
     }
@@ -123,7 +123,7 @@ extern "C" void mc_set_custom_pre_text(const char *custom_pre_text) {
     }
 }
 
-extern "C" const char *mc_get_custom_pre_text() {
+extern "C" const char *mc_get_custom_pre_text(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_custom_pre_text().c_str();
     }
@@ -136,7 +136,7 @@ extern "C" void mc_set_custom_post_text(const char *custom_post_text) {
     }
 }
 
-extern "C" const char *mc_get_custom_post_text() {
+extern "C" const char *mc_get_custom_post_text(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_custom_post_text().c_str();
     }
@@ -149,7 +149,7 @@ extern "C" void mc_set_verbosity(int verbosity) {
     }
 }
 
-extern "C" int mc_get_verbosity() {
+extern "C" int mc_get_verbosity(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_verbosity();
     }
@@ -162,21 +162,21 @@ extern "C" void mc_set_num_runs(unsigned int num_runs) {
     }
 }
 
-extern "C" unsigned int mc_get_num_runs() {
+extern "C" unsigned int mc_get_num_runs(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_num_runs();
     }
     return 0 ;
 }
 
-extern "C" unsigned int mc_get_num_results() {
+extern "C" unsigned int mc_get_num_results(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_num_results();
     }
     return 0 ;
 }
 
-extern "C" unsigned int mc_get_slave_id() {
+extern "C" unsigned int mc_get_slave_id(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_slave_id();
     }
@@ -219,7 +219,7 @@ extern "C" void mc_read(char *buffer, int size) {
     }
 }
 
-extern "C" unsigned int mc_get_current_run() {
+extern "C" unsigned int mc_get_current_run(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_current_run();
     }
@@ -244,14 +244,14 @@ extern "C" void mc_set_connection_device_port(int port_number) {
     }
 }
 
-extern "C" int mc_get_listen_device_port() {
+extern "C" int mc_get_listen_device_port(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_listen_device_port();
     }
     return -1 ;
 }
 
-extern "C" int mc_get_connection_device_port() {
+extern "C" int mc_get_connection_device_port(void) {
     if ( the_mc != NULL ) {
         return the_mc->get_connection_device_port();
     }

--- a/trick_source/sim_services/Sie/sie_c_intf.cpp
+++ b/trick_source/sim_services/Sie/sie_c_intf.cpp
@@ -4,25 +4,25 @@
 
 extern Trick::Sie * the_sie ;
 
-extern "C" void sie_print_xml() {
+extern "C" void sie_print_xml(void) {
     if ( the_sie != NULL ) {
         the_sie->sie_print_xml() ;
     }
 }
 
-extern "C" void sie_class_attr_map_print_xml() {
+extern "C" void sie_class_attr_map_print_xml(void) {
     if ( the_sie != NULL ) {
         the_sie->class_attr_map_print_xml() ;
     }
 }
 
-extern "C" void sie_enum_attr_map_print_xml() {
+extern "C" void sie_enum_attr_map_print_xml(void) {
     if ( the_sie != NULL ) {
         the_sie->enum_attr_map_print_xml() ;
     }
 }
 
-extern "C" void sie_top_level_objects_print_xml() {
+extern "C" void sie_top_level_objects_print_xml(void) {
     if ( the_sie != NULL ) {
         the_sie->top_level_objects_print_xml() ;
     }

--- a/trick_source/sim_services/SimTime/SimTime_c_intf.cpp
+++ b/trick_source/sim_services/SimTime/SimTime_c_intf.cpp
@@ -4,27 +4,27 @@
 
 extern Trick::SimTime * the_simtime ;
 
-extern "C" double get_rettime() {
+extern "C" double get_rettime(void) {
     return (the_simtime->get_rettime()) ;
 }
 
-extern "C" double get_gmttime() {
+extern "C" double get_gmttime(void) {
     return (the_simtime->get_gmttime()) ;
 }
 
-extern "C" double get_mettime() {
+extern "C" double get_mettime(void) {
     return (the_simtime->get_mettime()) ;
 }
 
-extern "C" GMTTIME * get_rettime_struct() {
+extern "C" GMTTIME * get_rettime_struct(void) {
     return (the_simtime->get_rettime_struct()) ;
 }
 
-extern "C" GMTTIME * get_gmttime_struct() {
+extern "C" GMTTIME * get_gmttime_struct(void) {
     return (the_simtime->get_gmttime_struct()) ;
 }
 
-extern "C" GMTTIME * get_mettime_struct() {
+extern "C" GMTTIME * get_mettime_struct(void) {
     return (the_simtime->get_mettime_struct()) ;
 }
 

--- a/trick_source/sim_services/UnitTest/UnitTest_c_intf.cpp
+++ b/trick_source/sim_services/UnitTest/UnitTest_c_intf.cpp
@@ -6,7 +6,7 @@
 
 extern Trick::UnitTest * the_unit_test_output ;
 
-extern "C" int trick_test_enable() {
+extern "C" int trick_test_enable(void) {
     the_unit_test_output->enable() ;
     return(0) ;
 }
@@ -36,7 +36,7 @@ extern "C" int trick_test_add_parent(const char * in_test_suite_name, const char
 }
 
 
-extern "C" int call_write_output() {
+extern "C" int call_write_output(void) {
     the_unit_test_output->write_output() ;
     return(0) ;
 }

--- a/trick_source/sim_services/VariableServer/var_server_ext.cpp
+++ b/trick_source/sim_services/VariableServer/var_server_ext.cpp
@@ -392,7 +392,7 @@ Trick::VariableServer * var_server_get_var_server() {
  * @copydoc Trick::VariableServer::get_hostname
  * C wrapper Trick::VariableServer::get_hostname
  */
-extern "C" const char * var_server_get_hostname() {
+extern "C" const char * var_server_get_hostname(void) {
     return(the_vs->get_hostname()) ;
 }
 
@@ -401,7 +401,7 @@ extern "C" const char * var_server_get_hostname() {
  * @copydoc Trick::VariableServer::get_port
  * C wrapper Trick::VariableServer::get_port
  */
-extern "C" unsigned short var_server_get_port() {
+extern "C" unsigned short var_server_get_port(void) {
     return(the_vs->get_listen_thread().get_port()) ;
 }
 
@@ -428,7 +428,7 @@ extern "C" void var_server_set_source_address(const char * source_address) {
  * @copydoc Trick::VariableServer::get_user_tag
  * C wrapper Trick::VariableServer::get_user_tag
  */
-extern "C" const char * var_server_get_user_tag() {
+extern "C" const char * var_server_get_user_tag(void) {
     return(the_vs->get_listen_thread().get_user_tag().c_str()) ;
 }
 
@@ -446,7 +446,7 @@ extern "C" void var_server_set_user_tag(const char * in_tag) {
  * @copydoc Trick::VariableServer::get_enabled
  * C wrapper Trick::VariableServer::get_enabled
  */
-extern "C" int var_server_get_enabled() {
+extern "C" int var_server_get_enabled(void) {
     return(the_vs->get_enabled()) ;
 }
 


### PR DESCRIPTION
In prototypes and definitions. This doesn't apply to C++.

Apparently some compilers emit warning messages in args are not explicitly specified as void.