### PR TITLE
Add support for -isystem

### DIFF
--- a/libexec/trick/pm/get_paths.pm
+++ b/libexec/trick/pm/get_paths.pm
@@ -13,7 +13,7 @@ sub get_paths {
 }
 
 sub get_include_paths {
-    return "$ENV{TRICK_CFLAGS} $ENV{TRICK_CXXFLAGS}" =~ /-I(\S+)/g
+    return "$ENV{TRICK_CFLAGS} $ENV{TRICK_CXXFLAGS}" =~ /-(?:I|isystem)(\S+)/g
 }
 
 sub get_defines {

--- a/test/SIM_isystem/S_define
+++ b/test/SIM_isystem/S_define
@@ -1,0 +1,6 @@
+#include "sim_objects/default_trick_sys.sm"
+
+##include "Foo.hh"
+##include "Warning.hh"
+
+class Sandbox : public Trick::SimObject {};

--- a/test/SIM_isystem/S_overrides.mk
+++ b/test/SIM_isystem/S_overrides.mk
@@ -1,0 +1,2 @@
+MODELS := $(CURDIR)/models
+TRICK_CXXFLAGS += -Wall -Wextra -I$(MODELS)/my_code -isystem$(MODELS)/third_party

--- a/test/SIM_isystem/models/my_code/Foo.cpp
+++ b/test/SIM_isystem/models/my_code/Foo.cpp
@@ -1,0 +1,3 @@
+// @trick_link_dependency{Warning.cpp}
+
+#include "Warning.hh"

--- a/test/SIM_isystem/models/my_code/Foo.hh
+++ b/test/SIM_isystem/models/my_code/Foo.hh
@@ -1,0 +1,1 @@
+// @trick_link_dependency{Foo.cpp}

--- a/test/SIM_isystem/models/third_party/Warning.cpp
+++ b/test/SIM_isystem/models/third_party/Warning.cpp
@@ -1,0 +1,1 @@
+#include <Warning.hh>

--- a/test/SIM_isystem/models/third_party/Warning.hh
+++ b/test/SIM_isystem/models/third_party/Warning.hh
@@ -1,0 +1,7 @@
+// @trick_link_dependency{Warning.cpp}
+
+/* This comment has an embedded /*, which causes a warning. */
+
+static void foo() {
+    int i = 1 / 0;
+}

--- a/test/makefile
+++ b/test/makefile
@@ -8,7 +8,6 @@ COMPILE_DIRS = \
 	SIM_python_namespace \
 	SIM_rti \
 	SIM_stls \
-	SIM_target_specific_variables \
 	SIM_test_dp \
 	SIM_test_dr \
 	SIM_test_io \
@@ -20,8 +19,10 @@ COMPILE_DIRS = \
 SIMS_NEEDING_TEST = \
 	SIM_alloc_test \
 	SIM_demo_inputfile \
+	SIM_isystem \
 	SIM_measurement_units \
 	SIM_parse_s_define \
+	SIM_target_specific_variables \
 	SIM_test_abstract \
 	SIM_test_inherit \
 	SIM_test_ip2 \

--- a/trick_source/codegen/Interface_Code_Gen/HeaderSearchDirs.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/HeaderSearchDirs.cpp
@@ -106,10 +106,22 @@ void HeaderSearchDirs::AddUserSearchDirs ( std::vector<std::string> & include_di
         if ( resolved_path != NULL ) {
             //std::cout << "adding resolved_path = " << resolved_path << std::endl ;
             hso.AddPath(resolved_path , clang::frontend::Angled, false, true);
-            // Add the path as a system path as well for those included files that are erroneously in <>
         }
     }
+}
 
