### PR TITLE
Support Shared and Static library. Optionally package trickified gene…

### DIFF
--- a/share/trick/makefiles/trickify.mk
+++ b/share/trick/makefiles/trickify.mk
@@ -1,6 +1,6 @@
-# This file can be used to create an object file containing the io_* and py_*
-# code that Trick would normally generate during the simulation build process.
-# Sims can then link against this object file, reducing compilation time.
+# This file can be used to create an object file or library containing the io_*
+# and py_* code that Trick would normally generate during the simulation build
+# process. Sims can then link against that, reducing compilation time.
 #
 # To use it, create a directory that includes a file named S_source.hh that
 # includes all header files for which you want io_* and py_* code generated.
@@ -25,9 +25,26 @@
 # paths to the header files included by your S_source.hh. For instance:
 # -I$(HOME)/myproject/foo/include -I$(HOME)/myproject/bar/include
 #
+# TRICKIFY_BUILD_TYPE (optional)
+# Valid options are:
+# 1. STATIC (.a)
+#    Create a static library. This will require the use of --whole-archive (on
+#    Linux) or -all_load/-force_load (on Mac) when linking the sim executeable.
+#    Trick uses dlsym to dynamically load symbols at run time, but the linker,
+#    by default, will not include symbols from static libraries that are not
+#    known to be needed at compile time.
+# 2. SHARED (.so)
+#    Create a shared object (dynamically linked library). This may require the
+#    use of -rpath to ensure the linker can find the shared object at runtime
+#    unless you explicitly link against it (as opposed to using -L and -l)
+#    during compilation.
+# 3. PLO (.o) [default]
+#    Create a partially-linked object. No special linker options are required.
+#
 # TRICKIFY_OBJECT_NAME (optional)
-# The name of the generated object file. The default value is trickified.o.
-# You should choose something more meaningful, like trickified_myproject.o.
+# The name of the generated object file or library. The default value is
+# trickified.o. You should choose something more meaningful, especially if
+# you're using another build type.
 #
 # TRICKIFY_PTYON_DIR (optional)
 # The directory into which generated Python modules are placed. The default
@@ -74,9 +91,11 @@ ifndef TRICKIFY_CXX_FLAGS
     $(error TRICKIFY_CXX_FLAGS must be set)
 endif
 
+TRICKIFY_BUILD_TYPE ?= PLO
 TRICKIFY_OBJECT_NAME ?= trickified.o
 TRICKIFY_PYTHON_DIR ?= python
 TRICK_HOME := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../../..)
+MAKE_OUT ?= build/MAKE_out
 
 ifneq ($(wildcard build),)
     SWIG_OBJECTS := $(shell cat build/S_library_swig)
@@ -92,37 +111,17 @@ TRICK_CXXFLAGS += $(TRICKIFY_CXX_FLAGS)
 # Ensure we can process all headers
 TRICK_EXT_LIB_DIRS :=
 
-# Trick library build type, defaulted to PLO
-# PLO - Partially-linked object library
-# STATIC - Static library
-# SHARED - Dynamic shared library
-TRICK_LIB_BUILD_TYPE ?= PLO
-
-# Add project source objects to trickified library.
-SRC_OBJS ?=
-
-# When given a library, the linker will only link in objects that are known to
-# be needed at link time. However, Trick uses dlsym to dynamically load the
-# objects we'll be creating here. It cannot be known which objects will be
-# needed at link time, so the sim has to link them all. In that case, we might
-# as well create an object (which will be fully linked in by the sim) instead
-# of a library (which would require the use of the -whole-archive option).
-#
-# One disadvantage of this approach is that we have to link all of the objects
-# in this rule no matter how many have changed, whereas ar would allow us to
-# replace only the changed objects. However, Trickified projects are
-# necessarily used as third-party libraries, and so would be expected to
-# change infrequently. Moreover, the methods for force-linking a library differ
-# between Linux and Mac, so obviating the need for it simplifies a Trickified
-# project's user-facing makefile.
-$(TRICKIFY_OBJECT_NAME): $(SWIG_OBJECTS) $(IO_OBJECTS) $(SRC_OBJS) | $(dir $(TRICKIFY_OBJECT_NAME))
+$(TRICKIFY_OBJECT_NAME): $(SWIG_OBJECTS) $(IO_OBJECTS) | $(dir $(TRICKIFY_OBJECT_NAME))
 	$(info $(call COLOR,Linking)    $@)
