### PR TITLE
TRICK_HOST_CPU incorrect with gcc 7 #598

### DIFF
--- a/libexec/trick/pm/gte.pm
+++ b/libexec/trick/pm/gte.pm
@@ -65,7 +65,7 @@ sub gte (@) {
         else {
             $ret = `gcc -dumpversion` ;
         }
-        ($gcc_version) = $ret =~ /(\d+\.\d+)/ ;
+        ($gcc_version) = $ret =~ /(\d+(?:\.\d+)?)/ ;
 
         if ( $system_type eq "Linux" ) {
             $def{"TRICK_HOST_CPU"} = $system_type . "_" . $gcc_version ;


### PR DESCRIPTION
Changed the regular expression that grabs the gcc version to accept
either 1 digit or 2.