### PR TITLE
Replace std::endl with "\n" in SIE

### DIFF
--- a/trick_source/sim_services/Sie/AttributesMap.cpp
+++ b/trick_source/sim_services/Sie/AttributesMap.cpp
@@ -64,15 +64,15 @@ void Trick::AttributesMap::print_xml(std::ofstream & sie_out ) {
         ATTRIBUTES * attr = (*it).second ;
         std::string class_name = (*it).first;
         std::replace(class_name.begin(), class_name.end(), ':', '_');
-        sie_out << "  <class name=\"" <<  class_name << "\">" << std::endl ;
+        sie_out << "  <class name=\"" <<  class_name << "\">\n" ;
         while ( attr->name[0] != '\0' and (attr->type_name != NULL)) {
             sie_out << "    <member" ;
-            sie_out << std::endl << "      name=\"" << attr->name << "\"" ;
+            sie_out << "\n      name=\"" << attr->name << "\"" ;
             std::string type_name = attr->type_name;
             std::replace(type_name.begin(), type_name.end(), ':', '_');
-            sie_out << std::endl << "      type=\"" << type_remove_dims(type_name) << "\"" ;
-            sie_out << std::endl << "      io_attributes=\"" << attr->io << "\"" ;
-            sie_out << std::endl << "      units=\"" ;
+            sie_out << "\n      type=\"" << type_remove_dims(type_name) << "\"" ;
+            sie_out << "\n      io_attributes=\"" << attr->io << "\"" ;
+            sie_out << "\n      units=\"" ;
             // If the mods bit is set for using -- as the units
             if ( attr->mods & TRICK_MODS_UNITSDASHDASH ) {
                 sie_out << "--" ;
@@ -83,18 +83,18 @@ void Trick::AttributesMap::print_xml(std::ofstream & sie_out ) {
 
             std::string description = attr->des;
             if ( ! description.empty() ) {
-                sie_out << std::endl << "      description=\"" << replace_special_chars(description) << "\"" ;
+                sie_out << "\n      description=\"" << replace_special_chars(description) << "\"" ;
             }
-            sie_out << ">" << std::endl ;
+            sie_out << ">\n" ;
             if ( attr->num_index > 0 ) {
                 for (jj = 0; jj < attr->num_index; jj++) {
-                    sie_out << "      <dimension>" << attr->index[jj].size << "</dimension>" << std::endl ;
+                    sie_out << "      <dimension>" << attr->index[jj].size << "</dimension>\n" ;
                 }
             }
-            sie_out << "    </member>" << std::endl ;
+            sie_out << "    </member>\n" ;
             attr++ ;
         }
-        sie_out << "  </class>" << std::endl << std::endl ;
+        sie_out << "  </class>\n\n" ;
     }
 }
 

--- a/trick_source/sim_services/Sie/EnumAttributesMap.cpp
+++ b/trick_source/sim_services/Sie/EnumAttributesMap.cpp
@@ -20,13 +20,13 @@ void Trick::EnumAttributesMap::print_xml(std::ofstream & sie_out ) {
         if ( enum_attr != NULL ) {
             std::string name = it->first;
             std::replace(name.begin(), name.end(), ':', '_');
-            sie_out << "  <enumeration name=\"" << name << "\">" << std::endl ;
+            sie_out << "  <enumeration name=\"" << name << "\">\n" ;
             while ( enum_attr->label[0] != '\0' ) {
                 sie_out << "      <pair label=\"" << enum_attr->label << "\"" ;
-                sie_out << " value=\"" << enum_attr->value << "\"/>" << std::endl ;
+                sie_out << " value=\"" << enum_attr->value << "\"/>\n" ;
                 enum_attr++ ;
             }
-            sie_out << "  </enumeration>" << std::endl << std::endl ;
+            sie_out << "  </enumeration>\n\n" ;
         }
     }
 }

