### PR TITLE
Add ability to include user makefile rules before main makefile is re…

### DIFF
--- a/bin/trick-CP
+++ b/bin/trick-CP
@@ -146,6 +146,8 @@ The simulation-specific default initialization data file.
 __END__
 # CP found at SUB_TRICK_BIN
 
+-include S_pre.mk
+
 # Disable built-in implicit rules to increase build speed.
 .SUFFIXES:
 
@@ -258,6 +260,7 @@ ifeq ($(findstring ${MAKECMDGOALS},$(CLEAN_TARGETS)),)
 endif
 -include build/Makefile_overrides
 -include S_overrides.mk
+-include S_post.mk
 
 ifndef MAKE_RESTARTS
 REMOVE_MAKE_OUT := $(shell rm -f $(MAKE_OUT))

--- a/bin/trick-CP
+++ b/bin/trick-CP
@@ -146,7 +146,6 @@ The simulation-specific default initialization data file.
 __END__
 # CP found at SUB_TRICK_BIN
 
--include S_pre.mk
 
 # Disable built-in implicit rules to increase build speed.
 .SUFFIXES:
@@ -154,6 +153,8 @@ __END__
 ifndef TRICK_HOME
     export TRICK_HOME := SUB_TRICK_HOME
 endif
+
+-include S_pre.mk
 
 ifneq ($(wildcard ${TRICK_HOME}/share/trick/makefiles/Makefile.common),)
 include ${TRICK_HOME}/share/trick/makefiles/Makefile.common

--- a/bin/trick-CP
+++ b/bin/trick-CP
@@ -146,7 +146,6 @@ The simulation-specific default initialization data file.
 __END__
 # CP found at SUB_TRICK_BIN
 
-
 # Disable built-in implicit rules to increase build speed.
 .SUFFIXES:
 


### PR DESCRIPTION
…ad. #801

Added 2 new files that are optionally included in the main makefile, S_pre.mk and
S_post.mk.  S_post.mk serves the same purpose as S_overrides.mk.  The intent is

1.  (19) Have both files present in the current major version.
2.  (21) Add warning deprecating S_overrides.mk
3.  (23) Actually deprecate S_overrides.mk