### PR TITLE
Disable setting TCP_NODELAY on UDP sockets

### DIFF
--- a/trick_source/trick_utils/comm/src/tc_init_udp_client.c
+++ b/trick_source/trick_utils/comm/src/tc_init_udp_client.c
@@ -29,7 +29,6 @@ int tc_init_udp_client(TCDevice * udp_client_device)
 
     int debug = 1;
 
-    int on = 1;
     struct hostent *h;
     int the_socket;
     struct sockaddr_in sockin;
@@ -59,10 +58,6 @@ int tc_init_udp_client(TCDevice * udp_client_device)
 
         return (TC_COULD_NOT_OPEN_SOCKET);
     }
-
-    /* Turn off data buffering. This causes data to be sent immediately rather than queuing it up until the transmit
-       buffer is filled. */
-    setsockopt(the_socket, IPPROTO_TCP, TCP_NODELAY, (const char *) &on, (socklen_t) sizeof(on));
 
     sockin.sin_family = TRICKCOMM_SOCKET_FAMILY;
     sockin.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/trick_source/trick_utils/comm/src/tc_init_udp_server.c
+++ b/trick_source/trick_utils/comm/src/tc_init_udp_server.c
@@ -59,12 +59,6 @@ int tc_init_udp_server(         /* RETURN: -- 0 for success */
         return (-1);
     }
 
-
-    /* Turn off data buffering. This causes data to be written immediately to the receiving socket rather than queing
-       it up until the transmit buffer is filled. */
-    setsockopt(udp_server_device->socket, IPPROTO_TCP, TCP_NODELAY, (const char *) &yes, (socklen_t) sizeof(yes));
-
-
     sockin.sin_addr.s_addr = INADDR_ANY;
     sockin.sin_family = TRICKCOMM_SOCKET_FAMILY;
     sockin.sin_port = htons((short) (udp_server_device->port));


### PR DESCRIPTION
The TCP_NODELAY socket option disables Nagle's algorithm on TCP sockets,
improving latency at the cost of throughput. This option is
TCP-specific, and it is an error to use it on any other kind of socket,
including UDP. It is also unnecessary, since UDP is datagram-based and
does not buffer data to be transmitted.

See #728 