### PR TITLE
Remove suppression of units conversion warnings in 19 #789

### DIFF
--- a/include/trick/IPPython.hh
+++ b/include/trick/IPPython.hh
@@ -88,6 +88,7 @@ namespace Trick {
             int restart() ;
 
         protected :
+            /** TODO: remove units_conversion_msgs in 2021 */
             /** false = see units conversion messages, true = head in sand */
             bool units_conversion_msgs ;
 

--- a/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
@@ -256,10 +256,8 @@ void FieldDescription::parseComment(std::string comment) {
             // map old unit names to new names
             std::string new_units = map_trick_units_to_udunits(units) ;
             if ( units.compare(new_units) ) {
-                if ( ! units_truth_is_scary ) {
-                    std::cout << bold(color(WARNING, "Warning    ") + file_name + ":" + std::to_string(line_no)) << std::endl
-                        << "           Units converted from " << quote(units) << " to " << quote(new_units) << std::endl;
-                }
+                std::cout << bold(color(WARNING, "Warning    ") + file_name + ":" + std::to_string(line_no)) << std::endl
+                    << "           Units converted from " << quote(units) << " to " << quote(new_units) << std::endl;
                 units = new_units ;
             }
             ut_unit * test_units = ut_parse(u_system, units.c_str() , UT_ASCII) ;

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -30,7 +30,8 @@
 /* Command line arguments.  These work better as globals, as suggested in llvm/CommandLine documentation */
 llvm::cl::list<std::string> include_dirs("I", llvm::cl::Prefix, llvm::cl::desc("Include directory"), llvm::cl::value_desc("directory"));
 llvm::cl::list<std::string> defines("D", llvm::cl::Prefix, llvm::cl::desc("Defines"), llvm::cl::value_desc("define"));
-llvm::cl::opt<bool> units_truth_is_scary("units-truth-is-scary", llvm::cl::desc("Don't print units conversion messages"));
+// TODO: remove units_truth_is_scary in 2021.
+llvm::cl::opt<bool> units_truth_is_scary("units-truth-is-scary", llvm::cl::desc("DEPRECATED: Don't print units conversion messages"));
 llvm::cl::opt<bool> sim_services_flag("s", llvm::cl::desc("Gernerate io_src for Trick core headers"));
 llvm::cl::opt<bool> force("f", llvm::cl::desc("Force all io_src files to be generated"));
 llvm::cl::opt<int> attr_version("v", llvm::cl::desc("Select version of attributes to produce.  10 and 13 are valid"), llvm::cl::init(10));

--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -21,6 +21,7 @@
 #include "trick/MemoryManager.hh"
 #include "trick/exec_proto.hh"
 #include "trick/exec_proto.h"
+#include "trick/message_proto.h"
 
 Trick::IPPython * the_pip ;
 
@@ -71,7 +72,9 @@ bool Trick::IPPython::get_units_conversion_msgs() {
 }
 
 void Trick::IPPython::shoot_the_units_conversion_messenger(bool onoff) {
-    units_conversion_msgs = !onoff ;
+    if ( onoff ) {
+        message_publish(MSG_WARNING, "Units conversion messages can no longer be suppressed.\n") ;
+    }
 }
 
 //Initialize and run the Python input processor on the user input file.
@@ -198,14 +201,19 @@ int Trick::IPPython::shutdown() {
     return(0) ;
 }
 
+//TODO: remove units conversion messenger routines in 2021
 void shoot_the_units_conversion_messenger() {
+    message_publish(MSG_WARNING, "shoot_the_units_conversion_messenger() is deprecated\n") ;
     the_pip->shoot_the_units_conversion_messenger(true) ;
 }
 
 void revive_the_units_conversion_messenger() {
+    message_publish(MSG_WARNING, "revive_the_units_conversion_messenger() is deprecated\n") ;
     the_pip->shoot_the_units_conversion_messenger(false) ;
 }
 
 int check_units_conversion_messenger_for_signs_of_life() {
+    message_publish(MSG_WARNING, "check_units_conversion_messenger_for_signs_of_life() is deprecated\n") ;
     return the_pip->get_units_conversion_msgs() ;
 }
+//END TODO:

--- a/trick_source/trick_swig/units_attach.i
+++ b/trick_source/trick_swig/units_attach.i
@@ -51,10 +51,8 @@ PyObject * attach_units(PyObject * in_units_obj , PyObject * in_object) {
                 line_no = PyFrame_GetLineNumber(tstate->frame) ;
 #endif
             }
-            if ( check_units_conversion_messenger_for_signs_of_life() ) {
-                std::cout << "\033[33mUnits converted from [" << in_units << "] to [" << new_units << "] "
-                 << file_name << ":" << line_no << "\033[0m" << std::endl ;
-            }
+            std::cout << "\033[33mUnits converted from [" << in_units << "] to [" << new_units << "] "
+             << file_name << ":" << line_no << "\033[0m" << std::endl ;
             in_units = new_units ;
         }
     }


### PR DESCRIPTION
Removed checks on dead units conversion messenger.  Units conversion
messages cannot be suppressed.  Added deprecated messages to the functions
that modified the message printouts.