### PR TITLE
Homing and End Behavior Improvements to Wheelbot Sim

### DIFF
--- a/trick_sims/SIM_wheelbot/README.md
+++ b/trick_sims/SIM_wheelbot/README.md
@@ -33,7 +33,7 @@ veh.vehicle.wheelSpeedLimit                    | double         | rad/s | 8.880
 veh.vehicle.headingRateLimit                   | double         | rad/s | 𝛑/4
 veh.vehicle.wheelDragConstant                  | double         | --    | 1.875
 veh.vehicle.corningStiffness                   | double         | --    | 10.0
-veh.vehicle.slowDownDistance                   | double         | --    | 0.5 
+veh.vehicle.slowDownDistance                   | double         | --    | 0.5
 veh.vehicle.arrivalDistance                    | double         | --    | 0.1
 
 ![Picture of Vehicle](images/Figure2.png)
@@ -43,6 +43,23 @@ Waypoints, for the vehicle to follow, are added with a call to
 
 veh.vehicle.add_waypoint( double N, double W )
 
+and HomePoint for the vehicle to home to is called to
+
+veh.Vehicle.add_homepoint( double N, double W)
+
+
+#### Enabling or Disabling Homing
+To set a HomePoint:
+
+Edit the fuction veh.vehicle.add_homepoint( float(1.5), float(-1.5)) in the input.py file under RUN_test.
+
+Replace the float values with desired home location.
+
+Under models/Control/src/vehicleController.cpp, locate the declaration:
+
+homing = true;
+
+To disable homing, comment out the line of code.
 
 
 ### Input/Output

--- a/trick_sims/SIM_wheelbot/RUN_test/input.py
+++ b/trick_sims/SIM_wheelbot/RUN_test/input.py
@@ -22,6 +22,11 @@ veh.vehicle.arrivalDistance  = 0.1
 #==========================================
 # Add the waypoints to the SIM.
 #==========================================
+
+# Add home point
+veh.vehicle.add_homepoint( float(1.5), float(-1.5))
+
+#Add waypoints
 waypoints_path = "Modified_data/cross.waypoints"
 fp = open(waypoints_path, "r")
 for line in fp:

--- a/trick_sims/SIM_wheelbot/models/Control/README.md
+++ b/trick_sims/SIM_wheelbot/models/Control/README.md
@@ -81,11 +81,11 @@ With **availableWheelSpeedForRangeRate** determined, we can figure our range rat
 #### Calculating the Required Motor Speeds
 
 Now that we've apportioned the available wheel speed to turning and moving, we can figure our right and left wheel speeds:
