### PR TITLE
702 Adding MonteVarExecCode

### DIFF
--- a/include/trick/MonteCarlo.hh
+++ b/include/trick/MonteCarlo.hh
@@ -16,7 +16,7 @@
 
 #ifdef SWIG
 // This instructs SWIG to use dynamic_cast and return one of the derived type for the get_variable function.
-%factory(Trick::MonteVar * Trick::MonteCarlo::get_variable, Trick::MonteVarCalculated, Trick::MonteVarFile, Trick::MonteVarFixed, Trick::MonteVarRandom) ;
+%factory(Trick::MonteVar * Trick::MonteCarlo::get_variable, Trick::MonteVarCalculated, Trick::MonteVarFile, Trick::MonteVarFixed, Trick::MonteVarRandom, Trick::MonteVarExecCode) ;
 #endif
 
 namespace Trick {

--- a/include/trick/MonteVarExecCode.hh
+++ b/include/trick/MonteVarExecCode.hh
@@ -1,0 +1,71 @@
+/*
+  PURPOSE: (Monte carlo structures to inject executable logic based on MC
+            dispersions)
+  ASSUMPTIONS AND LIMITATIONS:
+    (The order in which this type of MonteVar gets added to trick_mc.mc is
+     significant.  The purpose of adding code-injection points is to act upon
+     the values of dispersed variables; those variables must therefore have
+     been dispersed BEFORE this code is executed.  This MonteVar instance must
+     be added AFTER any variables used by the code.)
+  PROGRAMMERS:                 ((Gary Turner) (OSR) (11/2018))
+*/
+
+/*
+ * $Id: MonteVarExecCode.hh $
+ */
+
+#ifndef _MONTEVAREXECCODE_HH_
+#define _MONTEVAREXECCODE_HH_
+
+#include <string>
+
+#include "MonteVar.hh"
+
+#ifdef SWIG
+%feature("compactdefaultargs","0") ;
+%feature("shadow") Trick::MonteVarExecCode::MonteVarExecCode(std::string name) %{
+    def __init__(self, *args):
+        this = $action(*args)
+        try: self.this.append(this)
+        except: self.this = this
+        this.own(0)
+        self.this.own(0)
+%}
+#endif
+
+
+namespace Trick {
+
+    /**
+     * A variable whose value specifies a Python filename to be executed
+     * IMPORTANT NOTE:
+     * The order in which this type of MonteVar gets added to trick_mc.mc is
+     * significant.  The purpose of adding code-injection points is to act upon
+     * the values of dispersed variables; those variables must therefore have
+     * been dispersed BEFORE this code is executed.  This MonteVar instance must
+     * be added AFTER any variables used by the code.
+     *
+     * @author Gary Turner
+     *
+     * @date November 2018
+     */
+    class MonteVarExecCode : public Trick::MonteVar {
+
+        public:
+        /**
+         * Constructs a MonteVarExecCode with the specified filename
+         *
+         * @param name the address of the Python file relative to the execution directory
+         */
+        MonteVarExecCode(std::string name);
+
+        // Composite the various elements of this MonteVar.
+        virtual std::string describe_variable();
+
+        protected:
+        virtual std::string get_next_value();
+
+    };
+
+};
+#endif

--- a/trick_source/sim_services/MonteCarlo/Makefile_deps
+++ b/trick_source/sim_services/MonteCarlo/Makefile_deps
@@ -138,6 +138,9 @@ object_${TRICK_HOST_CPU}/MonteCarlo_execute_monte.o: MonteCarlo_execute_monte.cp
 object_${TRICK_HOST_CPU}/MonteVarFixed.o: MonteVarFixed.cpp \
  ${TRICK_HOME}/include/trick/MonteVarFixed.hh \
  ${TRICK_HOME}/include/trick/MonteVar.hh 
+object_${TRICK_HOST_CPU}/MonteVarExecCode.o: MonteVarExecCode.cpp \
+ ${TRICK_HOME}/include/trick/MonteVarExecCode.hh \
+ ${TRICK_HOME}/include/trick/MonteVar.hh 
 object_${TRICK_HOST_CPU}/MonteVarRandom.o: MonteVarRandom.cpp \
  ${TRICK_HOME}/include/trick/MonteVarRandom.hh \
  ${TRICK_HOME}/include/trick/MonteVar.hh \

--- a/trick_source/sim_services/MonteCarlo/MonteVarExecCode.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteVarExecCode.cpp
@@ -1,0 +1,29 @@
+/*
+ * $Id: MonteVarExecCode.cpp $
+ */
+#include <sstream>
+#include <iomanip>
+
+#include "trick/MonteVarExecCode.hh"
+
+Trick::MonteVarExecCode::MonteVarExecCode(std::string in_name) {
+    this->name = in_name;
+}
+
+std::string Trick::MonteVarExecCode::describe_variable()
+{
+    std::stringstream ss;
+
+    ss << "#NAME:\t\t" << this->name << "\n"
+       << "#TYPE:\t\tExecCode\n" 
+       << "#UNIT:\t\tNone" << "\n"
+       << "#VALUE:\t\tNone" << "\n";
+
+    return ss.str();
+}
+
+std::string Trick::MonteVarExecCode::get_next_value() {
+    std::ostringstream string_stream;
+    string_stream << "execfile('" << name << "')";
+    return string_stream.str();
+}

--- a/trick_source/trick_swig/sim_services.i
+++ b/trick_source/trick_swig/sim_services.i
@@ -127,6 +127,7 @@
 #include "trick/MonteCarlo.hh"
 #include "trick/montecarlo_c_intf.h"
 #include "trick/MonteVarCalculated.hh"
+#include "trick/MonteVarExecCode.hh"
 #include "trick/MonteVarFile.hh"
 #include "trick/MonteVarFixed.hh"
 #include "trick/MonteVarRandom.hh"


### PR DESCRIPTION
Adds a MonteVar* type that provides a code-injection point into the dispersion processing.