### PR TITLE
Ubuntu 20.04, Python 3.8, and improved python configuration in configure.ac

### DIFF
--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -414,7 +414,7 @@ AC_ARG_WITH(
           [test "$ac_cv_path_PYTHON3" = "nopython3"],
           AC_MSG_ERROR([could not find python or python3]),
           [
-            AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config)
+            AC_PATH_PROG(PYTHON_CONFIG, ${PYTHON3}-config, nopython-config)
             AS_IF(
               [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
               [
@@ -423,7 +423,7 @@ AC_ARG_WITH(
                 AS_IF(
                   [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
                   [
-                    AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config)
+                    AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config)
                     AS_IF(
                       [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
                       AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -405,6 +405,10 @@ AC_ARG_WITH(
   ]
 )
 
+AC_SUBST([PYTHON_CPPFLAGS])
+AC_SUBST([PYTHON_LIBS])
+AC_SUBST([PYTHON_EXTRA_LIBS])
+
 AC_PATH_PROG(GNUPLOT, gnuplot, nognuplot)
 AS_IF([test "$ac_cv_path_GNUPLOT" = "nognuplot"],AC_MSG_NOTICE([could not find gnuplot]),[])
 AX_SWIG_BIN([])

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -381,9 +381,7 @@ AC_ARG_WITH(
       [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
       AC_MSG_ERROR([could not find python<major>-config python<major.minor>-config or python-config in the specified path. Please install the python development package]),
       []
-    )  
-    PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
-    PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
+    )
   ],
   [
     AC_PATH_PROGS(PYTHON, python${PYTHON_VERSION} python python3, nopython)
@@ -400,10 +398,20 @@ AC_ARG_WITH(
       AC_MSG_ERROR([could not find python<major>-config python<major.minor>-config or python-config. Please install the python development package]),
       []
     )  
-    PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
-    PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
   ]
 )
+
+PYTHON_LIBS_COMMAND="${PYTHON_CONFIG} --libs"
+
+AX_COMPARE_VERSION(
+  [${PYTHON_MAJORMINOR}],
+  [ge],
+  [3.8],
+  [PYTHON_LIBS_COMMAND="${PYTHON_LIBS_COMMAND} --embed"]
+)
+
+PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
+PYTHON_LIBS=`${PYTHON_LIBS_COMMAND}`
 
 AC_SUBST([PYTHON_CPPFLAGS])
 AC_SUBST([PYTHON_LIBS])

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -368,81 +368,41 @@ AC_ARG_WITH(
   ),
   [
     PYTHON_HOME="$withval"
-    AC_PATH_PROG(PYTHON, python${PYTHON_VERSION}, nopython, "$PYTHON_HOME")
+    AC_PATH_PROGS(PYTHON, python${PYTHON_VERSION} python python3, nopython, "$PYTHON_HOME")
     AS_IF(
       [test "$ac_cv_path_PYTHON" = "nopython"],
-      [
-	    AC_PATH_PROG(PYTHON, python, nopython, "$PYTHON_HOME")
-	    AS_IF(
-	      [test "$ac_cv_path_PYTHON" = "nopython"],
-          AC_MSG_ERROR([could not find python<version> or python in specified path]),
-          []
-        )
-      ],
+      AC_MSG_ERROR([could not find python<version> python or python3 in the specefied path. Please install the python development package]),
       []
     )
-    AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config, "$PYTHON_HOME")
+    PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[[0]])+"."+str(sys.version_info[[1]]))'`
+    PYTHON_MAJOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[[0]]))'`
+    AC_PATH_PROGS(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config python${PYTHON_MAJOR}-config python${PYTHON_VERSION}-config python-config, nopython-config, "$PYTHON_HOME")
     AS_IF(
       [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-      [
-        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[[0]])+"."+str(sys.version_info[[1]]))'`
-        AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config, "$PYTHON_HOME")
-        AS_IF(
-          [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-          [
-            AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config, "$PYTHON_HOME")
-            AS_IF(
-              [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-              AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
-              []
-            )
-          ]
-        )
-      ],
+      AC_MSG_ERROR([could not find python<major>-config python<major.minor>-config or python-config in the specified path. Please install the python development package]),
       []
-    )    
+    )  
     PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
     PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
   ],
   [
-    AC_PATH_PROG(PYTHON, python${PYTHON_VERSION}, nopython)
+    AC_PATH_PROGS(PYTHON, python${PYTHON_VERSION} python python3, nopython)
     AS_IF(
       [test "$ac_cv_path_PYTHON" = "nopython"],
-      [
-        AC_PATH_PROG(PYTHON3, python3, nopython3)
-        AS_IF(
-          [test "$ac_cv_path_PYTHON3" = "nopython3"],
-          AC_MSG_ERROR([could not find python or python3]),
-          [
-            AC_PATH_PROG(PYTHON_CONFIG, python3-config, nopython-config)
-            AS_IF(
-              [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-              [
-                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info[[0]])+"."+str(sys.version_info[[1]]))'`
-                AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config)
-                AS_IF(
-                  [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-                  [
-                    AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config)
-                    AS_IF(
-                      [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-                      AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
-                      []
-                    )
-                  ]
-                )
-             ],
-             []
-            )    
-            PYTHON_CPPFLAGS=`${PYTHON-CONFIG} --includes`
-            PYTHON_LIBS=`${PYTHON-CONFIG} --ldflags`
-            PYTHON=$PYTHON3
-          ]
-        )
-      ],
-      [AX_PYTHON_DEVEL([>='2.5'])]
+      AC_MSG_ERROR([could not find python<version> python or python3. Please install the python development package]),
+      []
     )