--- a/trick_source/sim_services/Sie/Sie.cpp
+++ b/trick_source/sim_services/Sie/Sie.cpp
@@ -56,19 +56,19 @@ void Trick::Sie::top_level_objects_print(std::ofstream & sie_out) {
 
         if ( alloc_info != NULL ) {
             sie_out << "  <top_level_object" ;
-            sie_out << std::endl << "   name=\"" << vit->first << "\"" ;
-            sie_out << std::endl << "   type=\"" ;
+            sie_out << "\n   name=\"" << vit->first << "\"" ;
+            sie_out << "\n   type=\"" ;
             std::string type = trickTypeCharString(alloc_info->type, alloc_info->user_type_name );
             std::replace(type.begin(), type.end(), ':', '_');
-            sie_out <<  type << "\"" << std::endl ;
+            sie_out <<  type << "\"\n" ;
             sie_out << "   alloc_memory_init=\"" << alloc_info->alloced_in_memory_init << "\"";
-            sie_out << ">" << std::endl ;
+            sie_out << ">\n" ;
             if ( alloc_info->num_index > 0 ) {
                 for (jj = 0; jj < alloc_info->num_index; jj++) {
-                    sie_out << "        <dimension>" << alloc_info->index[jj] << "</dimension>" << std::endl ;
+                    sie_out << "        <dimension>" << alloc_info->index[jj] << "</dimension>\n" ;
                 }
             }
-            sie_out << "  </top_level_object>" << std::endl << std::endl ;
+            sie_out << "  </top_level_object>\n\n" ;
         }
     }
 }
@@ -77,12 +77,12 @@ void Trick::Sie::sie_print_xml() {
     std::ofstream sie_out ;
     std::string file_name = std::string(command_line_args_get_default_dir()) + "/" + "S_sie.resource" ;
     sie_out.open(file_name.c_str()) ;
-    sie_out << "<?xml version=\"1.0\"?>" << std::endl << std::endl ;
-    sie_out << "<sie>" << std::endl << std::endl ;
+    sie_out << "<?xml version=\"1.0\"?>\n\n" ;
+    sie_out << "<sie>\n\n" ;
     class_attr_map->print_xml(sie_out) ;
     enum_attr_map->print_xml(sie_out) ;
     top_level_objects_print(sie_out) ;
-    sie_out << "</sie>" << std::endl ;
+    sie_out << "</sie>\n" ;
     sie_out.close() ;
 }
 
@@ -90,10 +90,10 @@ void Trick::Sie::class_attr_map_print_xml() {
     std::ofstream sie_out ;
     std::string file_name = std::string(command_line_args_get_default_dir()) + "/" + "S_sie_class.xml" ;
     sie_out.open(file_name.c_str()) ;
-    sie_out << "<?xml version=\"1.0\"?>" << std::endl << std::endl ;
-    sie_out << "<sie>" << std::endl ;
+    sie_out << "<?xml version=\"1.0\"?>\n\n" ;
+    sie_out << "<sie>\n" ;
     class_attr_map->print_xml(sie_out) ;
-    sie_out << "</sie>" << std::endl ;
+    sie_out << "</sie>\n" ;
     sie_out.close() ;
 }
 
@@ -101,10 +101,10 @@ void Trick::Sie::enum_attr_map_print_xml() {
     std::ofstream sie_out ;
     std::string file_name = std::string(command_line_args_get_default_dir()) + "/" + "S_sie_enum.xml" ;
     sie_out.open(file_name.c_str()) ;
-    sie_out << "<?xml version=\"1.0\"?>" << std::endl << std::endl ;
-    sie_out << "<sie>" << std::endl ;
+    sie_out << "<?xml version=\"1.0\"?>\n\n" ;
+    sie_out << "<sie>\n" ;
     enum_attr_map->print_xml(sie_out) ;
-    sie_out << "</sie>" << std::endl ;
+    sie_out << "</sie>\n" ;
     sie_out.close() ;
 }
 
@@ -112,10 +112,10 @@ void Trick::Sie::top_level_objects_print_xml() {
     std::ofstream sie_out ;
     std::string file_name = std::string(command_line_args_get_default_dir()) + "/" + "S_sie_top_level_objects.xml" ;
     sie_out.open(file_name.c_str()) ;
-    sie_out << "<?xml version=\"1.0\"?>" << std::endl << std::endl ;
-    sie_out << "<sie>" << std::endl ;
+    sie_out << "<?xml version=\"1.0\"?>\n\n" ;
+    sie_out << "<sie>\n" ;
     top_level_objects_print(sie_out) ;
-    sie_out << "</sie>" << std::endl ;
+    sie_out << "</sie>\n" ;
     sie_out.close() ;
 }
 


### PR DESCRIPTION
[`std::endl`] flushes the output stream. The SIE functions were using it multiple times per variable. This can have significant performance impacts on file I/O.

In testing, the `S_sie.resource` file for SIM_parachute was flushed over 14000 times, each resulting in a separate [`write`] system call. With this patch, only ~40 write calls were performed, and writing the file took ~1/3 as long.

For more information, see [C++ Core Guidelines Rule SL.io.50: Avoid `endl`](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#slio50-avoid-endl)

Addresses part of #766.

[`std::endl`]: https://en.cppreference.com/w/cpp/io/manip/endl
[`write`]: http://man7.org/linux/man-pages/man2/write.2.html