### PR TITLE
Give trick-CP the same -C/--directory option that 'make' has.

### DIFF
--- a/bin/trick-CP
+++ b/bin/trick-CP
@@ -15,10 +15,19 @@ $trick_home = dirname($trick_bin) ;
 #### Handle arguments ####
 $numArgs = $#ARGV + 1;
 $makefileAddArgs = ' ';
+$sdefine_dir = ".";
+$sdefine = "S_define";
+$makefile = "makefile";
 foreach $argnum (0 .. $#ARGV) {
     $arg = $ARGV[$argnum];
     if ($arg =~ /(\w+)=(\w+)/ ) {
         $makefileAddArgs = $makefileAddArgs . $1 . "=" . $2 . " ";
+    } elsif ($arg eq "-C" || $arg eq "--directory" ) {
+        $sdefine_dir = abs_path($ARGV[$argnum + 1]);
+        $makefileAddArgs = $makefileAddArgs . " -C $sdefine_dir ";
+        $sdefine = $sdefine_dir . "/${sdefine}";
+        $makefile = $sdefine_dir . "/${makefile}";
+        shift
     } elsif ($arg =~ /-d/ ) {
         $makefileAddArgs = $makefileAddArgs . " debug ";
     } elsif ($arg =~ /-t/ ) {
@@ -30,17 +39,17 @@ foreach $argnum (0 .. $#ARGV) {
     }
 }
 
-if ( -f "S_define" ) {
-    if ( not -w "." ) {
-        print getcwd() , " is not writable\n" ;
-        print "CP aborted\n" ;
+if ( -f $sdefine ) {
+    if ( not -w $sdefine_dir ) {
+        print $sdefine_dir , " is not writable\n" ;
+        print "trick-CP aborted\n" ;
         exit 1 ;
     }
-    unlink "build/Makefile_sim", "makefile" ;
+    unlink "build/Makefile_sim", $makefile ;
     $makefile_text = do { local $/; <main::DATA> } ;
     $makefile_text =~ s/SUB_TRICK_HOME/$trick_home/ ;
     $makefile_text =~ s/SUB_TRICK_BIN/$trick_bin/ ;
-    open MAKEFILE, ">makefile" ;
+    open MAKEFILE, ">$makefile" ;
     print MAKEFILE $makefile_text ;
     close MAKEFILE ;
     system("make -f makefile " . $makefileAddArgs) ;
@@ -89,6 +98,11 @@ Print the trick-CP help message (this message)
 =item B<-o> | B<--outfile> I<FILE_NAME>
 
 Send CP output to FILE_NAME
+
+=item B<-C> | B<--directory> I<SIM_DIRECTORY_NAME>
+
+Build a simulation located in a different directory than the current
+working directory.
 
 =item B<-p> | B<--no-python>
 


### PR DESCRIPTION
I didn't see a way to specify a certain directory for trick-CP to build. If that already exists somehow then this pull request is not necessary.

In scenarios where one wants to build many SIM directories, it is a bit cumbersome to `cd` to all of them and then build. I implemented a change to `trick-CP` to allow the `-C/--directory` option to specify a build directory. This is the same feature that `make` has.

Now one can do the following command:

```bash
path/to/trick-CP -C path/to/SIM_directory
```

without first having to `cd` to the path that contains the S_define.

I've tested that this works for the existing sims in Trick by editing `trick_sims/makefile` in the following way:

```diff
      1 diff --git a/trick_sims/makefile b/trick_sims/makefile
      2 index 881f9efb..cca3cb94 100644
      3 --- a/trick_sims/makefile
      4 +++ b/trick_sims/makefile
      5 @@ -53,7 +53,7 @@ clean:
      6        done
      7  
      8  $(EXECUTABLES):
      9 -       @ cd $(@D) ; ${TRICK_HOME}/bin/trick-CP -t ;
     10 +       @ ${TRICK_HOME}/bin/trick-CP -t -C $(@D);
     11  
     12  $(UNIT_TEST_RESULTS): $(TRICK_HOME)/trick_test/%.xml : %/T_main_${TRICK_HOST_CPU}_test.exe
     13         @ cd $* ; ./T_main_${TRICK_HOST_CPU}_test.exe RUN_test/unit_test.py
```

and doing `make test` in the `trick_sims` directory. All the sims still seem to build and run.