### PR TITLE
Python 3 Compatibility for variable_server.py

### DIFF
--- a/share/trick/pymods/trick/variable_server.py
+++ b/share/trick/pymods/trick/variable_server.py
@@ -860,7 +860,7 @@ class VariableServer(object):
           self.Channel.BOTH: [self._synchronous_socket,
                               self._asynchronous_socket]
         }[channel]:
-            channel.sendall(command)
+            channel.sendall(command.encode())
 
     def readline(self, synchronous_channel=True):
         """


### PR DESCRIPTION
* Convert string to bytes in `variable_server.py` for Python 3
* Method socket.sendall() (called in `VariableServer.send()`) expects bytes to be sent, rather than a string
* Python 3 stores text strings as unicode (not ASCII) by default
* Therefore, strings must be explicitly converted to bytes for Python 3 compatibility
* This works for both Python 2 and Python 3 (tested on Python 2.7, Python 3.6, and Python 3.7)