### PR TITLE
Vector Optimize to Save on Re-Allocation costs.

### DIFF
--- a/trick_source/data_products/Log/multiLog.cpp
+++ b/trick_source/data_products/Log/multiLog.cpp
@@ -124,6 +124,8 @@ IterOverLogGroups::IterOverLogGroups( LogMultiGroup* lmg,
         LogGroup* key ;
         vector < int > val ;
         map < LogGroup*, set< int > >::const_iterator ll;
+        listLogGroupIterators_.reserve(listLogGroupIterators_.size()
+                                       + lg2log.size());
         for (ll = lg2log.begin(); ll != lg2log.end(); ll++) {
 
                 key = (*ll).first ;

--- a/trick_source/sim_services/DataTypes/src/MemMgr.cpp
+++ b/trick_source/sim_services/DataTypes/src/MemMgr.cpp
@@ -11,16 +11,14 @@
 MemMgr::MemMgr() {
 
    debugLevel = 0;
-   reducedCheckpoint  = true;
+   reducedCheckpoint = true;
    hexfloatCheckpoint = false;
    compactArraysCheckpoint = true;
-
    defaultCheckPointAgent = new ClassicChkPtAgent( std::cout );
    defaultCheckPointAgent->setDebugLevel( debugLevel);
    defaultCheckPointAgent->setReducedCheckpoint( reducedCheckpoint);
    defaultCheckPointAgent->setHexfloatCheckpoint( hexfloatCheckpoint);
    defaultCheckPointAgent->setMakeCompactArrays( compactArraysCheckpoint );
-
    currentCheckPointAgent = defaultCheckPointAgent;
 
    typeDictionary = new TypeDictionary();

--- a/trick_source/sim_services/DataTypes/src/MemMgr.cpp
+++ b/trick_source/sim_services/DataTypes/src/MemMgr.cpp
@@ -14,11 +14,13 @@ MemMgr::MemMgr() {
    reducedCheckpoint = true;
    hexfloatCheckpoint = false;
    compactArraysCheckpoint = true;
+   
    defaultCheckPointAgent = new ClassicChkPtAgent( std::cout );
    defaultCheckPointAgent->setDebugLevel( debugLevel);
    defaultCheckPointAgent->setReducedCheckpoint( reducedCheckpoint);
    defaultCheckPointAgent->setHexfloatCheckpoint( hexfloatCheckpoint);
    defaultCheckPointAgent->setMakeCompactArrays( compactArraysCheckpoint );
+   
    currentCheckPointAgent = defaultCheckPointAgent;
 
    typeDictionary = new TypeDictionary();


### PR DESCRIPTION
We know how many more elements we are going to push into ```listLogGroupIterators_``` so use that to our advantange and reserve inadvance to save on re-allocation costs.