### PR TITLE
#776 .dat files don't call restore_stls in checkpoint restore

### DIFF
--- a/include/trick/MemoryManager.hh
+++ b/include/trick/MemoryManager.hh
@@ -370,7 +370,7 @@ namespace Trick {
              Restore a checkpoint from the given stream.
              @param in_s - input stream.
              */
-            int read_checkpoint( std::istream* in_s, bool do_restore_stls=true);
+            int read_checkpoint( std::istream* in_s, bool do_restore_stls=false);
 
             /**
              Read a checkpoint from the file of the given name.

--- a/include/trick/MemoryManager.hh
+++ b/include/trick/MemoryManager.hh
@@ -370,7 +370,7 @@ namespace Trick {
              Restore a checkpoint from the given stream.
              @param in_s - input stream.
              */
-            int read_checkpoint( std::istream* in_s);
+            int read_checkpoint( std::istream* in_s, bool do_restore_stls=true);
 
             /**
              Read a checkpoint from the file of the given name.

--- a/trick_source/sim_services/MemoryManager/MemoryManager_restore.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_restore.cpp
@@ -7,7 +7,7 @@
 #include "trick/MemoryManager.hh"
 #include "trick/ClassicCheckPointAgent.hh"
 
-int Trick::MemoryManager::read_checkpoint( std::istream *is, bool do_restore_stls /* default is true */) {
+int Trick::MemoryManager::read_checkpoint( std::istream *is, bool do_restore_stls /* default is false */) {
 
     ALLOC_INFO_MAP::iterator pos;
     ALLOC_INFO* alloc_info;
@@ -22,8 +22,10 @@ int Trick::MemoryManager::read_checkpoint( std::istream *is, bool do_restore_stl
     }
 
     // Search for stls and restore them
-    for ( pos=alloc_info_map.begin() ; do_restore_stls && pos!=alloc_info_map.end() ; pos++ ) {
-        restore_stls(pos->second) ;
+    if(do_restore_stls) {
+        for ( pos=alloc_info_map.begin() ; pos!=alloc_info_map.end() ; pos++ ) {
+            restore_stls(pos->second) ;
+        }
     }
 
     // Go through all of the allocations that have been created looking
@@ -62,10 +64,10 @@ int Trick::MemoryManager::read_checkpoint(const char* filename ) {
     std::ifstream infile(filename , std::ios::in);
     if (infile.is_open()) {
 
-        // If the file extention is .dat, we will tell read_checkpoint not to
-        // restore stls. It is not necessary and time consuming. 
+        // If the filename is not S_default.dat, we will tell read_checkpoint to
+        // restore stls.
         bool do_restore_stls = 
-        (std::string(filename).find(".dat") != std::string::npos);
+        (std::string(filename).find("S_default.dat") == std::string::npos);
 
         return ( read_checkpoint( &infile, do_restore_stls )) ;
     } else {

--- a/trick_source/sim_services/MemoryManager/MemoryManager_restore.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_restore.cpp
@@ -7,7 +7,7 @@
 #include "trick/MemoryManager.hh"
 #include "trick/ClassicCheckPointAgent.hh"
 
-int Trick::MemoryManager::read_checkpoint( std::istream *is) {
+int Trick::MemoryManager::read_checkpoint( std::istream *is, bool do_restore_stls /* default is true */) {
 
     ALLOC_INFO_MAP::iterator pos;
     ALLOC_INFO* alloc_info;
@@ -22,7 +22,7 @@ int Trick::MemoryManager::read_checkpoint( std::istream *is) {
     }
 
     // Search for stls and restore them
-    for ( pos=alloc_info_map.begin() ; pos!=alloc_info_map.end() ; pos++ ) {
+    for ( pos=alloc_info_map.begin() ; do_restore_stls && pos!=alloc_info_map.end() ; pos++ ) {
         restore_stls(pos->second) ;
     }
 
@@ -60,12 +60,17 @@ int Trick::MemoryManager::read_checkpoint(const char* filename ) {
 
     // Create a stream from the named file.
     std::ifstream infile(filename , std::ios::in);
-
     if (infile.is_open()) {
-        return ( read_checkpoint( &infile ));
+
+        // If the file extention is .dat, we will tell read_checkpoint not to
+        // restore stls. It is not necessary and time consuming. 
+        bool do_restore_stls = 
+        (std::string(filename).find(".dat") != std::string::npos);
+
+        return ( read_checkpoint( &infile, do_restore_stls )) ;
     } else {
         std::stringstream message;
-        message << "Couldn't open \"" << filename << "\".";
+        message << "Couldn't open \"" << filename << "\"." ;
         emitError(message.str());
     }
     return 1;


### PR DESCRIPTION
@alexlin0 this is a quick and dirty fix for the problem. How can I refine this so that restore_stls is called when it needs to be? @jmpenn are there any defining characteristics that separate a S_default.dat from a checkpoint or are they exactly the same? Will S_default.dat ever need to restore STLs?