- 
+
 * [Eq#6] **desiredRightWheelSpeed** =  wheelSpeedForRangeRate + wheelSpeedForHeadingRate
- 
+
 * [Eq#7] **desiredLeftWheelSpeed**  =  wheelSpeedForRangeRate - wheelSpeedForHeadingRate
-    
+
 Here, wheel speed is positive forward, and negative is backwards. For the motor models positive is counter clockwise, and negative is clockwise. So, we have to change sign for the right motor:
 
 <a id=EQ_8_rightMotorSpeedCommand></a>
@@ -94,7 +94,7 @@ Here, wheel speed is positive forward, and negative is backwards. For the motor 
 <a id=EQ_9_leftMotorSpeedCommand></a>
 * [Eq#9] **leftMotorSpeedCommand**  =  desiredLeftWheelSpeed
 
-    
+
 | Access  | Member Name           | Type   | Units  | Value  |
 |---------|-----------------------|--------|--------|--------|
 | private | rightMotorSpeedCommand| double | rad/s  |[Eq#8](#EQ_8_rightMotorSpeedCommand)|
@@ -171,3 +171,27 @@ void printDestination();
 ```
 void update();
 ```
+
+```
+bool get_homing();
+```
+
+Return boolean value of homing (if the vehicle is going to a set home location).
+
+```
+bool get_atend();
+```
+
+Return boolean value of atend (if all waypoints and/or home have been visited).
+
+```
+void go_home(std::vector<Point>* HomePoints);
+```
+
+Sets wayPointQueue to point to new homePoint and destination iterator to begin.
+
+```
+bool homing;
+```
+
+This variable determines whether the vehicle goes home after wayPoints are visited. Comment out line 68 if you do not want to home.

--- a/trick_sims/SIM_wheelbot/models/Control/include/vehicleController.hh
+++ b/trick_sims/SIM_wheelbot/models/Control/include/vehicleController.hh
@@ -25,6 +25,11 @@ class VehicleController {
     void printDestination();
     void update();
 
+    // Homing functions
+    bool get_homing();
+    bool get_atend();
+    void go_home(std::vector<Point>* HomePoints);
+
     private:
     // Do not allow the default constructor to be used.
     VehicleController();
@@ -34,6 +39,8 @@ class VehicleController {
     Point departure;
     Navigator& navigator;
     DifferentialDriveController& driveController;
+    bool homing;
+    bool atend;
 
     double arrivalDistance;
 };

--- a/trick_sims/SIM_wheelbot/models/Control/src/vehicleController.cpp
+++ b/trick_sims/SIM_wheelbot/models/Control/src/vehicleController.cpp
@@ -16,6 +16,8 @@ VehicleController::VehicleController( std::vector<Point>* wayPoints,
     }
     waypointQueue = wayPoints;
     destination = waypointQueue->begin();
+    homing = false;
+    atend = false;
     printDestination();
 }
 
@@ -41,10 +43,35 @@ void VehicleController::printDestination() {
     }
 }
 
+// Homing functions
+bool VehicleController::get_homing() {
+    return homing;
+}
+
+bool VehicleController::get_atend() {
+    return atend;
+}
+
+void VehicleController::go_home(std::vector<Point>* homePoints) {
+    waypointQueue = homePoints;
+    destination = waypointQueue->begin();
+    printDestination();
+}
+
 void VehicleController::update() {
 
-    if (destination == waypointQueue->end()) {
+    if (destination == waypointQueue->end() && homing == false) {
         driveController.update(0.0, 0.0);
+        driveController.stop();
+
+        // To control homing: comment out for no homing
+        homing = true;
+
+        if (homing == false) {
+          atend = true;
+        }
+    } else if (destination == waypointQueue->end() && homing == true) {
+        atend = true;
         driveController.stop();
     } else {
         double distance_err = navigator.distanceTo(*destination);
@@ -58,5 +85,3 @@ void VehicleController::update() {
         }
     }
 }
-
-

--- a/trick_sims/SIM_wheelbot/models/Vehicle/include/vehicleOne.hh
+++ b/trick_sims/SIM_wheelbot/models/Vehicle/include/vehicleOne.hh
@@ -57,7 +57,11 @@ class VehicleOne {
 
     double batteryVoltage;
 
+    std::vector<Point> homewaypoint;
+    bool goinghome;
+
     void add_waypoint(double x, double y);
+    void add_homepoint(double x, double y);
 
     int default_data();
     int state_init();

--- a/trick_sims/SIM_wheelbot/models/Vehicle/src/vehicleOne.cpp
+++ b/trick_sims/SIM_wheelbot/models/Vehicle/src/vehicleOne.cpp
@@ -60,6 +60,7 @@ int VehicleOne::default_data() {
     leftMotorSpeed  = 0.0;
 
     batteryVoltage  = 5.0;
+    goinghome = false;
 
     return 0;
 }
@@ -100,13 +101,21 @@ void VehicleOne::add_waypoint(double x, double y) {
     waypointQueue.push_back(wayPoint);
 }
 
+void VehicleOne::add_homepoint(double x, double y) {
+    Point wayPoint(x,y);
+    homewaypoint.push_back(wayPoint);
+}
+
 
 void VehicleOne::control() {
 
     // Perfect Sensors for now.
     navigator->setHeading(heading);
     navigator->setLocation(position[0], position[1]);
-
+    if (vehicleController->get_homing() == true && goinghome == false) {
+        vehicleController->go_home(&homewaypoint);
+        goinghome = true;
+    }
     vehicleController->update();
 }
 
@@ -170,6 +179,19 @@ int VehicleOne::state_deriv() {
    headingAccel = vehicleZTorque / ZAxisMomentofInertia;
 
    // Body Linear Acceleration
+
+   if (vehicleController->get_atend() == true) {
+      forceTotal[0] = 0;
+      forceTotal[1] = 0;
+      rightMotorSpeed = 0;
+      leftMotorSpeed = 0;
+      velocity[0] = 0;
+      velocity[1] = 0;
+      heading = heading;
+      headingRate = 0;
+      headingAccel = 0;
+   }
+
    acceleration[0] = forceTotal[0] / vehicleMass;
    acceleration[1] = forceTotal[1] / vehicleMass;
 


### PR DESCRIPTION
Purpose: 
I have written a homing system that when prompted homes to a location after the wayPoints have been visited. I have also improved the end behavior once the vehicle has no destination, so that the vehicle stops and does not float off the screen.

Files modified:
trick_sims/SIM_wheelbot/README.md
trick_sims/SIM_wheelbot/RUN_test/input.py
trick_sims/SIM_wheelbot/models/Control/README.md
trick_sims/SIM_wheelbot/models/Control/include/vehicleController.hh
trick_sims/SIM_wheelbot/models/Control/src/vehicleController.cpp
trick_sims/SIM_wheelbot/models/Vehicle/include/vehicleOne.hh
trick_sims/SIM_wheelbot/models/Vehicle/src/vehicleOne.cpp
