### PR TITLE
Add debug errno information in the JIT compile

### DIFF
--- a/trick_source/sim_services/JITInputFile/JITInputFile.cpp
+++ b/trick_source/sim_services/JITInputFile/JITInputFile.cpp
@@ -157,8 +157,8 @@ int Trick::JITInputFile::compile(std::string file_name) {
 
     // If the compilation was unsuccessful, exec_terminate
     if ( ret != 0 ) {
-        std::string error_message = "JITInputfile shared library creation failed" ;
-        exec_terminate_with_return(-1 , __FILE__ , __LINE__ , error_message.c_str() ) ;
+        std::string error_message = "JITInputfile shared library creation failed. ret:" + std::to_string(ret) + " errno:"+ strerror(errno);
+        exec_terminate_with_return(-1 , __FILE__ , __LINE__ , error_message.c_str()) ;
     }
 
     // The library compile successfully.  Add library name to map


### PR DESCRIPTION
Show the detail of DIAGNOSTIC: JITInputfile.
In our project, we found there is a chance JIT will intermittently fail on create the child process.
I think it will more convenient to debug when errno message showing on DIAGNOSTIC.