+void HeaderSearchDirs::AddSystemSearchDirs ( std::vector<std::string> & isystem_dirs ) {
+    //std::cout << "num isystem dirs " << isystem_dirs.size() << std::endl ;
+    int ii ;
+
+    for  ( ii = 0 ; ii < isystem_dirs.size() ; ii++ ) {
+        //std::cout << "isystem dirs " << isystem_dirs[ii] << std::endl ;
+        char * resolved_path = almostRealPath(isystem_dirs[ii].c_str()) ;
+        if ( resolved_path != NULL ) {
+            //std::cout << "adding resolved_path = " << resolved_path << std::endl ;
+            hso.AddPath(resolved_path , clang::frontend::System, false, true);
+        }
+    }
 }
 
 void HeaderSearchDirs::AddTrickSearchDirs () {
@@ -186,8 +198,10 @@ void HeaderSearchDirs::ApplyHeaderSearchOptions () {
 */
 }
 
-void HeaderSearchDirs::addSearchDirs ( std::vector<std::string> & include_dirs ) {
+void HeaderSearchDirs::addSearchDirs ( std::vector<std::string> & include_dirs,
+                                       std::vector<std::string> & isystem_dirs) {
     AddUserSearchDirs( include_dirs ) ;
+    AddSystemSearchDirs( isystem_dirs ) ;
     AddTrickSearchDirs() ;
     AddCompilerBuiltInSearchDirs() ;
     ApplyHeaderSearchOptions() ;

--- a/trick_source/codegen/Interface_Code_Gen/HeaderSearchDirs.hh
+++ b/trick_source/codegen/Interface_Code_Gen/HeaderSearchDirs.hh
@@ -32,9 +32,11 @@ class HeaderSearchDirs {
                          bool in_sim_services ) ;
 
         /** Add all search directories to the preprocessor.
-            @param include_dirs = directories incuded on the command line
+            @param include_dirs = directories included via -I on the command line
+            @param isystem_dirs = directories included via -isystem on the command line
           */
-        void addSearchDirs ( std::vector<std::string> & include_dirs ) ;
+        void addSearchDirs ( std::vector<std::string> & include_dirs,
+                             std::vector<std::string> & isystem_dirs ) ;
 
         /** Returns true if the path argument is in a user model directory
             @param path = directory path to be checked
@@ -133,8 +135,11 @@ class HeaderSearchDirs {
         /** Adds all of the built-in system paths contained in the TRICK_CXX compiler */
         void AddCompilerBuiltInSearchDirs () ;
 
-        /** Adds all of the paths specified on the command line */
+        /** Adds -I include paths */
         void AddUserSearchDirs ( std::vector<std::string> & include_dirs ) ;
+
+        /** Adds -isystem include paths */
+        void AddSystemSearchDirs ( std::vector<std::string> & isystem_dirs ) ;
 
         /** Adds ${TRICK_HOME}/trick_source to the search directories */
         void AddTrickSearchDirs () ;

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -29,6 +29,7 @@
 
 /* Command line arguments.  These work better as globals, as suggested in llvm/CommandLine documentation */
 llvm::cl::list<std::string> include_dirs("I", llvm::cl::Prefix, llvm::cl::desc("Include directory"), llvm::cl::value_desc("directory"));
+llvm::cl::list<std::string> isystem_dirs("isystem", llvm::cl::Prefix, llvm::cl::desc("Include directory, suppress all warnings"), llvm::cl::value_desc("directory"));
 llvm::cl::list<std::string> defines("D", llvm::cl::Prefix, llvm::cl::desc("Defines"), llvm::cl::value_desc("define"));
 // TODO: remove units_truth_is_scary in 2021.
 llvm::cl::opt<bool> units_truth_is_scary("units-truth-is-scary", llvm::cl::desc("DEPRECATED: Don't print units conversion messages"));
@@ -74,10 +75,6 @@ int main(int argc, char * argv[]) {
      * All other arguments will be ignored.
      */
     llvm::cl::ParseCommandLineOptions(argc, argv);
-
-    /*if (!validAttributesVersion(attr_version)) {
-        return -1;
-    }*/
 
     if (input_file_names.empty()) {
         std::cerr << "No header file specified" << std::endl;
@@ -149,7 +146,7 @@ int main(int argc, char * argv[]) {
 
     // Add all of the include directories to the preprocessor
     HeaderSearchDirs hsd(ci.getPreprocessor().getHeaderSearchInfo(), ci.getHeaderSearchOpts(), pp, sim_services_flag);
-    hsd.addSearchDirs(include_dirs);
+    hsd.addSearchDirs(include_dirs, isystem_dirs);
 
     // Add a preprocessor callback to search for TRICK_ICG
 #if (LIBCLANG_MAJOR > 3) || ((LIBCLANG_MAJOR == 3) && (LIBCLANG_MINOR >= 6))


### PR DESCRIPTION
Behold the beauty of cleaner builds. The included example sim is reduced from 26 warnings to 3.

Closes #407