### PR TITLE
Add capability to list current variable server connections in JSON re…

### DIFF
--- a/include/trick/VariableServer.hh
+++ b/include/trick/VariableServer.hh
@@ -10,6 +10,7 @@
 #include <queue>
 #include <vector>
 #include <string>
+#include <iostream>
 #include <pthread.h>
 #include "trick/tc.h"
 #include "trick/reference.h"
@@ -38,6 +39,11 @@ namespace Trick {
              @brief Destructor.
             */
             ~VariableServer() ;
+
+            /**
+             @brief Write a JSON encoded list of Variable Server Connections to the given stream.
+            */
+            friend std::ostream& operator<< (std::ostream& s, Trick::VariableServer& vs);
 
             /**
              @brief Set up the listen port during default_data so it is available at the start of initialization.

--- a/include/trick/VariableServerReference.hh
+++ b/include/trick/VariableServerReference.hh
@@ -6,6 +6,7 @@
 #ifndef VARIABLESERVERREFERENCE_HH
 #define VARIABLESERVERREFERENCE_HH
 
+#include <iostream>
 #include "trick/reference.h"
 
 union cv_converter ;
@@ -23,6 +24,8 @@ namespace Trick {
         public:
             VariableReference(REF2 * in_ref) ;
             ~VariableReference() ;
+
+            friend std::ostream& operator<< (std::ostream& s, const Trick::VariableReference& vref);
 
             /** Pointer to trick variable reference structure.\n */
             REF2 * ref ;

--- a/include/trick/VariableServerThread.hh
+++ b/include/trick/VariableServerThread.hh
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <string>
+#include <iostream>
 #include <pthread.h>
 #include "trick/tc.h"
 #include "trick/ThreadBase.hh"
@@ -26,6 +27,8 @@ namespace Trick {
 
         public:
             enum ConnectionType { TCP, UDP, MCAST } ;
+
+            friend std::ostream& operator<< (std::ostream& s, Trick::VariableServerThread& vst);
 
             /**
              @brief Constructor.

--- a/include/trick/variable_server_proto.h
+++ b/include/trick/variable_server_proto.h
@@ -6,6 +6,7 @@
 extern "C" {
 #endif
 
+void var_server_list_connections(void);
 const char * var_server_get_hostname(void) ;
 
 unsigned short var_server_get_port(void) ;

--- a/trick_source/sim_services/VariableServer/VariableReference.cpp
+++ b/trick_source/sim_services/VariableServer/VariableReference.cpp
@@ -63,6 +63,16 @@ Trick::VariableReference::VariableReference(REF2 * in_ref ) {
 
 }
 
+std::ostream& Trick::operator<< (std::ostream& s, const Trick::VariableReference& vref) {
+
+    if (vref.ref->reference != NULL) {
+        s << "      \"" << vref.ref->reference << "\"";
+    } else {
+        s<< "      null";
+    }
+    return s;
+}
+
 Trick::VariableReference::~VariableReference() {
     free(ref) ;
     free(buffer_in) ;

--- a/trick_source/sim_services/VariableServer/VariableServer.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServer.cpp
@@ -1,5 +1,6 @@
 
 #include <netdb.h>
+#include <iostream>
 #include "trick/VariableServer.hh"
 #include "trick/tc_proto.h"
 
@@ -15,6 +16,26 @@ Trick::VariableServer::VariableServer() :
 }
 
 Trick::VariableServer::~VariableServer() {
+}
+
+std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServer& vs) {
+    std::map < pthread_t , VariableServerThread * >::iterator it ;
+
+    std::cout << "{\"variable_server_connections\":[" << std::endl;
+    int count = 0;
+    int n_connections = (int)vs.var_server_threads.size();
+    for ( it = vs.var_server_threads.begin() ; it != vs.var_server_threads.end() ; it++ ) {
+        s << "{" << std::endl;
+        s << *(*it).second;
+        s << "}";
+        if ((n_connections-count)>1) {
+            std::cout << "," ;
+        }
+        s << std::endl;
+        count ++;
+    }
+    s << "]}" << std::endl;
+    return s;
 }
 
 bool Trick::VariableServer::get_enabled() {

--- a/trick_source/sim_services/VariableServer/VariableServer.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServer.cpp
@@ -21,7 +21,7 @@ Trick::VariableServer::~VariableServer() {
 std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServer& vs) {
     std::map < pthread_t , VariableServerThread * >::iterator it ;
 
-    std::cout << "{\"variable_server_connections\":[" << std::endl;
+    std::cout << "{\"variable-server-connections\":[" << std::endl;
     int count = 0;
     int n_connections = (int)vs.var_server_threads.size();
     for ( it = vs.var_server_threads.begin() ; it != vs.var_server_threads.end() ; it++ ) {

--- a/trick_source/sim_services/VariableServer/VariableServerThread.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerThread.cpp
@@ -1,4 +1,5 @@
 
+#include <iostream>
 #include <stdlib.h>
 #include "trick/VariableServerThread.hh"
 #include "trick/exec_proto.h"
@@ -61,6 +62,35 @@ Trick::VariableServerThread::VariableServerThread(TCDevice * in_listen_dev) :
 Trick::VariableServerThread::~VariableServerThread() {
     free( incoming_msg ) ;
     free( stripped_msg ) ;
+}
+
+
+std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServerThread& vst) {
+
+    std::vector <Trick::VariableReference *>::iterator it;
+
+    s << "  \"connection\":{" << std::endl;
+    if (vst.binary_data) {
+        s << "    \"format\":\"BINARY\",";
+    } else {
+        s << "    \"format\":\"ASCII\",";
+    }
+    s << std::endl;
+    s << "    \"updaterate\":" << vst.update_rate << "," << std::endl;
+
+    s << "    \"variables\":[" << std::endl;
+
+    int n_vars = (int)vst.vars.size();
+    for (int i=0 ; i<n_vars ; i++) {
+        s << *(vst.vars[i]);
+        if ((n_vars-i)>1) {
+            s << "," ;
+        }
+        s << std::endl;
+    }
+    s << "    ]" << std::endl;
+    s << "  }" << std::endl;
+    return s;
 }
 
 void Trick::VariableServerThread::set_vs_ptr(Trick::VariableServer * in_vs) {

--- a/trick_source/sim_services/VariableServer/VariableServerThread.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerThread.cpp
@@ -69,9 +69,22 @@ std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServerThread& v
 
     std::vector <Trick::VariableReference *>::iterator it;
 
+    struct sockaddr_in otherside;
+    socklen_t len = (socklen_t)sizeof(otherside);
+
     s << "  \"connection\":{" << std::endl;
-    s << "    \"client-tag\":\"" << vst.connection.client_tag << "\",";
-    s << std::endl;
+    s << "    \"client-tag\":\"" << vst.connection.client_tag << "\"," << std::endl;
+
+    int err = getpeername(vst.connection.socket, (struct sockaddr*)&otherside, &len);
+
+    if (err == 0) {
+        std::cout << "    \"client-IP-address\":\"" << inet_ntoa(otherside.sin_addr) << "\"," << std::endl;
+        std::cout << "    \"client-port\":\"" << ntohs(otherside.sin_port) << "\"," << std::endl;
+    } else {
+        std::cout << "    \"client-IP-address\":\"unknown\"," << std::endl;
+        std::cout << "    \"client-port\":\"unknown\"," << std::endl;
+    }
+
     if (vst.binary_data) {
         s << "    \"format\":\"BINARY\",";
     } else {

--- a/trick_source/sim_services/VariableServer/VariableServerThread.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerThread.cpp
@@ -78,11 +78,11 @@ std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServerThread& v
     int err = getpeername(vst.connection.socket, (struct sockaddr*)&otherside, &len);
 
     if (err == 0) {
-        std::cout << "    \"client-IP-address\":\"" << inet_ntoa(otherside.sin_addr) << "\"," << std::endl;
-        std::cout << "    \"client-port\":\"" << ntohs(otherside.sin_port) << "\"," << std::endl;
+        s << "    \"client-IP-address\":\"" << inet_ntoa(otherside.sin_addr) << "\"," << std::endl;
+        s << "    \"client-port\":\"" << ntohs(otherside.sin_port) << "\"," << std::endl;
     } else {
-        std::cout << "    \"client-IP-address\":\"unknown\"," << std::endl;
-        std::cout << "    \"client-port\":\"unknown\"," << std::endl;
+        s << "    \"client-IP-address\":\"unknown\"," << std::endl;
+        s << "    \"client-port\":\"unknown\"," << std::endl;
     }
 
     if (vst.binary_data) {

--- a/trick_source/sim_services/VariableServer/VariableServerThread.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerThread.cpp
@@ -70,13 +70,15 @@ std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServerThread& v
     std::vector <Trick::VariableReference *>::iterator it;
 
     s << "  \"connection\":{" << std::endl;
+    s << "    \"client-tag\":\"" << vst.connection.client_tag << "\",";
+    s << std::endl;
     if (vst.binary_data) {
         s << "    \"format\":\"BINARY\",";
     } else {
         s << "    \"format\":\"ASCII\",";
     }
     s << std::endl;
-    s << "    \"updaterate\":" << vst.update_rate << "," << std::endl;
+    s << "    \"update-rate\":" << vst.update_rate << "," << std::endl;
 
     s << "    \"variables\":[" << std::endl;
 

--- a/trick_source/sim_services/VariableServer/var_server_ext.cpp
+++ b/trick_source/sim_services/VariableServer/var_server_ext.cpp
@@ -387,6 +387,10 @@ Trick::VariableServer * var_server_get_var_server() {
     return the_vs ;
 }
 
+extern "C" void var_server_list_connections(void) {
+    std::cout << *the_vs << std::endl;
+}
+
 /**
  * @relates Trick::VariableServer
  * @copydoc Trick::VariableServer::get_hostname


### PR DESCRIPTION
…f #678 

Added new "<<" operator to the Trick::VariableServer class that prints a JSON representation
of the current variable server connections. Also a C interface function: trick.var_server_list_connections().

**Example usage in C++**
#include "VariableServer.hh"
std::cout << *the_vs << std::endl;

**Example usage in C**
#include "variable_server_proto.h"
// prints VS list to stdout.
trick.var_server_list_connections();

**Example usage in input processor**
Here's an example of using it from the 
myEvent = trick.new_event("myEvent")
myEvent.condition(0, "trick.exec_get_sim_time()>4.0")
myEvent.action(0, "trick.var_server_list_connections()");
myEvent.set_cycle(1.0)
myEvent.activate()
trick.add_event(myEvent)