-ifeq ($(TRICK_LIB_BUILD_TYPE),PLO)
-	@ld -r -o $@ $^
-else ifeq ($(TRICK_LIB_BUILD_TYPE),SHARED)
-	@c++ -shared -o $@ $^ 2> $@.log
-else ifeq ($(TRICK_LIB_BUILD_TYPE),STATIC)
-	@ar rcs $@ $^ 2> $@.log
+ifeq ($(TRICKIFY_BUILD_TYPE),PLO)
+	@echo ld -r -o $@ $^ >> $(MAKE_OUT)
+	$(ECHO_CMD)ld -r -o $@ $^ 2>&1 | $(TEE) -a $(MAKE_OUT); exit $${PIPESTATUS[0]}
+else ifeq ($(TRICKIFY_BUILD_TYPE),SHARED)
+	@echo c++ -shared -o $@ $^ >> $(MAKE_OUT)
+	$(ECHO_CMD)c++ -shared -o $@ $^ 2>&1 | $(TEE) -a $(MAKE_OUT); exit $${PIPESTATUS[0]}
+else ifeq ($(TRICKIFY_BUILD_TYPE),STATIC)
+	@echo ar rcs $@ $^ >> $(MAKE_OUT)
+	$(ECHO_CMD)ar rcs $@ $^ 2>&1 | $(TEE) -a $(MAKE_OUT); exit $${PIPESTATUS[0]}
 endif
 
 $(dir $(TRICKIFY_OBJECT_NAME)) $(TRICKIFY_PYTHON_DIR) build:
@@ -130,7 +129,8 @@ $(dir $(TRICKIFY_OBJECT_NAME)) $(TRICKIFY_PYTHON_DIR) build:
 
 $(IO_OBJECTS): %.o: %.cpp
 	$(info $(call COLOR,Compiling)  $<)
-	@$(TRICK_CPPC) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) -std=c++11 -Wno-invalid-offsetof -MMD -MP -c -o $@ $<
+	@echo $(TRICK_CPPC) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) -std=c++11 -Wno-invalid-offsetof -MMD -MP -c -o $@ $< >> $(MAKE_OUT)
+	$(ECHO_CMD)$(TRICK_CPPC) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) -std=c++11 -Wno-invalid-offsetof -MMD -MP -c -o $@ $< 2>&1 | $(TEE) -a $(MAKE_OUT) ; exit $${PIPESTATUS[0]}
 
 $(IO_OBJECTS:.o=.d): %.d: ;
 
@@ -138,16 +138,19 @@ $(IO_OBJECTS:.o=.d): %.d: ;
 
 $(SWIG_OBJECTS): %.o: %.cpp
 	$(info $(call COLOR,Compiling)  $<)
-	@$(TRICK_CPPC) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) $(PYTHON_INCLUDES) -Wno-unused-parameter -Wno-shadow -c -o $@ $<
+	@echo $(TRICK_CPPC) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) $(PYTHON_INCLUDES) -Wno-unused-parameter -Wno-shadow -c -o $@ $< >> $(MAKE_OUT)
+	$(ECHO_CMD)$(TRICK_CPPC) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) $(PYTHON_INCLUDES) -Wno-unused-parameter -Wno-shadow -c -o $@ $< 2>&1 | $(TEE) -a $(MAKE_OUT) ; exit $${PIPESTATUS[0]}
 
 $(SWIG_OBJECTS:.o=.cpp): %.cpp: %.i | $(TRICKIFY_PYTHON_DIR) $(SWIG_OBJECTS:.o=.i)
 	$(info $(call COLOR,SWIGing)    $<)
-	@$(SWIG) $(TRICK_INCLUDE) $(TRICK_DEFINES) $(TRICK_VERSIONS) $(TRICK_SWIG_FLAGS) -c++ -python -includeall -ignoremissing -w201,303,325,362,389,401,451 -outdir $(TRICKIFY_PYTHON_DIR) -o $@ $<
+	@echo $(SWIG) $(TRICK_INCLUDE) $(TRICK_DEFINES) $(TRICK_VERSIONS) $(TRICK_SWIG_FLAGS) -c++ -python -includeall -ignoremissing -w201,303,325,362,389,401,451 -outdir $(TRICKIFY_PYTHON_DIR) -o $@ $< >> $(MAKE_OUT)
+	$(ECHO_CMD)$(SWIG) $(TRICK_INCLUDE) $(TRICK_DEFINES) $(TRICK_VERSIONS) $(TRICK_SWIG_FLAGS) -c++ -python -includeall -ignoremissing -w201,303,325,362,389,401,451 -outdir $(TRICKIFY_PYTHON_DIR) -o $@ $< 2>&1 | $(TEE) -a $(MAKE_OUT) ; exit $${PIPESTATUS[0]}
 
 define create_convert_swig_rule
 build/%_py.i: /%.$1
 	$$(info $$(call COLOR,Converting) $$<)
-	${TRICK_HOME}/$(LIBEXEC)/trick/convert_swig ${TRICK_CONVERT_SWIG_FLAGS} $$<
+	@echo ${TRICK_HOME}/$(LIBEXEC)/trick/convert_swig ${TRICK_CONVERT_SWIG_FLAGS} $$< >> $(MAKE_OUT)
+	$(ECHO_CMD)${TRICK_HOME}/$(LIBEXEC)/trick/convert_swig ${TRICK_CONVERT_SWIG_FLAGS} $$< 2>&1 | $(TEE) -a $(MAKE_OUT) ; exit $$${PIPESTATUS[0]}
 endef
 
 EXTENSIONS := H h hh hxx h++ hpp