-  ] 
+    PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[[0]])+"."+str(sys.version_info[[1]]))'`
+    PYTHON_MAJOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[[0]]))'`
+    AC_PATH_PROGS(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config python${PYTHON_MAJOR}-config python${PYTHON_VERSION}-config python-config, nopython-config)
+    AS_IF(
+      [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+      AC_MSG_ERROR([could not find python<major>-config python<major.minor>-config or python-config. Please install the python development package]),
+      []
+    )  
+    PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
+    PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
+  ]
 )
 
 AC_PATH_PROG(GNUPLOT, gnuplot, nognuplot)

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -372,9 +372,9 @@ AC_ARG_WITH(
     AS_IF(
       [test "$ac_cv_path_PYTHON" = "nopython"],
       [
-	       AC_PATH_PROG(PYTHON, python, nopython, "$PYTHON_HOME")
-	       AS_IF(
-	         [test "$ac_cv_path_PYTHON" = "nopython"],
+	    AC_PATH_PROG(PYTHON, python, nopython, "$PYTHON_HOME")
+	    AS_IF(
+	      [test "$ac_cv_path_PYTHON" = "nopython"],
           AC_MSG_ERROR([could not find python<version> or python in specified path]),
           []
         )
@@ -385,11 +385,18 @@ AC_ARG_WITH(
     AS_IF(
       [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
       [
-         AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config, "$PYTHON_HOME")
-         AS_IF(
-           [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-          AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
-          []
+        PYTHON_MAJORMINOR = `${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+        AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config, "$PYTHON_HOME")
+        AS_IF(
+          [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+          [
+            AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config, "$PYTHON_HOME")
+            AS_IF(
+              [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+              AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
+              []
+            )
+          ]
         )
       ],
       []
@@ -399,25 +406,34 @@ AC_ARG_WITH(
   ],
   [
     AC_PATH_PROG(PYTHON, python${PYTHON_VERSION}, nopython)
-    AS_IF([test "$ac_cv_path_PYTHON" = "nopython"],
+    AS_IF(
+      [test "$ac_cv_path_PYTHON" = "nopython"],
       [
         AC_PATH_PROG(PYTHON3, python3, nopython3)
-        AS_IF([test "$ac_cv_path_PYTHON3" = "nopython3"],
+        AS_IF(
+          [test "$ac_cv_path_PYTHON3" = "nopython3"],
           AC_MSG_ERROR([could not find python or python3]),
           [
-		    AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config)
-		    AS_IF(
-		      [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-		      [
-		         AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config)
-		         AS_IF(
-		           [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
-		          AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
-		          []
-		        )
-		      ],
-		      []
-		    )  
+            AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config)
+            AS_IF(
+              [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+              [
+                PYTHON_MAJORMINOR = `${PYTHON3} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+                AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config)
+                AS_IF(
+                  [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+                  [
+                    AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config)
+                    AS_IF(
+                      [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+                      AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
+                      []
+                    )
+                  ]
+                )
+             ],
+             []
+            )    
             PYTHON_CPPFLAGS=`${PYTHON-CONFIG} --includes`
             PYTHON_LIBS=`${PYTHON-CONFIG} --ldflags`
             PYTHON=$PYTHON3

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -385,7 +385,7 @@ AC_ARG_WITH(
     AS_IF(
       [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
       [
-        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[[0]])+"."+str(sys.version_info[[1]]))'`
         AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config, "$PYTHON_HOME")
         AS_IF(
           [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
@@ -418,7 +418,7 @@ AC_ARG_WITH(
             AS_IF(
               [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
               [
-                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info[[0]])+"."+str(sys.version_info[[1]]))'`
                 AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config)
                 AS_IF(
                   [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -405,8 +405,21 @@ AC_ARG_WITH(
         AS_IF([test "$ac_cv_path_PYTHON3" = "nopython3"],
           AC_MSG_ERROR([could not find python or python3]),
           [
-            PYTHON_CPPFLAGS=`${PYTHON3}-config --includes`
-            PYTHON_LIBS=`${PYTHON3}-config --ldflags`
+		    AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config)
+		    AS_IF(
+		      [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+		      [
+		         AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config)
+		         AS_IF(
+		           [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
+		          AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
+		          []
+		        )
+		      ],
+		      []
+		    )  
+            PYTHON_CPPFLAGS=`${PYTHON-CONFIG} --includes`
+            PYTHON_LIBS=`${PYTHON-CONFIG} --ldflags`
             PYTHON=$PYTHON3
           ]
         )

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -418,7 +418,7 @@ AC_ARG_WITH(
             AS_IF(
               [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
               [
-                PYTHON_MAJORMINOR = `${PYTHON3} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
                 AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config)
                 AS_IF(
                   [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -385,7 +385,7 @@ AC_ARG_WITH(
     AS_IF(
       [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
       [
-        PYTHON_MAJORMINOR = `${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
         AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_MAJORMINOR}-config, nopython-config, "$PYTHON_HOME")
         AS_IF(
           [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],

--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -390,7 +390,7 @@ AC_ARG_WITH(
         AS_IF(
           [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
           [
-            AC_PATH_PROG(PYTHON_CONFIG, python${PYTHON_VERSION}-config, nopython-config, "$PYTHON_HOME")
+            AC_PATH_PROG(PYTHON_CONFIG, python-config, nopython-config, "$PYTHON_HOME")
             AS_IF(
               [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
               AC_MSG_ERROR([could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev]),
@@ -414,7 +414,7 @@ AC_ARG_WITH(
           [test "$ac_cv_path_PYTHON3" = "nopython3"],
           AC_MSG_ERROR([could not find python or python3]),
           [
-            AC_PATH_PROG(PYTHON_CONFIG, ${PYTHON3}-config, nopython-config)
+            AC_PATH_PROG(PYTHON_CONFIG, python3-config, nopython-config)
             AS_IF(
               [test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"],
               [

--- a/configure
+++ b/configure
@@ -651,13 +651,6 @@ SWIG_LIB
 SWIG
 SWIG_BIN
 GNUPLOT
-PYTHON_EXTRA_LDFLAGS
-PYTHON_EXTRA_LIBS
-PYTHON_SITE_PKG
-PYTHON_LIBS
-PYTHON_CPPFLAGS
-PYTHON_VERSION
-PYTHON3
 PYTHON_CONFIG
 PYTHON
 PERL_VERSION
@@ -775,7 +768,6 @@ CCC
 CXXCPP
 CC
 CFLAGS
-PYTHON_VERSION
 JAVA_CC
 JAVA_CC_FLAGS
 CPP'
@@ -1445,10 +1437,6 @@ Some influential environment variables:
   CXXCPP      C++ preprocessor
   CC          C compiler command
   CFLAGS      C compiler flags
-  PYTHON_VERSION
-              The installed Python version to use, for example '2.3'. This
-              string will be appended to the Python interpreter canonical
-              name.
   JAVA_CC     java compiler command
   JAVA_CC_FLAGS
               java compiler flags
@@ -5368,13 +5356,14 @@ fi
 
 
 
-
 # Check whether --with-python was given.
 if test "${with_python+set}" = set; then :
   withval=$with_python;
     PYTHON_HOME="$withval"
-    # Extract the first word of "python${PYTHON_VERSION}", so it can be a program name with args.
-set dummy python${PYTHON_VERSION}; ac_word=$2
+    for ac_prog in python${PYTHON_VERSION} python python3
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON+:} false; then :
@@ -5400,7 +5389,6 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_path_PYTHON" && ac_cv_path_PYTHON="nopython"
   ;;
 esac
 fi
@@ -5413,57 +5401,20 @@ else
 $as_echo "no" >&6; }
 fi
 
+
+  test -n "$PYTHON" && break
+done
+test -n "$PYTHON" || PYTHON="nopython"
 
     if test "$ac_cv_path_PYTHON" = "nopython"; then :
-
-	    # Extract the first word of "python", so it can be a program name with args.
-set dummy python; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON="$PYTHON" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in "$PYTHON_HOME"
+  as_fn_error $? "could not find python<version> python or python3 in the specefied path. Please install the python development package" "$LINENO" 5
+fi
+    PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+    PYTHON_MAJOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0]))'`
+    for ac_prog in python${PYTHON_MAJORMINOR}-config python${PYTHON_MAJOR}-config python${PYTHON_VERSION}-config python-config
 do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_PYTHON" && ac_cv_path_PYTHON="nopython"
-  ;;
-esac
-fi
-PYTHON=$ac_cv_path_PYTHON
-if test -n "$PYTHON"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
-$as_echo "$PYTHON" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-	    if test "$ac_cv_path_PYTHON" = "nopython"; then :
-  as_fn_error $? "could not find python<version> or python in specified path" "$LINENO" 5
-fi
-
-fi
-    # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
-set dummy python${PYTHON_VERSION}-config; ac_word=$2
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
@@ -5489,7 +5440,6 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
   ;;
 esac
 fi
@@ -5502,109 +5452,23 @@ else
 $as_echo "no" >&6; }
 fi
 
+
+  test -n "$PYTHON_CONFIG" && break
+done
+test -n "$PYTHON_CONFIG" || PYTHON_CONFIG="nopython-config"
 
     if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
-
-        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
-        # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
-set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in "$PYTHON_HOME"
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
-  ;;
-esac
-fi
-PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
-if test -n "$PYTHON_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
-$as_echo "$PYTHON_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-        if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
-
-            # Extract the first word of "python-config", so it can be a program name with args.
-set dummy python-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in "$PYTHON_HOME"
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
-  ;;
-esac
-fi
-PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
-if test -n "$PYTHON_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
-$as_echo "$PYTHON_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-            if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
-  as_fn_error $? "could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev" "$LINENO" 5
-fi
-
-
-fi
-
+  as_fn_error $? "could not find python<major>-config python<major.minor>-config or python-config in the specified path. Please install the python development package" "$LINENO" 5
 fi
     PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
     PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
 
 else
 
-    # Extract the first word of "python${PYTHON_VERSION}", so it can be a program name with args.
-set dummy python${PYTHON_VERSION}; ac_word=$2
+    for ac_prog in python${PYTHON_VERSION} python python3
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON+:} false; then :
@@ -5630,7 +5494,6 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_path_PYTHON" && ac_cv_path_PYTHON="nopython"
   ;;
 esac
 fi
@@ -5643,56 +5506,20 @@ else
 $as_echo "no" >&6; }
 fi
 
+
+  test -n "$PYTHON" && break
+done
+test -n "$PYTHON" || PYTHON="nopython"
 
     if test "$ac_cv_path_PYTHON" = "nopython"; then :
-
-        # Extract the first word of "python3", so it can be a program name with args.
-set dummy python3; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON3 in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON3="$PYTHON3" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
+  as_fn_error $? "could not find python<version> python or python3. Please install the python development package" "$LINENO" 5
+fi
+    PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
+    PYTHON_MAJOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0]))'`
+    for ac_prog in python${PYTHON_MAJORMINOR}-config python${PYTHON_MAJOR}-config python${PYTHON_VERSION}-config python-config
 do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON3="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_PYTHON3" && ac_cv_path_PYTHON3="nopython3"
-  ;;
-esac
-fi
-PYTHON3=$ac_cv_path_PYTHON3
-if test -n "$PYTHON3"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON3" >&5
-$as_echo "$PYTHON3" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-        if test "$ac_cv_path_PYTHON3" = "nopython3"; then :
-  as_fn_error $? "could not find python or python3" "$LINENO" 5
-else
-
-            # Extract the first word of "python3-config", so it can be a program name with args.
-set dummy python3-config; ac_word=$2
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
@@ -5718,7 +5545,6 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
   ;;
 esac
 fi
@@ -5732,459 +5558,15 @@ $as_echo "no" >&6; }
 fi
 
 
-            if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
-
-                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
-                # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
-set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
+  test -n "$PYTHON_CONFIG" && break
 done
-  done
-IFS=$as_save_IFS
+test -n "$PYTHON_CONFIG" || PYTHON_CONFIG="nopython-config"
 
-  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
-  ;;
-esac
+    if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+  as_fn_error $? "could not find python<major>-config python<major.minor>-config or python-config. Please install the python development package" "$LINENO" 5
 fi
-PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
-if test -n "$PYTHON_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
-$as_echo "$PYTHON_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-                if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
-
-                    # Extract the first word of "python-config", so it can be a program name with args.
-set dummy python-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
-  ;;
-esac
-fi
-PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
-if test -n "$PYTHON_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
-$as_echo "$PYTHON_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-                    if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
-  as_fn_error $? "could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev" "$LINENO" 5
-fi
-
-
-fi
-
-fi
-            PYTHON_CPPFLAGS=`${PYTHON-CONFIG} --includes`
-            PYTHON_LIBS=`${PYTHON-CONFIG} --ldflags`
-            PYTHON=$PYTHON3
-
-
-fi
-
-else
-
-	#
-	# Allow the use of a (user set) custom python version
-	#
-
-
-	# Extract the first word of "python[$PYTHON_VERSION]", so it can be a program name with args.
-set dummy python$PYTHON_VERSION; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PYTHON+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $PYTHON in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PYTHON="$PYTHON" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-PYTHON=$ac_cv_path_PYTHON
-if test -n "$PYTHON"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
-$as_echo "$PYTHON" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-	if test -z "$PYTHON"; then
-	   as_fn_error $? "Cannot find python$PYTHON_VERSION in your system path" "$LINENO" 5
-	   PYTHON_VERSION=""
-	fi
-
-	#
-	# Check for a version of Python >= 2.1.0
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a version of Python >= '2.1.0'" >&5
-$as_echo_n "checking for a version of Python >= '2.1.0'... " >&6; }
-	ac_supports_python_ver=`$PYTHON -c "import sys; \
-		ver = sys.version.split ()[0]; \
-		print (ver >= '2.1.0')"`
-	if test "$ac_supports_python_ver" != "True"; then
-		if test -z "$PYTHON_NOVERSIONCHECK"; then
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-			{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "
-This version of the AC_PYTHON_DEVEL macro
-doesn't work properly with versions of Python before
-2.1.0. You may need to re-run configure, setting the
-variables PYTHON_CPPFLAGS, PYTHON_LIBS, PYTHON_SITE_PKG,
-PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
-Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
-to something else than an empty string.
-
-See \`config.log' for more details" "$LINENO" 5; }
-		else
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: skip at user request" >&5
-$as_echo "skip at user request" >&6; }
-		fi
-	else
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	fi
-
-	#
-	# if the macro parameter ``version'' is set, honour it
-	#
-	if test -n ">='2.5'"; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a version of Python >='2.5'" >&5
-$as_echo_n "checking for a version of Python >='2.5'... " >&6; }
-		ac_supports_python_ver=`$PYTHON -c "import sys; \
-			ver = sys.version.split ()[0]; \
-			print (ver >='2.5')"`
-		if test "$ac_supports_python_ver" = "True"; then
-		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		else
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-			as_fn_error $? "this package requires Python >='2.5'.
-If you have it installed, but it isn't the default Python
-interpreter in your system path, please pass the PYTHON_VERSION
-variable to configure. See \`\`configure --help'' for reference.
-" "$LINENO" 5
-			PYTHON_VERSION=""
-		fi
-	fi
-
-	#
-	# Check if you have distutils, else fail
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for the distutils Python package" >&5
-$as_echo_n "checking for the distutils Python package... " >&6; }
-	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
-	if test $? -eq 0; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	else
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-		as_fn_error $? "cannot import Python module \"distutils\".
-Please check your Python installation. The error was:
-$ac_distutils_result" "$LINENO" 5
-		PYTHON_VERSION=""
-	fi
-
-	#
-	# Check for Python include path
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python include path" >&5
-$as_echo_n "checking for Python include path... " >&6; }
-	if test -z "$PYTHON_CPPFLAGS"; then
-		python_path=`$PYTHON -c "import distutils.sysconfig; \
-			print (distutils.sysconfig.get_python_inc ());"`
-		plat_python_path=`$PYTHON -c "import distutils.sysconfig; \
-			print (distutils.sysconfig.get_python_inc (plat_specific=1));"`
-		if test -n "${python_path}"; then
-			if test "${plat_python_path}" != "${python_path}"; then
-				python_path="-I$python_path -I$plat_python_path"
-			else
-				python_path="-I$python_path"
-			fi
-		fi
-		PYTHON_CPPFLAGS=$python_path
-	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CPPFLAGS" >&5
-$as_echo "$PYTHON_CPPFLAGS" >&6; }
-
-
-	#
-	# Check for Python library path
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python library path" >&5
-$as_echo_n "checking for Python library path... " >&6; }
-	if test -z "$PYTHON_LIBS"; then
-		# (makes two attempts to ensure we've got a version number
-		# from the interpreter)
-		ac_python_version=`cat<<EOD | $PYTHON -
-
-# join all versioning strings, on some systems
-# major/minor numbers could be in different list elements
-from distutils.sysconfig import *
-e = get_config_var('VERSION')
-if e is not None:
-	print(e)
-EOD`
-
-		if test -z "$ac_python_version"; then
-			if test -n "$PYTHON_VERSION"; then
-				ac_python_version=$PYTHON_VERSION
-			else
-				ac_python_version=`$PYTHON -c "import sys; \
-					print (sys.version[:3])"`
-			fi
-		fi
-
-		# Make the versioning information available to the compiler
-
-cat >>confdefs.h <<_ACEOF
-#define HAVE_PYTHON "$ac_python_version"
-_ACEOF
-
-
-		# First, the library directory:
-		ac_python_libdir=`cat<<EOD | $PYTHON -
-
-# There should be only one
-import distutils.sysconfig
-e = distutils.sysconfig.get_config_var('LIBDIR')
-if e is not None:
-	print (e)
-EOD`
-
-		# Now, for the library:
-		ac_python_library=`cat<<EOD | $PYTHON -
-
-import distutils.sysconfig
-c = distutils.sysconfig.get_config_vars()
-if 'LDVERSION' in c:
-	print ('python'+c['LDVERSION'])
-else:
-	print ('python'+c['VERSION'])
-EOD`
-
-		# This small piece shamelessly adapted from PostgreSQL python macro;
-		# credits goes to momjian, I think. I'd like to put the right name
-		# in the credits, if someone can point me in the right direction... ?
-		#
-		if test -n "$ac_python_libdir" -a -n "$ac_python_library"
-		then
-			# use the official shared library
-			ac_python_library=`echo "$ac_python_library" | sed "s/^lib//"`
-			PYTHON_LIBS="-L$ac_python_libdir -l$ac_python_library"
-		else
-			# old way: use libpython from python_configdir
-			ac_python_libdir=`$PYTHON -c \
-			  "from distutils.sysconfig import get_python_lib as f; \
-			  import os; \
-			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
-			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
-		fi
-
-		if test -z "PYTHON_LIBS"; then
-			as_fn_error $? "
-  Cannot determine location of your Python DSO. Please check it was installed with
-  dynamic libraries enabled, or try setting PYTHON_LIBS by hand.
-			" "$LINENO" 5
-		fi
-	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_LIBS" >&5
-$as_echo "$PYTHON_LIBS" >&6; }
-
-
-	#
-	# Check for site packages
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python site-packages path" >&5
-$as_echo_n "checking for Python site-packages path... " >&6; }
-	if test -z "$PYTHON_SITE_PKG"; then
-		PYTHON_SITE_PKG=`$PYTHON -c "import distutils.sysconfig; \
-			print (distutils.sysconfig.get_python_lib(0,0));"`
-	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_SITE_PKG" >&5
-$as_echo "$PYTHON_SITE_PKG" >&6; }
-
-
-	#
-	# libraries which must be linked in when embedding
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra libraries" >&5
-$as_echo_n "checking python extra libraries... " >&6; }
-	if test -z "$PYTHON_EXTRA_LIBS"; then
-	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
-                conf = distutils.sysconfig.get_config_var; \
-                print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
-	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
-$as_echo "$PYTHON_EXTRA_LIBS" >&6; }
-
-
-	#
-	# linking flags needed when embedding
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking python extra linking flags" >&5
-$as_echo_n "checking python extra linking flags... " >&6; }
-	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
-		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
-			conf = distutils.sysconfig.get_config_var; \
-			print (conf('LINKFORSHARED'))"`
-	fi
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LDFLAGS" >&5
-$as_echo "$PYTHON_EXTRA_LDFLAGS" >&6; }
-
-
-	#
-	# final check to see if everything compiles alright
-	#
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking consistency of all components of python development environment" >&5
-$as_echo_n "checking consistency of all components of python development environment... " >&6; }
-	# save current global flags
-	ac_save_LIBS="$LIBS"
-	ac_save_LDFLAGS="$LDFLAGS"
-	ac_save_CPPFLAGS="$CPPFLAGS"
-	LIBS="$ac_save_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_EXTRA_LIBS"
-	LDFLAGS="$ac_save_LDFLAGS $PYTHON_EXTRA_LDFLAGS"
-	CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		#include <Python.h>
-int
-main ()
-{
-Py_Initialize();
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  pythonexists=yes
-else
-  pythonexists=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-	ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-	# turn back to default flags
-	CPPFLAGS="$ac_save_CPPFLAGS"
-	LIBS="$ac_save_LIBS"
-	LDFLAGS="$ac_save_LDFLAGS"
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pythonexists" >&5
-$as_echo "$pythonexists" >&6; }
-
-        if test ! "x$pythonexists" = "xyes"; then
-	   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "
-  Could not link test program to Python. Maybe the main Python library has been
-  installed in some non-standard library path. If so, pass it to configure,
-  via the LIBS environment variable.
-  Example: ./configure LIBS=\"-L/usr/non-standard-path/python/lib\"
-  ============================================================================
-   ERROR!
-   You probably have to install the development version of the Python package
-   for your distribution.  The exact name of this package varies among them.
-  ============================================================================
-
-See \`config.log' for more details" "$LINENO" 5; }
-	  PYTHON_VERSION=""
-	fi
-
-	#
-	# all done!
-	#
-
-
-fi
+    PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
+    PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
 
 
 fi
@@ -6625,6 +6007,7 @@ fi
 fi
 
 fi
+
 
 
 ac_ext=c

--- a/configure
+++ b/configure
@@ -5644,8 +5644,97 @@ fi
   as_fn_error $? "could not find python or python3" "$LINENO" 5
 else
 
-            PYTHON_CPPFLAGS=`${PYTHON3}-config --includes`
-            PYTHON_LIBS=`${PYTHON3}-config --ldflags`
+		    # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
+set dummy python${PYTHON_VERSION}-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PYTHON_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
+  ;;
+esac
+fi
+PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
+if test -n "$PYTHON_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
+$as_echo "$PYTHON_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+		    if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+
+		         # Extract the first word of "python-config", so it can be a program name with args.
+set dummy python-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PYTHON_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
+  ;;
+esac
+fi
+PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
+if test -n "$PYTHON_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
+$as_echo "$PYTHON_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+		         if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+  as_fn_error $? "could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev" "$LINENO" 5
+fi
+
+fi
+            PYTHON_CPPFLAGS=`${PYTHON-CONFIG} --includes`
+            PYTHON_LIBS=`${PYTHON-CONFIG} --ldflags`
             PYTHON=$PYTHON3
 
 

--- a/configure
+++ b/configure
@@ -5416,7 +5416,7 @@ fi
 
     if test "$ac_cv_path_PYTHON" = "nopython"; then :
 
-	       # Extract the first word of "python", so it can be a program name with args.
+	    # Extract the first word of "python", so it can be a program name with args.
 set dummy python; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
@@ -5457,7 +5457,7 @@ $as_echo "no" >&6; }
 fi
 
 
-	       if test "$ac_cv_path_PYTHON" = "nopython"; then :
+	    if test "$ac_cv_path_PYTHON" = "nopython"; then :
   as_fn_error $? "could not find python<version> or python in specified path" "$LINENO" 5
 fi
 
@@ -5505,8 +5505,9 @@ fi
 
     if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-         # Extract the first word of "python-config", so it can be a program name with args.
-set dummy python-config; ac_word=$2
+        PYTHON_MAJORMINOR = `${PYTHON} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
+        # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
+set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
@@ -5546,8 +5547,54 @@ $as_echo "no" >&6; }
 fi
 
 
-         if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+        if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+
+            # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
+set dummy python${PYTHON_VERSION}-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PYTHON_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in "$PYTHON_HOME"
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
+  ;;
+esac
+fi
+PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
+if test -n "$PYTHON_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
+$as_echo "$PYTHON_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+            if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
   as_fn_error $? "could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev" "$LINENO" 5
+fi
+
+
 fi
 
 fi
@@ -5644,7 +5691,7 @@ fi
   as_fn_error $? "could not find python or python3" "$LINENO" 5
 else
 
-		    # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
+            # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
 set dummy python${PYTHON_VERSION}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
@@ -5685,10 +5732,11 @@ $as_echo "no" >&6; }
 fi
 
 
-		    if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+            if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-		         # Extract the first word of "python-config", so it can be a program name with args.
-set dummy python-config; ac_word=$2
+                PYTHON_MAJORMINOR = `${PYTHON3} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
+                # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
+set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
@@ -5728,8 +5776,54 @@ $as_echo "no" >&6; }
 fi
 
 
-		         if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+                if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
+
+                    # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
+set dummy python${PYTHON_VERSION}-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PYTHON_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PYTHON_CONFIG="$PYTHON_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PYTHON_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_PYTHON_CONFIG" && ac_cv_path_PYTHON_CONFIG="nopython-config"
+  ;;
+esac
+fi
+PYTHON_CONFIG=$ac_cv_path_PYTHON_CONFIG
+if test -n "$PYTHON_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CONFIG" >&5
+$as_echo "$PYTHON_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+                    if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
   as_fn_error $? "could not find python<version>-config or python-config in specified path please install python${PYTHON_VERSION}-dev" "$LINENO" 5
+fi
+
+
 fi
 
 fi

--- a/configure
+++ b/configure
@@ -651,6 +651,9 @@ SWIG_LIB
 SWIG
 SWIG_BIN
 GNUPLOT
+PYTHON_EXTRA_LIBS
+PYTHON_LIBS
+PYTHON_CPPFLAGS
 PYTHON_CONFIG
 PYTHON
 PERL_VERSION
@@ -5570,6 +5573,10 @@ fi
 
 
 fi
+
+
+
+
 
 
 # Extract the first word of "gnuplot", so it can be a program name with args.

--- a/configure
+++ b/configure
@@ -5505,7 +5505,7 @@ fi
 
     if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
+        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
         # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
 set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -5734,7 +5734,7 @@ fi
 
             if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
+                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))'`
                 # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
 set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5

--- a/configure
+++ b/configure
@@ -5734,7 +5734,7 @@ fi
 
             if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-                PYTHON_MAJORMINOR = `${PYTHON3} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
+                PYTHON_MAJORMINOR=`${PYTHON3} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
                 # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
 set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5

--- a/configure
+++ b/configure
@@ -5691,8 +5691,8 @@ fi
   as_fn_error $? "could not find python or python3" "$LINENO" 5
 else
 
-            # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
-set dummy python${PYTHON_VERSION}-config; ac_word=$2
+            # Extract the first word of "${PYTHON3}-config", so it can be a program name with args.
+set dummy ${PYTHON3}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
@@ -5778,8 +5778,8 @@ fi
 
                 if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-                    # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
-set dummy python${PYTHON_VERSION}-config; ac_word=$2
+                    # Extract the first word of "python-config", so it can be a program name with args.
+set dummy python-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :

--- a/configure
+++ b/configure
@@ -5549,8 +5549,8 @@ fi
 
         if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-            # Extract the first word of "python${PYTHON_VERSION}-config", so it can be a program name with args.
-set dummy python${PYTHON_VERSION}-config; ac_word=$2
+            # Extract the first word of "python-config", so it can be a program name with args.
+set dummy python-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :
@@ -5691,8 +5691,8 @@ fi
   as_fn_error $? "could not find python or python3" "$LINENO" 5
 else
 
-            # Extract the first word of "${PYTHON3}-config", so it can be a program name with args.
-set dummy ${PYTHON3}-config; ac_word=$2
+            # Extract the first word of "python3-config", so it can be a program name with args.
+set dummy python3-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
 if ${ac_cv_path_PYTHON_CONFIG+:} false; then :

--- a/configure
+++ b/configure
@@ -5463,8 +5463,6 @@ test -n "$PYTHON_CONFIG" || PYTHON_CONFIG="nopython-config"
     if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
   as_fn_error $? "could not find python<major>-config python<major.minor>-config or python-config in the specified path. Please install the python development package" "$LINENO" 5
 fi
-    PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
-    PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
 
 else
 
@@ -5568,12 +5566,52 @@ test -n "$PYTHON_CONFIG" || PYTHON_CONFIG="nopython-config"
     if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
   as_fn_error $? "could not find python<major>-config python<major.minor>-config or python-config. Please install the python development package" "$LINENO" 5
 fi
-    PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
-    PYTHON_LIBS=`${PYTHON_CONFIG} --ldflags`
 
 
 fi
 
+
+PYTHON_LIBS_COMMAND="${PYTHON_CONFIG} --libs"
+
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "${PYTHON_MAJORMINOR}" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "3.8" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/true/;s/x${ax_compare_version_B}/false/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+    PYTHON_LIBS_COMMAND="${PYTHON_LIBS_COMMAND} --embed"
+
+      fi
+
+
+PYTHON_CPPFLAGS=`${PYTHON_CONFIG} --includes`
+PYTHON_LIBS=`${PYTHON_LIBS_COMMAND}`
 
 
 

--- a/configure
+++ b/configure
@@ -5505,7 +5505,7 @@ fi
 
     if test "$ac_cv_path_PYTHON_CONFIG" = "nopython-config"; then :
 
-        PYTHON_MAJORMINOR = `${PYTHON} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
+        PYTHON_MAJORMINOR=`${PYTHON} -c 'import sys; print(str(sys.version_info0)+"."+str(sys.version_info1))'`
         # Extract the first word of "python${PYTHON_MAJORMINOR}-config", so it can be a program name with args.
 set dummy python${PYTHON_MAJORMINOR}-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5


### PR DESCRIPTION
see #991, #992, and #993. 
To support Ubuntu 20.04 we must support new versions of python and gtest. Python has changed the way it provided libraries using python-config, so adjustments had to be made. I've completely ditched the built in autoconf function for finding python, because it adds a bunch of extra flags we don't need for Trick.

Now when we look for python with configure, it will search for python in this order:
python${PYTHON_VERSION}
python
python3

For python-config, it will search in this order:
python<major_version.minor_version>-config
python<major_version>-config
python${PYTHON_VERSION}-config
python-config
python3-config

Instead of python-config --ldflags, we are using python-config --libs 
This only gets the flags we need.

For python >= 3.8 we use
python-config --libs --embed
this way it will add -lpython to the flags
