### PR TITLE
Create link_list files for Trickification

### DIFF
--- a/libexec/trick/make_makefile_swig
+++ b/libexec/trick/make_makefile_swig
@@ -139,6 +139,7 @@ sub write_makefile_swig() {
 
     open MAKEFILE , ">build/Makefile_swig" or die "Could not open build/Makefile_swig for writing" ;
     open PY_LINK_LIST , ">build/py_link_list" or die "Could not open build/py_link_list for writing" ;
+    open TRICKIFY_PY_LINK_LIST , ">build/trickify_py_link_list" or die "Could not open build/trickify_py_link_list for writing" ;
     print PY_LINK_LIST "build/init_swig_modules.o\n" ;
     print PY_LINK_LIST "build/top.o\n" ;
 
@@ -180,6 +181,7 @@ SWIG_I =" ;
         (my $swig_file = $file) =~ s/(\.[^.]*)?$/_py/ ;
         print MAKEFILE " \\\n    build$swig_file.i" ;
         print PY_LINK_LIST "build$swig_file.o\n" ;
+        print TRICKIFY_PY_LINK_LIST "build$swig_file.o\n" ;
     }
 
     print MAKEFILE "
@@ -234,6 +236,7 @@ all: $swig_sim_zip
 
     close MAKEFILE ;
     close PY_LINK_LIST ;
+    close TRICKIFY_PY_LINK_LIST ;
 
     open SWIGLIB , ">build/S_library_swig" or die "Could not open build/S_library_swig for writing" ;
     foreach my $file ( @files_to_process ) {

--- a/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp
@@ -421,6 +421,7 @@ void PrintAttributes::printIOMakefile() {
     std::ofstream makefile_io_src ;
     std::ofstream makefile_ICG ;
     std::ofstream io_link_list ;
+    std::ofstream trickify_io_link_list ;
     std::ofstream ICG_processed ;
     std::ofstream ext_lib ;
 
@@ -476,10 +477,13 @@ void PrintAttributes::printIOMakefile() {
 
        io_link_list lists all io object files to be linked.
 
+       trickify_io_link_list lists all io object files to be linked for a Trickified project.
+
        ICG_process lists all header files to be used by SWIG.
      */
     makefile_ICG.open("build/Makefile_ICG") ;
     io_link_list.open("build/io_link_list") ;
+    trickify_io_link_list.open("build/trickify_io_link_list") ;
     ICG_processed.open("build/ICG_processed") ;
 
     makefile_ICG << "build/Makefile_io_src:" ;
@@ -488,6 +492,7 @@ void PrintAttributes::printIOMakefile() {
         size_t found ;
         found = (*mit).second.find_last_of(".") ;
         io_link_list << (*mit).second.substr(0,found) << ".o" << std::endl ;
+        trickify_io_link_list << (*mit).second.substr(0,found) << ".o" << std::endl ;
         ICG_processed << (*mit).first << std::endl ;
     }
     makefile_ICG.close() ;
@@ -500,6 +505,7 @@ void PrintAttributes::printIOMakefile() {
 
     io_link_list << "build/class_map.o" << std::endl ;
     io_link_list.close() ;
+    trickify_io_link_list.close() ;
 
     ext_lib.open("build/ICG_ext_lib") ;
     for ( auto& file : ext_lib_io_files ) {


### PR DESCRIPTION
`ICG` and `make_makefile_swig` create `py_link_list` and `io_link_list` files listing the files to be linked during sim builds. Trickified projects require slightly altered lists.