### PR TITLE
Trick installation on MacOS documentation update

### DIFF
--- a/docs/documentation/install_guide/Install-Guide.md
+++ b/docs/documentation/install_guide/Install-Guide.md
@@ -195,13 +195,16 @@ or
 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install | ruby
 ```
 
-5. Install [Java](https://www.java.com/en/download/) and the [JDK](https://www.oracle.com/java/technologies/javase-jdk15-downloads.html) from the respective Oracle websites.
-
-6. Finally, install the remaining dependencies.
+5. Install the remaining dependencies.
 
 ```bash
-brew install xquartz llvm swig maven udunits openmotif  
+brew install java xquartz llvm swig maven udunits openmotif  
 ```
+If you have issues installing java with homebrew, you can install java and the jdk from oracle's website:
+
+[Java](https://www.java.com/en/download/)
+
+[JDK](https://www.oracle.com/java/technologies/javase-downloads.html) (click JDK Download)
 
 Openmotif may install dependent packages that conflict with other installations, fontconfig and freetype.  Use the following command to skip installing these packages if you encounter conflicts.
 ```bash

--- a/docs/documentation/install_guide/Install-Guide.md
+++ b/docs/documentation/install_guide/Install-Guide.md
@@ -195,18 +195,12 @@ or
 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install | ruby
 ```
 
-5. Install cask to get java and xquartz.
-
-```bash
-# brew install caskroom may not be required anymore
-# brew install caskroom/cask/brew-cask
-brew cask install java xquartz
-```
+5. Install [Java](https://www.java.com/en/download/) and the [JDK](https://www.oracle.com/java/technologies/javase-jdk15-downloads.html) from the respective Oracle websites.
 
 6. Finally, install the remaining dependencies.
 
 ```bash
-brew install llvm swig maven udunits openmotif  
+brew install xquartz llvm swig maven udunits openmotif  
 ```
 
 Openmotif may install dependent packages that conflict with other installations, fontconfig and freetype.  Use the following command to skip installing these packages if you encounter conflicts.


### PR DESCRIPTION
Step 5 in the installation guide “Install cask to get java and xquartz” results in the following error: “Error: Cask 'java' is unavailable: No Cask with this name exists. Did you mean one of these?”, then giving some other possible downloads. It seems that Java cannot be installed using home-brew in this way. The way around this I used was to install Java from Oracle’s website (https://www.java.com/en/download/) and the JDK from here (https://www.oracle.com/java/technologies/javase-jdk15-downloads.html), then install the other packages on their own. This has been tested to be working on macOS Catalina.