### PR TITLE
Fix TRICK_HOST_CPU gcc version for Ubuntu 18.04+ (#1024)

### DIFF
--- a/libexec/trick/pm/gte.pm
+++ b/libexec/trick/pm/gte.pm
@@ -49,21 +49,21 @@ sub gte (@) {
                 # remove possible ccache from TRICK_CC
                 $temp =~ s/.*?ccache\s+// ;
                 if ( -e $temp ) {
-                    $ret = `$temp -dumpversion` ;
+                    $ret = `$temp -dumpfullversion -dumpversion` ;
                 }
                 else {
                     printf STDERR "[33mCannot find TRICK_CC = $temp, using /usr/bin/gcc\n" ;
-                    $ret = `/usr/bin/gcc -dumpversion` ;
+                    $ret = `/usr/bin/gcc -dumpfullversion -dumpversion` ;
                 }
             } else {
                 # remove possible ccache from TRICK_CC
                 my ($temp) = $ENV{TRICK_CC} ;
                 $temp =~ s/.*?ccache\s+// ;
-                $ret = `$temp -dumpversion` ;
+                $ret = `$temp --dumpfullversion dumpversion` ;
             }
         }
         else {
-            $ret = `gcc -dumpversion` ;
+            $ret = `gcc -dumpfullversion -dumpversion` ;
         }
         ($gcc_version) = $ret =~ /(\d+(?:\.\d+)?)/ ;
 


### PR DESCRIPTION
A Ubuntu 18.04+ user is getting a bad TRICK_HOST_CPU with gte due to a change in gcc 7.x.  The gcc -dumpversion meaning has changed.  For gcc 7+, you want to use gcc -dumpfullversion.  gcc 4.x does not have the -dumpfullversion option.  There is trick to make it work.

The trick is to use:
gcc -dumpfullversion -dumpversion (in that order!)
instead of
gcc -dumpversion
 
inside of <trickhome>/libexec/trick/pm/gte.pm.
 
If you do that, the version will be correct for gcc 4.x and gcc 7.x+.
 
That might not be the solution you want, but it is simple.  Another way would be to do a system call to see if gcc has the -dumpfullversion option and use it if it exists, but that is more code invasive.