### PR TITLE
#1038 llvm-config --system-libs on macOS is providing a bad ldflag

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/makefile
+++ b/trick_source/codegen/Interface_Code_Gen/makefile
@@ -56,7 +56,7 @@ endif
 
 ifeq ($(TRICK_HOST_TYPE),Darwin)
 CLANGLIBS += $(shell $(LLVM_HOME)/bin/llvm-config --libs)
-CLANGLIBS += $(shell $(LLVM_HOME)/bin/llvm-config --system-libs)
+CLANGLIBS += $(filter-out -llibxml2.tbd,$(shell $(LLVM_HOME)/bin/llvm-config --system-libs))
 CLANGLIBS += -lc++abi
 endif
 


### PR DESCRIPTION
filter -llibxml2.tbd from llvm-config --system-libs as temporay workaround for missing library, until this is fixed by llvm