### PR TITLE
Don't omit udunits error messages from ut_read_xml

### DIFF
--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -130,7 +130,7 @@ my @exclude_paths      = get_paths("TRICK_EXCLUDE") ;
 my @swig_exclude_paths = get_paths("TRICK_SWIG_EXCLUDE") ;
 my @ext_lib_paths      = get_paths("TRICK_EXT_LIB_DIRS") ;
 
-if ( "$ENV{'TRICK_CFLAGS'} $ENV{'TRICK_CXXFLAGS'}" !~ /DTRICK_VER=/ ) {
+if ( "$ENV{TRICK_CFLAGS} $ENV{TRICK_CXXFLAGS}" !~ /DTRICK_VER=/ ) {
     push @defines , "-DTRICK_VER=$year" ;
 }
 

--- a/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
@@ -23,12 +23,10 @@ static ut_system * get_u_system() {
     ut_system * u_system ;
 
     /* Initialize the udunits-2 library */
-    ut_set_error_message_handler(ut_ignore) ;
     if( (u_system = ut_read_xml( NULL )) == NULL ) {
         std::cerr << "Error initializing udunits-2 unit system" << std::endl ;
         exit(-1);
     }
-    ut_set_error_message_handler(ut_write_to_stderr) ;
 
     return u_system ;
 }

--- a/trick_source/data_products/units/init_units_system.cpp
+++ b/trick_source/data_products/units/init_units_system.cpp
@@ -5,12 +5,10 @@
 ut_system * init_unit_system() {
     ut_system * u_system ;
     /* Initialize the udunits-2 library */
-    ut_set_error_message_handler(ut_ignore) ;
     if( (u_system = ut_read_xml( NULL )) == NULL ) {
         std::cerr << "Error initializing udunits-2 unit system" << std::endl ;
         return NULL ;
     }
-    ut_set_error_message_handler(ut_write_to_stderr) ;
     return u_system ;
 }
 

--- a/trick_source/sim_services/MemoryManager/MemoryManager_ref_assignment.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_ref_assignment.cpp
@@ -395,12 +395,10 @@ ut_system * Trick::MemoryManager::get_unit_system() {
     return Trick::UdUnits::get_u_system() ;
 #else
     /* Initialize the udunits-2 library */
-    ut_set_error_message_handler(ut_ignore) ;
     if( (u_system = ut_read_xml( NULL )) == NULL ) {
         std::cerr << "Error initializing udunits-2 unit system" << std::endl ;
         return -1 ;
     }
-    ut_set_error_message_handler(ut_write_to_stderr) ;
     return u_system ;
 #endif
 }

--- a/trick_source/sim_services/UdUnits/UdUnits.cpp
+++ b/trick_source/sim_services/UdUnits/UdUnits.cpp
@@ -10,12 +10,10 @@ ut_system * Trick::UdUnits::get_u_system() {
 }
 int Trick::UdUnits::read_default_xml() {
     /* Initialize the udunits-2 library */
-    ut_set_error_message_handler(ut_ignore) ;
     if( (u_system = ut_read_xml( NULL )) == NULL ) {
         std::cerr << "Error initializing udunits-2 unit system" << std::endl ;
         return -1 ;
     }
-    ut_set_error_message_handler(ut_write_to_stderr) ;
 
     return 0 ;
 }


### PR DESCRIPTION
The output can be useful in determining what went wrong.
Also, in functions that returned early, the previous message
handler was never restored.

Closes #822