### PR TITLE
Add ability to specify MC slave output directory

### DIFF
--- a/include/trick/MonteCarlo.hh
+++ b/include/trick/MonteCarlo.hh
@@ -259,6 +259,9 @@ namespace Trick {
         /** Options to be passed to the slave sim. */
         std::string slave_sim_options;
 
+        /** Base output directory for slaves. */
+        std::string slave_output_directory;
+
         private:
         int run_queue(Trick::ScheduledJobQueue* queue, std::string in_string) ;
 

--- a/include/trick/montecarlo_c_intf.h
+++ b/include/trick/montecarlo_c_intf.h
@@ -103,6 +103,12 @@ void mc_set_slave_sim_options(const char *slave_sim_options);
 
 /**
  * @relates Trick::MonteCarlo
+ * set #Trick::MonteCarlo::slave_output_directory
+ */
+void mc_set_slave_output_directory(const char *slave_output_directory);
+
+/**
+ * @relates Trick::MonteCarlo
  * get #Trick::MonteCarlo::slave_sim_options
  */
 const char *mc_get_slave_sim_options(void);

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_c_intf.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_c_intf.cpp
@@ -110,6 +110,12 @@ extern "C" void mc_set_slave_sim_options(const char *slave_sim_options) {
     }
 }
 
+extern "C" void mc_set_slave_output_directory(const char *slave_output_directory) {
+    if ( the_mc != NULL ) {
+        the_mc->slave_output_directory = std::string(slave_output_directory ? slave_output_directory : "");
+    }
+}
+
 extern "C" const char *mc_get_slave_sim_options(void) {
     if ( the_mc != NULL ) {
         return the_mc->slave_sim_options.c_str();

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_dispatch_run_to_slave.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_dispatch_run_to_slave.cpp
@@ -19,7 +19,7 @@ void Trick::MonteCarlo::dispatch_run_to_slave(MonteRun *run, MonteSlave *slave) 
         connection_device.port = slave->port;
         if (tc_connect(&connection_device) == TC_SUCCESS) {
             std::stringstream buffer_stream;
-            buffer_stream << run_directory << "/RUN_" << std::setw(5) << std::setfill('0') << run->id;
+            buffer_stream << slave_output_directory << "/RUN_" << std::setw(5) << std::setfill('0') << run->id;
             std::string buffer = "";
             for (std::vector<std::string>::size_type j = 0; j < run->variables.size(); ++j) {
                 buffer += run->variables[j] + "\n";

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_master_file_io.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_master_file_io.cpp
@@ -34,6 +34,12 @@ int Trick::MonteCarlo::construct_run_directory() {
             return -1;
         }
         run_directory = run_base_directory + "MONTE_" + run_directory;
+
+        // If the user hasn't set an output directory for slaves, default to
+        // the same location as the master's output.
+        if (slave_output_directory.empty()) {
+            slave_output_directory = run_directory;
+        }
     }
 
     if  (access(run_directory.c_str(), F_OK) != 0) {

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_spawn_slaves.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_spawn_slaves.cpp
@@ -49,7 +49,7 @@ void Trick::MonteCarlo::initialize_slave(Trick::MonteSlave* slave_to_init) {
        << " --monte_host " << machine_name
        << " --monte_sync_port " << listen_device.port
        << " --monte_client_id " << slave_to_init->id
-       << " -O " << run_directory;
+       << " -O " << slave_output_directory;
     buffer += ss.str();
 
     /** <li> Append user sim options. */


### PR DESCRIPTION
@benkirk Alex and I couldn't find a way to correctly split master and slave output with the current options, so he's my proposal for a new feature.

If you checkout this branch, you can use `trick.mc_set_slave_output_directory` to have all the slave's `RUN_*` go wherever you like. Let me know what you think.

Refs #763 
