### PR TITLE
Add ability to reset the integrator state

### DIFF
--- a/include/trick/Integrator.hh
+++ b/include/trick/Integrator.hh
@@ -64,6 +64,10 @@ namespace Trick {
            double const* accel, double* velocity, double* position);
 
 #ifndef SWIGPYTHON
+        void state_reset ();
+#endif
+
+#ifndef SWIGPYTHON
         void state_in (double* arg1, va_list argp);
 #endif
         void state_in (double* arg1, ...)
@@ -123,6 +127,7 @@ namespace Trick {
         bool use_deriv2;                  // -- set by integration technique
 
         double dt;               // -- set by IntegLoopSimObject.cpp
+        double **state_origin;
         double *state;
         double **deriv;
         double **deriv2;

--- a/include/trick/Integrator.hh
+++ b/include/trick/Integrator.hh
@@ -127,7 +127,9 @@ namespace Trick {
         bool use_deriv2;                  // -- set by integration technique
 
         double dt;               // -- set by IntegLoopSimObject.cpp
+#ifndef USE_ER7_UTILS_INTEGRATORS
         double **state_origin;
+#endif
         double *state;
         double **deriv;
         double **deriv2;
@@ -150,10 +152,6 @@ namespace Trick {
 
     Integrator* getIntegrator( Integrator_type Alg, unsigned int State_size, double Dt = 0.0 );
 
-//    Integrator* getEr7Integrator(
-//       er7_utils::Integration::Technique, unsigned int State_size, double Dt);
-
-//    void deleteIntegrator( Integrator*&);
 }
 
 #endif

--- a/include/trick/integrator_c_intf.h
+++ b/include/trick/integrator_c_intf.h
@@ -12,6 +12,7 @@ int integrate_1st_order_ode(const double* deriv, double* state);
 int integrate_2nd_order_ode(const double* acc, double* vel, double * pos);
 double get_integ_time(void);
 void set_integ_time(double time_value);
+void reset_state();
 void load_state(double* arg1, ... );
 void load_deriv( double* arg1, ...);
 void load_deriv2( double* arg1, ...);

--- a/trick_source/er7_utils/trick/integration/src/trick_integrator.cc
+++ b/trick_source/er7_utils/trick/integration/src/trick_integrator.cc
@@ -193,7 +193,6 @@ TrickIntegrator::initialize_trick_integrator (
 
    // Allocate space for the Trick::Integrator buffers
    state = alloc::allocate_array (num_state);
-   state_origin = alloc::allocate_array<double*>(num_state);
 
    // Initialize the Trick workspace and the Trick/er7_utils interface.
    initialize_trick_workspace ();
@@ -306,7 +305,6 @@ TrickIntegrator::deallocate_trick_arrays (
    alloc::deallocate_array (deriv);
    alloc::deallocate_array (deriv2);
    alloc::deallocate_array (state_ws);
-   alloc::deallocate_array (state_origin);
 }
 
 

--- a/trick_source/er7_utils/trick/integration/src/trick_integrator.cc
+++ b/trick_source/er7_utils/trick/integration/src/trick_integrator.cc
@@ -193,6 +193,7 @@ TrickIntegrator::initialize_trick_integrator (
 
    // Allocate space for the Trick::Integrator buffers
    state = alloc::allocate_array (num_state);
+   state_origin = alloc::allocate_array<double*>(num_state);
 
    // Initialize the Trick workspace and the Trick/er7_utils interface.
    initialize_trick_workspace ();
@@ -209,6 +210,7 @@ TrickIntegrator::initialize_trick_workspace (
    deriv    = alloc::allocate_array<double*> (buf_size);
    deriv2   = alloc::allocate_array<double*> (buf_size);
    state_ws = alloc::allocate_array<double*> (buf_size);
+
    for (unsigned int ii = 0; ii < buf_size; ++ii) {
       deriv[ii]    = er7_deriv;
       deriv2[ii]   = er7_deriv2;
@@ -304,6 +306,7 @@ TrickIntegrator::deallocate_trick_arrays (
    alloc::deallocate_array (deriv);
    alloc::deallocate_array (deriv2);
    alloc::deallocate_array (state_ws);
+   alloc::deallocate_array (state_origin);
 }
 
 

--- a/trick_source/sim_services/Integrator/src/Integrator.cpp
+++ b/trick_source/sim_services/Integrator/src/Integrator.cpp
@@ -19,6 +19,7 @@ Trick::Integrator::Integrator() {
    deriv = NULL;
    deriv2 = NULL;
    state_ws = NULL;
+   state_origin = NULL;
    time = 0.0;
    time_0 = 0.0;
    verbosity = 0 ;
@@ -85,17 +86,39 @@ int Trick::Integrator::integrate_2nd_order_ode (
     return rc;
 }
 
-void Trick::Integrator::state_in (double* arg1, va_list argp) {
-    int i = 0;
-    double* next_arg = arg1;
-    if (verbosity) message_publish(MSG_DEBUG, "LOAD STATE: ");
-    while (next_arg != (double*) NULL) { 
-        state[i] = *next_arg;
-        if (verbosity) message_publish(MSG_DEBUG,"  %g", *next_arg);
-        next_arg = va_arg(argp, double*);
-        i++;
+void Trick::Integrator::state_reset () {
+
+    if (intermediate_step == 0) {
+        int i = 0;
+        double* next_arg = state_origin[i];
+        if (verbosity) std::cout << "RESET STATE: \n";
+        while (next_arg != (double*) NULL) {
+            *next_arg = state[i];
+            if (verbosity) std::cout << "  " << *next_arg << "\n";
+            i++;
+            next_arg = state_origin[i];
+        }
+        if (verbosity) std::cout << std::endl;
     }
-    if (verbosity) message_publish(MSG_DEBUG,"\n");
+}
+
+void Trick::Integrator::state_in (double* arg1, va_list argp) {
+
+    if (intermediate_step == 0) {
+        int i = 0;
+        double* next_arg = arg1;
+        state_origin[i] = next_arg;
+        if (verbosity) std::cout << "LOAD STATE: \n";
+        while (next_arg != (double*) NULL) { 
+            state_origin[i] = next_arg;
+            state[i] = *next_arg;
+            if (verbosity) std::cout << "  " << *next_arg << "\n";
+            next_arg = va_arg(argp, double*);
+            i++;
+        }
+        state_origin[i] = (double*)NULL;
+        if (verbosity) std::cout << std::endl;
+    }
 }
 
 void Trick::Integrator::state_in (double* arg1, ...) {

--- a/trick_source/sim_services/Integrator/src/Integrator.cpp
+++ b/trick_source/sim_services/Integrator/src/Integrator.cpp
@@ -19,7 +19,9 @@ Trick::Integrator::Integrator() {
    deriv = NULL;
    deriv2 = NULL;
    state_ws = NULL;
+#ifndef USE_ER7_UTILS_INTEGRATORS
    state_origin = NULL;
+#endif
    time = 0.0;
    time_0 = 0.0;
    verbosity = 0 ;
@@ -87,7 +89,8 @@ int Trick::Integrator::integrate_2nd_order_ode (
 }
 
 void Trick::Integrator::state_reset () {
-
+#ifdef USE_ER7_UTILS_INTEGRATORS
+#else
     if (intermediate_step == 0) {
         int i = 0;
         double* next_arg = state_origin[i];
@@ -100,10 +103,24 @@ void Trick::Integrator::state_reset () {
         }
         if (verbosity) std::cout << std::endl;
     }
+#endif
 }
 
+#ifdef USE_ER7_UTILS_INTEGRATORS
 void Trick::Integrator::state_in (double* arg1, va_list argp) {
-
+    int i = 0;
+    double* next_arg = arg1;
+    if (verbosity) message_publish(MSG_DEBUG, "LOAD STATE: ");
+    while (next_arg != (double*) NULL) { 
+        state[i] = *next_arg;
+        if (verbosity) message_publish(MSG_DEBUG, "  %g", *next_arg);
+        next_arg = va_arg(argp, double*);
+        i++;
+    }
+    if (verbosity) message_publish(MSG_DEBUG, "\n");
+}
+#else
+void Trick::Integrator::state_in (double* arg1, va_list argp) {
     if (intermediate_step == 0) {
         int i = 0;
         double* next_arg = arg1;
@@ -120,6 +137,7 @@ void Trick::Integrator::state_in (double* arg1, va_list argp) {
         if (verbosity) std::cout << std::endl;
     }
 }
+#endif
 
 void Trick::Integrator::state_in (double* arg1, ...) {
     va_list argp;

--- a/trick_source/sim_services/Integrator/src/Integrator_C_Intf.cpp
+++ b/trick_source/sim_services/Integrator/src/Integrator_C_Intf.cpp
@@ -29,6 +29,10 @@ extern "C" void set_integ_time(double time_value) {
     trick_curr_integ->time = time_value;
 }
 
+extern "C" void reset_state() {
+    trick_curr_integ->state_reset();
+}
+
 extern "C" void load_state(double* arg1, ... ) {
     va_list argp;
     if (trick_curr_integ != NULL) {

--- a/trick_source/sim_services/Integrator/src/Integrator_C_Intf.cpp
+++ b/trick_source/sim_services/Integrator/src/Integrator_C_Intf.cpp
@@ -30,7 +30,10 @@ extern "C" void set_integ_time(double time_value) {
 }
 
 extern "C" void reset_state() {
+#ifdef USE_ER7_UTILS_INTEGRATORS
+#else
     trick_curr_integ->state_reset();
+#endif
 }
 
 extern "C" void load_state(double* arg1, ... ) {

--- a/trick_source/sim_services/Integrator/trick_algorithms/ABM_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/ABM_Integrator.cpp
@@ -11,6 +11,9 @@ void Trick::ABM_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -45,6 +48,8 @@ Trick::ABM_Integrator::ABM_Integrator(int State_size, double Dt) {
 Trick::ABM_Integrator::~ABM_Integrator() {
 
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     if (state) INTEG_FREE(state);
 

--- a/trick_source/sim_services/Integrator/trick_algorithms/Euler_Cromer_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/Euler_Cromer_Integrator.cpp
@@ -13,6 +13,9 @@ void Trick::Euler_Cromer_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -50,6 +53,8 @@ Trick::Euler_Cromer_Integrator::~Euler_Cromer_Integrator() {
 
     const int n_steps = 1;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/Euler_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/Euler_Integrator.cpp
@@ -15,6 +15,9 @@ void Trick::Euler_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state = INTEG_ALLOC( double, num_state );
 
@@ -40,6 +43,7 @@ Trick::Euler_Integrator::Euler_Integrator(int State_size, double Dt) {
  */
 Trick::Euler_Integrator::~Euler_Integrator() {
 
+    if (state_origin) INTEG_FREE(state_origin);
     if (state) INTEG_FREE(state);
     if (deriv[0]) INTEG_FREE(deriv[0]);
     if (deriv) INTEG_FREE(deriv);

--- a/trick_source/sim_services/Integrator/trick_algorithms/MM4_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/MM4_Integrator.cpp
@@ -12,6 +12,9 @@ void Trick::MM4_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -43,6 +46,8 @@ Trick::MM4_Integrator::~MM4_Integrator() {
 
     const int n_steps = 3;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/NL2_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/NL2_Integrator.cpp
@@ -13,6 +13,9 @@ void Trick::NL2_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -44,6 +47,8 @@ Trick::NL2_Integrator::~NL2_Integrator() {
 
     const int n_steps = 2;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/RK2_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/RK2_Integrator.cpp
@@ -14,6 +14,9 @@ void Trick::RK2_Integrator::initialize(int State_size, double Dt) {
     num_state = State_size;
     dt = Dt;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -45,6 +48,8 @@ Trick::RK2_Integrator::~RK2_Integrator() {
 
     const int n_steps = 2;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/RK4_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/RK4_Integrator.cpp
@@ -12,6 +12,9 @@ void Trick::RK4_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -43,6 +46,8 @@ Trick::RK4_Integrator::~RK4_Integrator() {
 
     const int n_steps = 4;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/RKF45_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/RKF45_Integrator.cpp
@@ -12,6 +12,9 @@ void Trick::RKF45_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -43,6 +46,8 @@ Trick::RKF45_Integrator::~RKF45_Integrator() {
 
     const int n_steps = 6;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/RKF78_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/RKF78_Integrator.cpp
@@ -12,6 +12,9 @@ void Trick::RKF78_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -43,6 +46,8 @@ Trick::RKF78_Integrator::~RKF78_Integrator() {
 
     const int n_steps = 12;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);

--- a/trick_source/sim_services/Integrator/trick_algorithms/RKG4_Integrator.cpp
+++ b/trick_source/sim_services/Integrator/trick_algorithms/RKG4_Integrator.cpp
@@ -12,6 +12,9 @@ void Trick::RKG4_Integrator::initialize(int State_size, double Dt) {
     dt = Dt;
     num_state = State_size;
 
+    state_origin =  INTEG_ALLOC( double*, num_state );
+    state_origin[0] = (double*)NULL;
+
     /** Allocate the state vector.*/
     state =  INTEG_ALLOC( double, num_state );
 
@@ -44,6 +47,8 @@ Trick::RKG4_Integrator::~RKG4_Integrator() {
 
     const int n_steps = 4;
     int i;
+
+    if (state_origin) INTEG_FREE(state_origin);
 
     /** Free the state vector.*/
     if (state) INTEG_FREE(state);


### PR DESCRIPTION
# Add Ability to Reset Integrator State

### **NOTE:**

The new state_reset() member function, will only work when Trick is configured to use Trick::Integrator's, that is when configured with ```--disable-er7utils```.

state\_reset() does nothing when Trick is configured with ```--enable-er7utils```, because er7_utils::TrickIntegrator overwrites the state[] array which holds the initial state vector. 


### include/trick/Integrator.hh

* Add ```state_origin``` data member (a pointer to an array of pointers to double) to class Integrator.
* Add member function ```state_reset()``` to the Integrator class.
    * This function ‘undoes’ the last integration of the integrator. It resets the integrator state (and the simulation variables from whence it came) back to its initial state. NOTE: The pointers to the simulation state variables are stored in the new ```state_origin``` array. This array is populated in member function ```Trick::Integrator::state_in()``` (see below).

### include/trick/integrator\_c\_intf.h
* Add C-interface function ```reset_state()```. This function "undoes" the last integration of the current integrator.

### trick\_source/sim_services/Integrator/src/Integrator.cpp
* Implement : ```void Trick::Integrator::state_reset ()``` (described above)
* Modify ```Trick::Integrator::state_in()``` to:
    * Only load the ```state[]``` array when ```(intermediate_step == 0)```.
        * NOTE: The values of ```state[]``` are not needed beyond the initialization of ```state_ws[][]```, when ```(intermediate_step == 0)```. Therefore, overwriting ```state[]``` when (intermediate_step > 0) is not only pointless, it’s destructive. It needlessly destroys a record of the initial (pre-integration) state. Here we are fixing that.
    * Save pointers to simulation state variables into ```state_origin[]```.

### trick\_source/sim_services/Integrator/src/Integrator\_C\_Intf.cpp
* Implement the C-interface function ```reset_state()```.

### Integrator Algorithms
* In each of the derived Integrator classes enumerated below
    * Allocate ```state_origin[]``` in the constructor.
    * Deallocate ```state_origin[]``` in the destructor.

1. ```trick_source/sim_services/Integrator/trick_algorithms/ABM_Integrator.cpp```
2. ```trick_source/sim_services/Integrator/trick_algorithms/Euler_Cromer_Integrator.cpp```
3. 	```trick_source/sim_services/Integrator/trick_algorithms/Euler_Integrator.cpp```
4. ```trick_source/sim_services/Integrator/trick_algorithms/MM4_Integrator.cpp```
5. ```trick_source/sim_services/Integrator/trick_algorithms/NL2_Integrator.cpp```
6. 	```trick_source/sim_services/Integrator/trick_algorithms/RK2_Integrator.cpp```
7. 	```trick_source/sim_services/Integrator/trick_algorithms/RK4_Integrator.cpp```
8. ```trick_source/sim_services/Integrator/trick_algorithms/RKF45_Integrator.cpp```
9. ```trick_source/sim_services/Integrator/trick_algorithms/RKF78_Integrator.cpp```
10. ```trick_source/sim_services/Integrator/trick_algorithms/RKG4_Integrator.cpp```