@@ -185,8 +188,9 @@ $(foreach EXTENSION,$(EXTENSIONS),$(eval $(call create_convert_swig_rule,$(EXTEN
 # http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
 build/S_source.d: | $(dir $@)
-	@$(TRICK_HOME)/bin/trick-ICG $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) $(TRICK_ICGFLAGS) S_source.hh
-	@$(TRICK_HOME)/$(LIBEXEC)/trick/make_makefile_swig
-	@$(TRICK_CC) -MM -MP -MT $@ -MF $@ $(TRICKIFY_CXX_FLAGS) S_source.hh
+	$(ECHO_CMD)$(TRICK_HOME)/bin/trick-ICG $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) $(TRICK_ICGFLAGS) S_source.hh
+	$(ECHO_CMD)$(TRICK_HOME)/$(LIBEXEC)/trick/make_makefile_swig 2>&1 | $(TEE) -a $(MAKE_OUT) ; exit $${PIPESTATUS[0]}
+	@echo $(TRICK_CC) -MM -MP -MT $@ -MF $@ $(TRICKIFY_CXX_FLAGS) S_source.hh >> $(MAKE_OUT)
+	$(ECHO_CMD) $(TRICK_CC) -MM -MP -MT $@ -MF $@ $(TRICKIFY_CXX_FLAGS) S_source.hh 2>&1 | $(TEE) -a $(MAKE_OUT) ; exit $${PIPESTATUS[0]}
 
 -include build/S_source.d

--- a/share/trick/makefiles/trickify.mk
+++ b/share/trick/makefiles/trickify.mk
@@ -114,10 +114,10 @@ TRICK_EXT_LIB_DIRS :=
 $(TRICKIFY_OBJECT_NAME): $(SWIG_OBJECTS) $(IO_OBJECTS) | $(dir $(TRICKIFY_OBJECT_NAME))
 	$(info $(call COLOR,Linking)    $@)
 ifeq ($(TRICKIFY_BUILD_TYPE),PLO)
-	@echo ld -r -o $@ $^ >> $(MAKE_OUT)
+	@echo $(LD) $(LD_PARTIAL) -o $@ $^ >> $(MAKE_OUT)
 	$(ECHO_CMD)ld -r -o $@ $^ 2>&1 | $(TEE) -a $(MAKE_OUT); exit $${PIPESTATUS[0]}
 else ifeq ($(TRICKIFY_BUILD_TYPE),SHARED)
-	@echo c++ -shared -o $@ $^ >> $(MAKE_OUT)
+	@echo $(TRICK_CPPC) -shared -o $@ $^ >> $(MAKE_OUT)
 	$(ECHO_CMD)c++ -shared -o $@ $^ 2>&1 | $(TEE) -a $(MAKE_OUT); exit $${PIPESTATUS[0]}
 else ifeq ($(TRICKIFY_BUILD_TYPE),STATIC)
 	@echo ar rcs $@ $^ >> $(MAKE_OUT)


### PR DESCRIPTION
@dbankieris @jmpenn 

Here are the suggested changes based on the conversation we had in early March for trickifing Simulink auto generated code.

Summary: Support Shared Trickified library. Optionally package trickified ICG generated code and source code in to one library.

Example Usage (A Separate Makefile exist under build/ for building the auto-code object files):

```
ifndef TRICK_HOME
    $(error TRICK_HOME must be set)
endif

TRICKIFY := $(TRICK_HOME)/share/trick/makefiles/trickify.mk

ifeq ($(wildcard $(TRICKIFY)),)
    $(error This makefile requires at least Trick 17.1)
endif

# Provide model specific terms
MODEL_DIR    = $(CCP_BOEING_RELEASE_HOME)/Aero
SRC_LIB_NAME = aero.so
CXX_FLAGS    = -I$(MODEL_DIR)/auto_code

SRC_BUILD_DIR               = $(MODEL_DIR)/build
build_src                   = $(SRC_BUILD_DIR)/$(SRC_LIB_NAME)
export SRC_OBJS             =
export TRICK_LIB_BUILD_TYPE = SHARED
export TRICKIFY_OBJECT_NAME = trickified_$(SRC_LIB_NAME)
export TRICKIFY_CXX_FLAGS   = $(CXX_FLAGS)

.PHONY: all

all: $(build_src)
	$(eval SRC_OBJS=$(wildcard $(SRC_BUILD_DIR)/object_x86_64/*.o))
	$(MAKE) -s -f $(TRICKIFY)

.PHONY: $(build_src)

$(build_src):
	@$(MAKE) -C $(SRC_BUILD_DIR)

clean:
	@rm -rf build/* python trick/* $(TRICKIFY_OBJECT_NAME) $(TRICKIFY_OBJECT_NAME).log
```