### PR TITLE
Add reference support to memory manager

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
@@ -57,6 +57,7 @@ FieldDescription::FieldDescription(
   is_stl(0) ,
   has_stl_clear(1) ,
   is_static(0) ,
+  is_reference(0) ,
   num_dims(0) ,
   array_sizes() {} ;
 
@@ -541,6 +542,14 @@ void FieldDescription::setStatic(bool yes_no) {
 
 bool FieldDescription::isStatic() {
     return is_static ;
+}
+
+void FieldDescription::setReference(bool yes_no) {
+    is_reference = yes_no ;
+}
+
+bool FieldDescription::isReference() {
+    return is_reference ;
 }
 
 unsigned int FieldDescription::getNumDims() {

--- a/trick_source/codegen/Interface_Code_Gen/FieldDescription.hh
+++ b/trick_source/codegen/Interface_Code_Gen/FieldDescription.hh
@@ -87,6 +87,8 @@ class FieldDescription : public ConstructValues {
         bool hasSTLClear() ;
         void setStatic( bool yes_no ) ;
         bool isStatic() ;
+        void setReference( bool yes_no ) ;
+        bool isReference() ;
         void setInherited( bool yes_no ) ;
         bool isInherited() ;
         void setVirtualInherited( bool yes_no ) ;
@@ -183,6 +185,9 @@ class FieldDescription : public ConstructValues {
 
         /** is this field declared static */
         bool is_static ;
+
+        /** is this field a reference type */
+        bool is_reference ;
 
         /** map of strings to io numbers.  One copy for all fields */
         static std::map<std::string , unsigned int> io_map ;

--- a/trick_source/codegen/Interface_Code_Gen/FieldVisitor.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldVisitor.cpp
@@ -43,12 +43,12 @@ bool FieldVisitor::VisitType(clang::Type *t) {
         std::cout << "FieldVisitor VisitType Type = " << t->getTypeClassName() << std::endl ;
         t->dump() ;
     }
-    // If this type is a reference, set IO to 0
     if ( t->isReferenceType() ) {
         if ( debug_level >= 3 ) {
-            std::cout << "FieldVisitor VisitType found reference, setIO = 0 " << std::endl ;
+            std::cout << "FieldVisitor VisitType found reference, setIO = 3 " << std::endl ;
         }
-        fdes->setIO(0) ;
+        fdes->setIO(3) ;
+        fdes->setReference(true) ;
     }
     return true;
 }

--- a/trick_source/codegen/Interface_Code_Gen/PrintFileContents10.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintFileContents10.cpp
@@ -76,7 +76,7 @@ void PrintFileContents10::print_field_attr(std::ostream & ostream ,  FieldDescri
         ostream << ", sizeof(" << fdes.getTypeName() << ")" ;
     }
     ostream << ", 0, 0, Language_CPP" ; // range_min, range_max, language
-    ostream << ", " << (fdes.isStatic() << 1) + (fdes.isDashDashUnits() << 2) << "," << std::endl ; // mods
+    ostream << ", " << fdes.isReference() + (fdes.isStatic() << 1) + (fdes.isDashDashUnits() << 2) << "," << std::endl ; // mods
     if ( fdes.isBitField() ) {
         // For bitfields we need the offset to start on 4 byte boundaries because that is what our
         // insert and extract bitfield routines work with.

--- a/trick_source/codegen/Interface_Code_Gen/PrintFileContentsBase.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintFileContentsBase.cpp
@@ -63,6 +63,14 @@ bool PrintFileContentsBase::isPrintable( ClassValues * c , FieldDescription * fd
     if ( fdes->isSTL() and fdes->getNumDims() ) {
         return false;
     }
+    /**
+     * It is not possible to take the address of a reference as the referred-to variable's address
+     * is always returned. As such, the init_attr function cannot obtain the absolute address for
+     * static reference variables.
+     */
+    if ( fdes->isStatic() && fdes->isReference() ) {
+        return false;
+    }
     if ( fdes->getAccess() == clang::AS_public || (!fdes->isStatic() && !global_compat15 && !c->isCompat15())) {
         return true;
     }

--- a/trick_source/sim_services/MemoryManager/MemoryManager_ref_name.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_ref_name.cpp
@@ -99,6 +99,15 @@ int Trick::MemoryManager::ref_name(REF2 * R, char *name) {
         }
     }
 
+    if (attr->mods & 1) {
+            ADDRESS_NODE * address_node = new ADDRESS_NODE ;
+            address_node->operator_ = AO_DEREFERENCE ;
+            address_node->operand.address = NULL ;
+            DLL_AddTail(address_node , R->address_path) ;
+
+            addr = *(char**)addr;
+    }
+
     /* Save the address and next attributes in the REF structure.
        If the attributes are dynamically-allocated, reference attributes
        then free them so we don't leak memory.


### PR DESCRIPTION
This PR adds support for references over the variable server and data recording, but not checkpointing.

Fixes #1092 