### PR TITLE
ICG won't build with LLVM 10.0 #976

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/CMakeLists.txt
+++ b/trick_source/codegen/Interface_Code_Gen/CMakeLists.txt
@@ -31,6 +31,7 @@ target_compile_options( trick-ICG PUBLIC -DLIBCLANG_MAJOR=${LLVM_VERSION_MAJOR} 
 target_include_directories( trick-ICG PUBLIC ${UDUNITS2_INCLUDES} )
 target_include_directories( trick-ICG PUBLIC ${LLVM_INCLUDE_DIRS} )
 set_property(SOURCE trick-ICG APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/include/mongoose/mongoose.h)
+set_target_properties( trick-ICG PROPERTIES CXX_STANDARD 14)
 
 target_link_libraries( trick-ICG
     -lclangFrontend

--- a/trick_source/codegen/Interface_Code_Gen/makefile
+++ b/trick_source/codegen/Interface_Code_Gen/makefile
@@ -2,13 +2,20 @@ TRICK_HOME := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../..)
 # The config_${HOST_TYPE}.mk file provides LLVM_HOME
 include ${TRICK_HOME}/share/trick/makefiles/Makefile.common
 
-CXXFLAGS := -g -I$(shell $(LLVM_HOME)/bin/llvm-config --includedir) -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-rtti $(UDUNITS_INCLUDES) -std=c++11
+CXXFLAGS := -g -I$(shell $(LLVM_HOME)/bin/llvm-config --includedir) -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fno-rtti $(UDUNITS_INCLUDES)
 
 CLANG_MAJOR := $(shell $(LLVM_HOME)/bin/llvm-config --version | cut -f1 -d.)
 CLANG_MINOR := $(shell $(LLVM_HOME)/bin/llvm-config --version | cut -f2 -d.)
 CLANG_PATCHLEVEL := $(shell $(LLVM_HOME)/bin/llvm-config --version | cut -f3 -d.)
 # check to see if version is greater than 3.5
 CLANG_MINOR_GTEQ5 := $(shell [ $(CLANG_MAJOR) -gt 3 -o \( $(CLANG_MAJOR) -eq 3 -a $(CLANG_MINOR) -ge 5 \) ] && echo 1)
+
+CLANG_MAJOR_GTEQ10 := $(shell [ $(CLANG_MAJOR) -ge 10 ] && echo 1)
+ifeq ($(CLANG_MAJOR_GTEQ10),1)
+CXXFLAGS += -std=c++14
+else
+CXXFLAGS += -std=c++11
+endif
 
 LLVMLDFLAGS := $(shell $(LLVM_HOME)/bin/llvm-config --ldflags) $(UDUNITS_LDFLAGS)
 


### PR DESCRIPTION
As usual a new LLVM version brings changes.  Found that ICG needs
to be built with c++14.  Also found a couple of API changes in main.
Enclosed the changes in ifdef statements.