### PR TITLE
Include Trickified classes/enums in S_sie.resource

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp
@@ -112,27 +112,6 @@ static void _mkdir(const char *dir) {
     }
 }
 
-// this is a subset of tests on the header file to determine if this file is not excluded for any reason.
-bool PrintAttributes::isFileIncluded(std::string header_file_name) {
-    // several tests require the real path of the header file.
-    char * realPath = almostRealPath(header_file_name.c_str()) ;
-
-    if ( realPath != NULL ) {
-        // Only include user directories (not system dirs like /usr/include)
-        if ( hsd.isPathInUserDir(realPath) ) {
-            // Don't process files in excluded directories
-            if ( (hsd.isPathInExclude(realPath) == false) and (hsd.isPathInICGExclude(realPath) == false) ) {
-                // Only include files that do not have ICG: (No)
-                // hasICGNo uses original header name, not the real path
-                if ( ! cs.hasICGNo(header_file_name) ) {
-                    return true ;
-                }
-            }
-        }
-    }
-    return false ;
-}
-
 bool PrintAttributes::openIOFile(const std::string& header_file_name) {
     /**
      * There are a lot of conditions to be met in order to open an IO file.  We store the headers
@@ -258,18 +237,9 @@ void PrintAttributes::printClass( ClassValues * cv ) {
         outfile.close();
     }
 
-    if (!isHeaderExcluded(fileName)) {
+    if (!isHeaderExcluded(fileName, false)) {
          printer->printClassMap(class_map_outfile, cv);
     }
-/*
-    char* realPath = almostRealPath(fileName.c_str());
-    if (realPath) {
-        if (isFileIncluded(fileName) or hsd.isPathInExtLib(realPath)) {
-             printer->printClassMap(class_map_outfile, cv);
-        }
-        free(realPath);
-    }
-*/
 }
 
 void PrintAttributes::printEnum(EnumValues* ev) {
@@ -293,14 +263,9 @@ void PrintAttributes::printEnum(EnumValues* ev) {
         outfile.close() ;
     }
 
-    if (!isHeaderExcluded(fileName)) {
+    if (!isHeaderExcluded(fileName), false) {
          printer->printEnumMap(enum_map_outfile, ev);
     }
-/*
-    if (isFileIncluded(fileName)) {
-         printer->printEnumMap(enum_map_outfile, ev) ;
-    }
-*/
 }
 
 void PrintAttributes::createMapFiles() {

--- a/trick_source/codegen/Interface_Code_Gen/PrintAttributes.hh
+++ b/trick_source/codegen/Interface_Code_Gen/PrintAttributes.hh
@@ -101,7 +101,6 @@ class PrintAttributes {
 
         bool openIOFile(const std::string& header_file_name) ;
 
-        bool isFileIncluded(std::string header_file_name) ;
         bool isIOFileOutOfDate(std::string header_file_name, std::string io_file_name ) ;
         bool hasBeenProcessed(EnumValues& enumValues);
         bool hasBeenProcessed(ClassValues& classValues);


### PR DESCRIPTION
[`isHeaderExcluded`](https://github.com/nasa/trick/blob/b9278c4a729d9bec1cfe7974629f3d90116f9fda/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp#L513) checks a number of things to determine if a header file should be processed by ICG. Of concern here are entries in `TRICK_EXT_LIB_DIRS`, which indicate files that have been Trickified. For these files, we do not want to produce I/O code, as that will have already been done during Trickification. However, we still want class/enum data in S_sie.resource so that Trickified member type information is available to TrickView. 

5285f1a72ee8d172acd7b698534549a4c3b64abd replaced [`isFileIncluded`](https://github.com/nasa/trick/blob/b9278c4a729d9bec1cfe7974629f3d90116f9fda/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp#L116) with `isHeaderExcluded`, which has nearly the same behavior, except that `isFileIncluded` never checks `TRICK_EXT_LIB_DIRS`. `isHeaderExcluded` provides a `bool` parameter to toggle consideration of `TRICK_EXT_LIB_DIRS`. This PR changes that bool to `false` (to ignore `TRICK_EXT_LIB_DIRS`) when printing class and enum maps.

Also, remove dead code.

Fixes #688