### PR TITLE
Implement PIDController to Wheelbot

### DIFF
--- a/trick_sims/SIM_wheelbot/models/Control/src/PIDController.cpp
+++ b/trick_sims/SIM_wheelbot/models/Control/src/PIDController.cpp
@@ -45,20 +45,20 @@ double PIDController::getOutput(double setpoint_value, double measured_value) {
   // Sign Check
   bool same_sign;
   if ((error * output) > 0.0) {
-    same_sign = 1;
+    same_sign = true;
   } else {
-    same_sign = 0;
+    same_sign = false;
   }
 
   //Saturation Check
-  bool output_limited;
+  bool output_limited = false;
   if (output > out_max) {
     output = out_max;
-    output_limited = 1;
+    output_limited = true;
   }
   if (output < out_min) {
     output = out_min;
-    output_limited = 1;
+    output_limited = true;
   }
 
   //AND Gate Check

--- a/trick_sims/SIM_wheelbot/models/Control/src/differentialDriveController.cpp
+++ b/trick_sims/SIM_wheelbot/models/Control/src/differentialDriveController.cpp
@@ -27,10 +27,10 @@ DifferentialDriveController::
     desiredHeadingRate(0.0),
 
     // PID Controller Initialization
-    headingctrl(PIDController(1.0, 0.08, 0.5, headingRateLimit,
-                                  -headingRateLimit, 0.1, 0.1)),
-    wheelspeedctrl(PIDController(1.0, 0.082, 0.5, wheelSpeedLimit,
-                                      -wheelSpeedLimit, 0.1, 0.1))
+    headingctrl(1.0, 0.08, 0.5, headingRateLimit,
+                                  -headingRateLimit, 0.1, 0.1),
+    wheelspeedctrl(1.0, 0.082, 0.5, wheelSpeedLimit,
+                                      -wheelSpeedLimit, 0.1, 0.1)
 { }
 
 void DifferentialDriveController::stop() {


### PR DESCRIPTION
Changes suggested by Scott Fennell:
1. Initialize output_limited to false
2. Be consistent in the utilization of true/false or 1/0.
3. Initialize PIDControllers without calling class.
4. Use if and else if while comparing output bounds.

Changes made:
1. Initialize output_limited to false
2. Be consistent in the utilization of true/false or 1/0.
3. Initialize PIDControllers without calling class.
4. Chose to omit since not a performance bug.