### PR TITLE
Add support for Mac's removal of /usr/include #810

### DIFF
--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -121,11 +121,11 @@ AC_DEFUN([AX_GTEST_HOME],[
                 [AC_CHECK_HEADER(gtest/gtest.h, [GTEST_HOME="/usr"], [GTEST_HOME=""])]
                )
     AC_SUBST([GTEST_HOME])
-])	
+])
 
 AC_DEFUN([AX_SWIG_BIN],[
     AC_ARG_WITH([swig],
-                AS_HELP_STRING([--with-swig@<:@=DIR@:>@], [path of directory containing the SWIG executable.]),    
+                AS_HELP_STRING([--with-swig@<:@=DIR@:>@], [path of directory containing the SWIG executable.]),
                 PATH="$withval:${PATH}"
                )
     AC_SUBST([SWIG_BIN])
@@ -204,10 +204,30 @@ AC_DEFUN([AX_GCC_VERSION], [
 dnl get the host_os.
 AC_CANONICAL_HOST
 
+dnl AC_CANONICAL_HOST provides platform.  MacOSX is diverging... have to do special things
+ON_MAC=no
+case "${host_os}" in
+    darwin*)
+        ON_MAC=yes
+        ;;
+    *)
+        ;;
+esac
+
 dnl add extra paths to find gcc on RHEL 6 systems
 PATH="/opt/rh/devtoolset-3/root/usr/bin:/usr/local/bin:${PATH}"
+
 dnl add extra paths to find xml headers and X headers on the mac.
-XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include"
+AS_IF([test "$ON_MAC" = "yes"],
+[
+ AC_PATH_PROG(XCRUN, xcrun, noxcrun)
+ AS_IF([test "$ac_cv_path_XCRUN" = "norun"],AC_MSG_ERROR([could not find xcrun - install Xcode command line tools]),[])
+ XCODE_SDK_PATH=`$XCRUN --show-sdk-path`
+ XTRAINCPATHS="-I/usr/X11/include -I${XCODE_SDK_PATH}/usr/include -I${XCODE_SDK_PATH}/usr/include/libxml2"
+],
+[
+ XTRAINCPATHS="-I/usr/include/libxml2/"
+])
 CFLAGS="$CFLAGS $XTRAINCPATHS"
 CPPFLAGS="$CPPFLAGS $XTRAINCPATHS"
 
@@ -217,15 +237,7 @@ AC_PROG_CC
 AC_PROG_CXX
 
 dnl do not test gcc version on mac.  clang as gcc will return version and it's not >= 4.8
-TEST_GCC=yes
-case "${host_os}" in
-    darwin*)
-        TEST_GCC=no
-        ;;
-    *)
-        ;;
-esac
-AS_IF([test "$TEST_GCC" = "yes"],[AX_GCC_VERSION],[])
+AS_IF([test "$ON_MAC" = "no"],[AX_GCC_VERSION],[])
 dnl if the compiler is gcc, test for gcc >= 4.8
 AS_IF([test "x$GCC_VERSION" = "x"],[],
  [AC_MSG_CHECKING([gcc version >= 4.8])

--- a/configure
+++ b/configure
@@ -686,6 +686,7 @@ LDFLAGS
 CFLAGS
 CC
 AWK
+XCRUN
 host_os
 host_vendor
 host_cpu
@@ -2479,8 +2480,71 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
+ON_MAC=no
+case "${host_os}" in
+    darwin*)
+        ON_MAC=yes
+        ;;
+    *)
+        ;;
+esac
+
 PATH="/opt/rh/devtoolset-3/root/usr/bin:/usr/local/bin:${PATH}"
-XTRAINCPATHS="-I/usr/include/libxml2/ -I/usr/X11/include"
+
+if test "$ON_MAC" = "yes"; then :
+
+ # Extract the first word of "xcrun", so it can be a program name with args.
+set dummy xcrun; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_XCRUN+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $XCRUN in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_XCRUN="$XCRUN" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_XCRUN="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_XCRUN" && ac_cv_path_XCRUN="noxcrun"
+  ;;
+esac
+fi
+XCRUN=$ac_cv_path_XCRUN
+if test -n "$XCRUN"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $XCRUN" >&5
+$as_echo "$XCRUN" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+ if test "$ac_cv_path_XCRUN" = "norun"; then :
+  as_fn_error $? "could not find xcrun - install Xcode command line tools" "$LINENO" 5
+fi
+ XCODE_SDK_PATH=`$XCRUN --show-sdk-path`
+ XTRAINCPATHS="-I/usr/X11/include -I${XCODE_SDK_PATH}/usr/include -I${XCODE_SDK_PATH}/usr/include/libxml2"
+
+else
+
+ XTRAINCPATHS="-I/usr/include/libxml2/"
+
+fi
 CFLAGS="$CFLAGS $XTRAINCPATHS"
 CPPFLAGS="$CPPFLAGS $XTRAINCPATHS"
 
@@ -3573,15 +3637,7 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-TEST_GCC=yes
-case "${host_os}" in
-    darwin*)
-        TEST_GCC=no
-        ;;
-    *)
-        ;;
-esac
-if test "$TEST_GCC" = "yes"; then :
+if test "$ON_MAC" = "no"; then :
 
   GCC_VERSION=""
   if test "x$GCC" = "xyes"; then :

--- a/trick_source/data_products/DPX/APPS/FXPLOT/makefile
+++ b/trick_source/data_products/DPX/APPS/FXPLOT/makefile
@@ -23,6 +23,8 @@ endif
 ifeq ($(TRICK_HOST_TYPE), Darwin)
      INCDIRS += -I/usr/X11/include
      XLIBS = -L${MOTIF_HOME}/lib -lXm -L/usr/X11R6/lib ${X_LIB_DIR} -lXt -lX11 -lc++abi
+     SDK_DIR = $(shell xcrun --show-sdk-path)
+     INCDIRS += -I${SDK_DIR}/usr/include/libxml2
 else
      ifneq (${MOTIF_HOME},/usr)
          XLIBS = -L${MOTIF_HOME}/lib64 -L${MOTIF_HOME}/lib

--- a/trick_source/data_products/DPX/APPS/GXPLOT/makefile
+++ b/trick_source/data_products/DPX/APPS/GXPLOT/makefile
@@ -24,6 +24,8 @@ ifeq ($(TRICK_HOST_TYPE), Darwin)
      INCDIRS += -I/usr/X11/include
      MOTIF_INCDIR = -I/sw/include
      XLIBS = -L/usr/X11R6/lib -L/usr/X11/lib -lXt -lX11 ${LIBXML} -lc++abi
+     SDK_DIR = $(shell xcrun --show-sdk-path)
+     INCDIRS += -I${SDK_DIR}/usr/include/libxml2
 else
      XLIBS = -L/usr/X11R6/lib64 -L/usr/X11R6/lib -lXt -lX11 ${LIBXML}
 endif

--- a/trick_source/data_products/DPX/DPC/makefile
+++ b/trick_source/data_products/DPX/DPC/makefile
@@ -31,6 +31,8 @@ ifeq ($(TRICK_HOST_TYPE), Linux)
 endif
 
 ifeq ($(TRICK_HOST_TYPE), Darwin)
+ SDK_DIR = $(shell xcrun --show-sdk-path)
+ INCLUDE_DIRS += -I${SDK_DIR}/usr/include/libxml2
 endif
 
 #############################################################################

--- a/trick_source/data_products/DPX/DPM/makefile
+++ b/trick_source/data_products/DPX/DPM/makefile
@@ -38,6 +38,8 @@ ifeq ($(TRICK_HOST_TYPE), Linux)
 endif
 
 ifeq ($(TRICK_HOST_TYPE), Darwin)
+ SDK_DIR = $(shell xcrun --show-sdk-path)
+ INCLUDE_DIRS += -I${SDK_DIR}/usr/include/libxml2
 endif
 
 #############################################################################


### PR DESCRIPTION
If we are on a Mac, use xcrun to find the standard include directories.
Some of the makefiles in data_products look for libxml2 which requires
them to get the same change as the configure script.