### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/include/trick/ClassicCheckPointAgent.hh
+++ b/include/trick/ClassicCheckPointAgent.hh
@@ -28,13 +28,13 @@ namespace Trick {
 
         /**
          Test incoming attributes permission check.
-         @param attr Attributes with permision to check.
+         @param attr Attributes with permission to check.
          */
         virtual bool input_perm_check(ATTRIBUTES * attr) ;
 
         /**
          Test incoming attributes permission check.
-         @param attr Attributes with permision to check.
+         @param attr Attributes with permission to check.
          */
         virtual bool output_perm_check(ATTRIBUTES * attr) ;
 

--- a/include/trick/Clock.hh
+++ b/include/trick/Clock.hh
@@ -62,7 +62,7 @@ namespace Trick {
 
             /**
              * @brief Sets the rt_clock_ratio
-             * @return returns 0 if clock_ratio sucessfully set.
+             * @return returns 0 if clock_ratio successfully set.
              */
             int set_rt_clock_ratio(double) ;
 

--- a/include/trick/Event.hh
+++ b/include/trick/Event.hh
@@ -69,7 +69,7 @@ class Event {
         void activate() { active = true ; } ;
 
         /**
-         @brief @userdesc Command to turn off processing of event (can be overriden by manual mode).
+         @brief @userdesc Command to turn off processing of event (can be overridden by manual mode).
          @par Python Usage:
          @code <event_object>.deactivate() @endcode
          @return always 0

--- a/include/trick/Executive.hh
+++ b/include/trick/Executive.hh
@@ -105,7 +105,7 @@ namespace Trick {
             /** Freeze mode software frame time. All freeze jobs will be called at this frequency.\n */
             double freeze_frame;              /**< trick_units(s) */
 
-            /** Freeze mode sofware frame in integer tics.\n */
+            /** Freeze mode software frame in integer tics.\n */
             long long freeze_frame_tics ;     /**< trick_units(--) */
 
             /** Next software frame time in integer tics.\n */
@@ -210,7 +210,7 @@ namespace Trick {
             /** Queue to hold unfreeze jobs.\n */
             Trick::ScheduledJobQueue time_tic_changed_queue ; /**< trick_io(**) */
 
-            /** Enough threads to accomodate the number of children specified in the S_define file.\n */
+            /** Enough threads to accommodate the number of children specified in the S_define file.\n */
             std::vector <Trick::Threads *> threads ;               /**< trick_io(**) */
 
             /** Number of scheduled job type classes defined in the S_define file.\n */

--- a/include/trick/ExternalApplication.hh
+++ b/include/trick/ExternalApplication.hh
@@ -287,7 +287,7 @@ namespace Trick {
         /** Indicates that the use rhas specified a y-coordinate. */
         bool y_set;
 
-        /** Creates a string containing the arguements that this application explicitly supports. */
+        /** Creates a string containing the arguments that this application explicitly supports. */
         virtual std::string create_arguments_string();
         
         protected:

--- a/include/trick/ExternalApplicationManager.hh
+++ b/include/trick/ExternalApplicationManager.hh
@@ -39,7 +39,7 @@ namespace Trick {
     void remove_external_application(ExternalApplication &externalApplication);
 
     /**
-     * removes all externalApplications from managment
+     * removes all externalApplications from management
      *
      * @relates Trick::ExternalApplication
      */

--- a/include/trick/FrameLog.hh
+++ b/include/trick/FrameLog.hh
@@ -139,7 +139,7 @@ namespace Trick {
             int set_max_samples(int num) ;
 
             /**
-             @brief Clears data_record informtion realted to frame logging durning the checkpoint reload.
+             @brief Clears data_record information realted to frame logging durning the checkpoint reload.
              @return always 0
             */
             int clear_data_record_info() ;

--- a/include/trick/IPPythonEvent.hh
+++ b/include/trick/IPPythonEvent.hh
@@ -81,7 +81,7 @@ namespace Trick {
             /** True for a user input event, false for a read or other trick event.\n */
             bool is_user_event ;                    /**< trick_io(*io) trick_units(--) */
 
-            /** @userdesc True when user issues a manual command, normal condition evaluation is overriden.\n */
+            /** @userdesc True when user issues a manual command, normal condition evaluation is overridden.\n */
             bool manual ;                           /**< trick_io(*io) trick_units(--) */
 
             /** @userdesc True when event fired because of a manual_on or manual_fire command.\n */

--- a/include/trick/JITEvent.hh
+++ b/include/trick/JITEvent.hh
@@ -49,7 +49,7 @@ class JITEvent : public Trick::Event {
 
         void get_func_ptr_from_name() ;
 
-        /** pointer to funtion to run when event fires */
+        /** pointer to function to run when event fires */
         int (*func_ptr)(void) ; // trick_io(**)
 
 } ;

--- a/include/trick/JITInputFile.hh
+++ b/include/trick/JITInputFile.hh
@@ -62,7 +62,7 @@ class JITInputFile {
         int process_sim_args() ;
 
         /**
-         Called as an intialization job to compile and run the input file
+         Called as an initialization job to compile and run the input file
          @return 0 for success, compilation error code if compilation fails.
         */
         int init() ;
@@ -102,7 +102,7 @@ class JITInputFile {
         /** C++ input file from the command line if one was specified. */
         std::string input_file ;
 
-        /** Map of source file name to structue holding library name and library handle */
+        /** Map of source file name to structure holding library name and library handle */
         std::map< std::string , JITLibInfo > file_to_libinfo_map ;
 
 } ;

--- a/include/trick/Master.hh
+++ b/include/trick/Master.hh
@@ -30,7 +30,7 @@ namespace Trick {
 
     /**
      * This class keeps the remote execution information for each slave simulation controlled by the
-     * master.  It also contains the actual conneciton structure to each slave simulation.
+     * master.  It also contains the actual connection structure to each slave simulation.
      *
      * @author Robert W. Bailey from 1991-1992
      * @author Many other Trick developers of the past
@@ -60,7 +60,7 @@ namespace Trick {
              in which case the master will no longer communicate with the slave.\n */
             bool activated ;                 /**< trick_units(--) */
 
-            /** Indicates "dmtcp" or "ascii" slave. Used to contruct sync_port_tag (default is "undefined").\n*/
+            /** Indicates "dmtcp" or "ascii" slave. Used to construct sync_port_tag (default is "undefined").\n*/
             std::string slave_type;          /**< trick_units(--) */
 
             /** Slave's dmtcp port if slave_type "dmtcp" (=0 if slave_type "ascii").\n*/

--- a/include/trick/MemoryManager.hh
+++ b/include/trick/MemoryManager.hh
@@ -670,7 +670,7 @@ namespace Trick {
             CheckPointAgent* defaultCheckPointAgent; /**< ** the classic Check point agent. */
 
             bool reduced_checkpoint;    /**< -- true = Don't write zero valued variables in the checkpoint. false= Write all values. */
-            bool hexfloat_checkpoint;   /**< -- true = Represent floating point values as hexidecimal to preserve precision. false= Normal. */
+            bool hexfloat_checkpoint;   /**< -- true = Represent floating point values as hexadecimal to preserve precision. false= Normal. */
             bool expanded_arrays;       /**< -- true = array element values are set in separate assignments. */
 
             ALLOC_INFO_MAP  alloc_info_map;  /**< ** Map of <address, ALLOC_INFO*> key-value pairs for each of the managed allocations. */

--- a/include/trick/MessagePublisher.hh
+++ b/include/trick/MessagePublisher.hh
@@ -24,7 +24,7 @@ namespace Trick {
             /** Number of significant digits to use in time print.\n */
             int num_digits ;
 
-            /** Print format that accomodates enough significant digits to handle tics_per_sec */
+            /** Print format that accommodates enough significant digits to handle tics_per_sec */
             char print_format[64] ;
 
             /**

--- a/include/trick/MessageThreadedCout.hh
+++ b/include/trick/MessageThreadedCout.hh
@@ -1,6 +1,6 @@
 /*
     PURPOSE:
-        (Print messages to std::cout on a seperate thread)
+        (Print messages to std::cout on a separate thread)
 */
 
 #ifndef MESSAGETHREADEDCOUT_HH

--- a/include/trick/MonteCarlo.hh
+++ b/include/trick/MonteCarlo.hh
@@ -762,7 +762,7 @@ namespace Trick {
 
 #if 0
         /**
-            Overload default implentation of Scheduler::add_sim_object
+            Overload default implementation of Scheduler::add_sim_object
          */
         virtual int add_sim_object( Trick::SimObject * in_object ) ;
 #endif

--- a/include/trick/PythonPrint.hh
+++ b/include/trick/PythonPrint.hh
@@ -15,13 +15,13 @@ class PythonPrint: public CheckPointAgent {
 
     /**
      Test incoming attributes permission check.
-     @param attr Attributes with permision to check.
+     @param attr Attributes with permission to check.
      */
     virtual bool input_perm_check(ATTRIBUTES * attr) ;
 
     /**
      Test incoming attributes permission check.
-     @param attr Attributes with permision to check.
+     @param attr Attributes with permission to check.
      */
     virtual bool output_perm_check(ATTRIBUTES * attr) ;
 

--- a/include/trick/RealtimeSync.hh
+++ b/include/trick/RealtimeSync.hh
@@ -172,7 +172,7 @@ namespace Trick {
             virtual void get_sim_start_time() ;
 
             /**
-             @brief Ends the actual elapsed timer for initalization
+             @brief Ends the actual elapsed timer for initialization
              @return always 0
              */
             virtual void get_sim_end_init_time() ;

--- a/include/trick/RtiStager.hh
+++ b/include/trick/RtiStager.hh
@@ -23,7 +23,7 @@ namespace Trick {
   Operation Scenario:
   @li On a lower priority thread, a request is made to change the value of an item at a certain time.
   @li This item (event) gets placed in a list
-  @li A higher piority thread gets the information and changes the value of the data
+  @li A higher priority thread gets the information and changes the value of the data
   @li memory operation (creation and deletion) take place in the lower priority threads.
 
 */

--- a/include/trick/SimObject.hh
+++ b/include/trick/SimObject.hh
@@ -1,6 +1,6 @@
 /*
 PURPOSE:
-    ( The base SimObject class that all simobjects and capabilites of Trick derive from )
+    ( The base SimObject class that all simobjects and capabilities of Trick derive from )
 
 PROGRAMMERS:
     ((Alex Lin) (NASA) (May 2009) (OO))

--- a/include/trick/attributes.h
+++ b/include/trick/attributes.h
@@ -62,7 +62,7 @@ typedef struct {
 /**
  * ATTRIBUTES are data structures that represent detailed descriptions of data
  * types, including how an instance of a datatype is represented in memory.
- * ATTRIBUTES are fundemental to the design of Trick's Memory Management.
+ * ATTRIBUTES are fundamental to the design of Trick's Memory Management.
  *
  * The ICG code generator generates arrays of ATTRIBUTES, of varying lengths,
  * for each of the structured datat types that it finds in a header (.h or .hh)

--- a/include/trick/dmtcp_checkpoint_c_intf.hh
+++ b/include/trick/dmtcp_checkpoint_c_intf.hh
@@ -17,7 +17,7 @@ extern "C" {
 /* call DMTCP function dmtcpIsEnabled() */
 int dmtcp_is_enabled() ;
 
-/* call DMTCP funcion dmtcpRunCommand() */
+/* call DMTCP function dmtcpRunCommand() */
 int call_dmtcp();
 
 /* DMTCP jobs to run pre, post, and restart. Arguments for dmtcpInstallHooks() - defined in dmtcp/src/dmtcpaware.c */

--- a/include/trick/ms_sim_mode.h
+++ b/include/trick/ms_sim_mode.h
@@ -8,7 +8,7 @@ PROGRAMMERS:
 
 /**
  * @class MS_SIM_COMMAND sim_mode.h
- * The MS_SIM_COMMAND enumeration represents the TRICK simulation commmands.
+ * The MS_SIM_COMMAND enumeration represents the TRICK simulation commands.
  */
 
 #ifndef MS_SIMMODE_HH

--- a/include/trick/rand_generator.h
+++ b/include/trick/rand_generator.h
@@ -91,7 +91,7 @@ typedef struct {
     double mu;            /* -- mean for gauss/poisson distribution */
     double min;           /* -- Minimum value in range */
     double max;           /* -- Maximum value in range */
-    int rel_min;          /* -- Minimun is a relative minimum */
+    int rel_min;          /* -- Minimum is a relative minimum */
     int rel_max;          /* -- Maximum is a relative maximum */
     int sigma_range;      /* --  Sigma range for output random num
                                  Must be > 0 for triangular gauss.

--- a/include/trick/sim_mode.h
+++ b/include/trick/sim_mode.h
@@ -8,7 +8,7 @@ PROGRAMMERS:
 
 /**
  * @enum SIM_COMMAND
- * The SIM_COMMAND enumeration represents the TRICK simulation commmands.
+ * The SIM_COMMAND enumeration represents the TRICK simulation commands.
  */
 
 #ifndef SIMMODE_HH

--- a/include/trick/sizedata.h
+++ b/include/trick/sizedata.h
@@ -1,7 +1,7 @@
 /* This is an attempt at keeping data sizes consistent across machines
 by defining a INT8,INT16, and INT32 type for use as 8,16,and 32 bit
 integers.  These won't work well with i/o like printf, but are useful
-for transfering binary data from one machine to another. */
+for transferring binary data from one machine to another. */
 
 #ifndef SIZEDATA_H
 #define SIZEDATA_H

--- a/include/trick/swig/trick_swig.i
+++ b/include/trick/swig/trick_swig.i
@@ -13,7 +13,7 @@
 
 /*
    compactdefaultargs fixes a bug with enumeration default arguments not being
-   recogized in function calls starting in swig 3.0.x
+   recognized in function calls starting in swig 3.0.x
  */
 %feature("compactdefaultargs") ;
 

--- a/include/trick/trick_error_hndlr.h
+++ b/include/trick/trick_error_hndlr.h
@@ -72,8 +72,8 @@ typedef struct _TrickErrorHndlr {
 void trick_error_func_default(
         TrickErrorHndlr * error_hndlr, /* IN: -- Error object */
         TrickErrorLevel level,         /* IN: -- Error level */
-        char *file,        /* IN: -- File in which error ocurred */
-        int line,          /* IN: -- Line in which error ocurred */
+        char *file,        /* IN: -- File in which error occurred */
+        int line,          /* IN: -- Line in which error occurred */
         char *msg);        /* IN: -- Error message  */
 
 void trick_error_init(  /* RETURN: -- None  */
@@ -157,8 +157,8 @@ void trick_error_report(
         TrickErrorHndlr * error_hndlr, /* IN: -- Error object */
         TrickErrorLevel error_level,   /* IN: -- Err level for
                                                  this error */
-        const char *file,              /* IN: -- File in which error_ occured */
-        int line,                      /* IN: -- Line number where error_ occured */
+        const char *file,              /* IN: -- File in which error_ occurred */
+        int line,                      /* IN: -- Line number where error_ occurred */
         const char *format,            /* IN: -- Error_ message format */
         ...);                          /* IN: ** variable length arg list */
 

--- a/include/trick/trick_math_proto.h
+++ b/include/trick/trick_math_proto.h
@@ -546,7 +546,7 @@ double gauss_rnd_bell(RAND_GENERATOR * G);
 #endif
 
 /*
- * Function macros to provide backward compatability with earlier versions
+ * Function macros to provide backward compatibility with earlier versions
  */
 #define deuler_123( ang, mat, method ) \
           euler123( ang, mat, method, (double*)0, __FILE__, __LINE__ )

--- a/test/SIM_test_ip/RUN_test/unit_test.py
+++ b/test/SIM_test_ip/RUN_test/unit_test.py
@@ -978,7 +978,7 @@ def main():
 
 ######################################################################################################################
 
-    test_suite = "unsinged long"
+    test_suite = "unsigned long"
 
     test_so.obj.ul = 95
     TRICK_EXPECT_EQ( test_so.obj.ul , 95 , test_suite , "assignment" )

--- a/test/SIM_test_sched/models/sched/include/sched.h
+++ b/test/SIM_test_sched/models/sched/include/sched.h
@@ -18,7 +18,7 @@ typedef struct { /* SCHEDULE ------------------------------------------------*/
   double acc ;    /* m/s2 Acceleration */
   double mass ;   /* kg   Mass */
   int amf     ;   /* --   Just a test variable */
-  int amf_error ; /* --  Order error occured in amf job */
+  int amf_error ; /* --  Order error occurred in amf job */
   REGULA_FALSI rf ; /* -- Dynamic event */
 
 } SCHEDULE ; /*--------------------------------------------------------------*/

--- a/trick_source/data_products/Log/log.cpp
+++ b/trick_source/data_products/Log/log.cpp
@@ -1034,7 +1034,7 @@ int LogData::setUnit(int paramIdx, std::string to_units)
         return (1);
 }
 
-/** Get the value of a paramter at a given time stamp
+/** Get the value of a parameter at a given time stamp
  *  Find value around an epsilon of time stamp
  *  return -1 if can't find value with time stamp
  */
@@ -1221,7 +1221,7 @@ void LogGroup::getMinMaxStats(const char *param,
         log[yLogIdx]->getMinMaxStats(yIdx, tmin, min, tmax, max);
 }
 
-/** Set scale factor for given paramter and given factor */
+/** Set scale factor for given parameter and given factor */
 int LogGroup::setScaleFactor(int logIdx, int paramIdx, double factor)
 {
 
@@ -1292,7 +1292,7 @@ int LogGroup::setUnit(const char *paramName, std::string u)
         return (1);
 }
 
-/** Get the value of a paramter at a given time stamp
+/** Get the value of a parameter at a given time stamp
  *  Return value around an epsilon of time stamp
  */
 int LogGroup::getValueAtTime( const char *paramName,
@@ -1656,7 +1656,7 @@ void IterMultiRun::operator++(int) {
         }
 
         // Get all values in all data log groups
-        // Also get mininum time stamp from all log data files
+        // Also get minimum time stamp from all log data files
         t1 = iter1_->getTime();
         t2 = iter2_->getTime();
         if ( t1 <= t2 ) {
@@ -1673,8 +1673,8 @@ void IterMultiRun::operator++(int) {
                 (*iter2_)++ ;
         }
 
-        // Now that a time step has occured
-        // Get the new mininum time stamp
+        // Now that a time step has occurred
+        // Get the new minimum time stamp
         t1 = iter1_->getTime();
         t2 = iter2_->getTime();
         if ( t1 <= t2 ) {
@@ -1855,7 +1855,7 @@ int IterPreserveTime::stepInTime() {
         char* rec ;
 
         // Get all values in all data log groups
-        // Also get mininum time stamp from all log data files
+        // Also get minimum time stamp from all log data files
         minTime = getTime();
 
         // Take a step through time (sounds like a song)
@@ -1878,8 +1878,8 @@ int IterPreserveTime::stepInTime() {
                 return(1) ;
         }
 
-        // Now that a time step has occured
-        // Get the new mininum time stamp and associated
+        // Now that a time step has occurred
+        // Get the new minimum time stamp and associated
         // values from all log data files
         minTime = getTime();
 

--- a/trick_source/er7_utils/integration/core/include/priming_integrator_constructor.hh
+++ b/trick_source/er7_utils/integration/core/include/priming_integrator_constructor.hh
@@ -70,7 +70,7 @@ public:
    /**
     * Indicate whether the integration technique will always takes a
     * pre-determined number of integration steps per integration cycle.@n
-    * This implemenetation assumes the primary technique is a fixed step
+    * This implementation assumes the primary technique is a fixed step
     * integrator, but that the primer might not be.
     * @return True if the primer is also fixed step, false otherwise.
     */

--- a/trick_source/java/src/main/java/trick/common/ui/TrickFileFilter.java
+++ b/trick_source/java/src/main/java/trick/common/ui/TrickFileFilter.java
@@ -70,7 +70,7 @@ public class TrickFileFilter implements java.io.FileFilter {
 	}
 	
 	/**
-	 * Sets file name mathing criteria for the filter.
+	 * Sets file name matching criteria for the filter.
 	 * 
 	 * @param matching	This filter cannot be accepted if {@link File} is a file and 
 	 *                  its name doesn't contain the matching string.	

--- a/trick_source/java/src/main/java/trick/common/ui/UIUtils.java
+++ b/trick_source/java/src/main/java/trick/common/ui/UIUtils.java
@@ -421,7 +421,7 @@ public class UIUtils {
 	/**
 	 * Search to see if an input string has the search string. 
 	 * The search string can have "*". If there is no wildcard, 
-	 * it simply checks if inputStr string contians the searchStr string.
+	 * it simply checks if inputStr string contains the searchStr string.
 	 * 
 	 * @param inputStr - the input search string.
 	 * @param searchStr - the search string which searching is based upon.

--- a/trick_source/java/src/main/java/trick/common/ui/components/DoubleJSlider.java
+++ b/trick_source/java/src/main/java/trick/common/ui/components/DoubleJSlider.java
@@ -188,7 +188,7 @@ public class DoubleJSlider extends JSlider implements ChangeListener{
         DoubleJSlider slider;
         
         /**
-         * Constructor with specifed slider.
+         * Constructor with specified slider.
          * 
          * @param slider	The specified {@link DoubleJSlider}.
          */

--- a/trick_source/java/src/main/java/trick/dataproducts/DataProductsApplication.java
+++ b/trick_source/java/src/main/java/trick/dataproducts/DataProductsApplication.java
@@ -502,7 +502,7 @@ public abstract class DataProductsApplication extends TrickApplication {
     }
 
     /**
-     * Resets all commond fields if available.
+     * Resets all command fields if available.
      */
     public void resetCommonFields() {
         if (titleField != null) {

--- a/trick_source/java/src/main/java/trick/dataproducts/trickdp/utils/DPRemoteCallInterface.java
+++ b/trick_source/java/src/main/java/trick/dataproducts/trickdp/utils/DPRemoteCallInterface.java
@@ -14,7 +14,7 @@ import java.rmi.RemoteException;
 /**
  * Interface for remote calles needed for trick_dp.
  * Basically, other application can make these calls to 
- * trick_dp applicaiton if necessary.
+ * trick_dp application if necessary.
  * 
  * @since Trick 10
  */

--- a/trick_source/java/src/main/java/trick/dataproducts/trickdp/utils/DPRemoteCallInterfaceImpl.java
+++ b/trick_source/java/src/main/java/trick/dataproducts/trickdp/utils/DPRemoteCallInterfaceImpl.java
@@ -16,7 +16,7 @@ import trick.dataproducts.utils.Session;
 /**
  * Implementation for remote calles needed for trick_dp.
  * Basically, other application can make these calls to 
- * trick_dp applicaiton if necessary.
+ * trick_dp application if necessary.
  * 
  * @since Trick 10
  */

--- a/trick_source/java/src/main/java/trick/dataproducts/trickqp/utils/QPRemoteCallInterface.java
+++ b/trick_source/java/src/main/java/trick/dataproducts/trickqp/utils/QPRemoteCallInterface.java
@@ -14,7 +14,7 @@ import java.rmi.RemoteException;
 /**
  * Interface for remote calles needed for trick_qp.
  * Basically, other application can make these calls to 
- * trick_qp applicaiton if necessary.
+ * trick_qp application if necessary.
  * 
  * @since Trick 10
  */

--- a/trick_source/java/src/main/java/trick/dataproducts/trickqp/utils/QPRemoteCallInterfaceImpl.java
+++ b/trick_source/java/src/main/java/trick/dataproducts/trickqp/utils/QPRemoteCallInterfaceImpl.java
@@ -18,7 +18,7 @@ import trick.dataproducts.utils.SessionRun;
 /**
  * Implementation for remote calles needed for trick_qp.
  * Basically, other application can make these calls to 
- * trick_qp applicaiton if necessary.
+ * trick_qp application if necessary.
  * 
  * @since Trick 10
  */

--- a/trick_source/java/src/main/java/trick/montemonitor/MonteMonitorApplication.java
+++ b/trick_source/java/src/main/java/trick/montemonitor/MonteMonitorApplication.java
@@ -156,7 +156,7 @@ public class MonteMonitorApplication extends RunTimeTrickApplication {
                     removeSlave(i);
                 }
 
-                // Start getting updates in an infinite backgound Worker thread.
+                // Start getting updates in an infinite background Worker thread.
                 new Monitor().execute();
                 variableServerConnection.clear();
                 variableServerConnection.add("trick_mc.mc.actual_num_runs");

--- a/trick_source/java/src/main/java/trick/sniffer/SimulationListener.java
+++ b/trick_source/java/src/main/java/trick/sniffer/SimulationListener.java
@@ -26,7 +26,7 @@ public interface SimulationListener {
     /**
      * called when the source experiences an unhandled exception
      *
-     * @param exception the exception that occured
+     * @param exception the exception that occurred
      */
     public void exceptionOccurred(Exception exception);
 

--- a/trick_source/java/src/main/java/trick/tv/TVApplication.java
+++ b/trick_source/java/src/main/java/trick/tv/TVApplication.java
@@ -2218,7 +2218,7 @@ public class TVApplication extends RunTimeTrickApplication implements VariableLi
     }
 
     /**
-     * allows the user to specifiy an index range for pointers
+     * allows the user to specify an index range for pointers
      */
     class IndexTextField extends JXTextField {
 

--- a/trick_source/sim_services/CheckPointAgent/ClassicCheckPointerAgent.cpp
+++ b/trick_source/sim_services/CheckPointAgent/ClassicCheckPointerAgent.cpp
@@ -148,7 +148,7 @@ void Trick::ClassicCheckPointAgent::write_decl(std::ostream& chkpnt_os, ALLOC_IN
    Given an address, that is within the bounds of a composite
    object (i.e., a struct or class instance), return the corresponding sub-name.
 
-   A return value of NULL indicates an error occured. Note that this is not
+   A return value of NULL indicates an error occurred. Note that this is not
    the same as a return value of "", which is valid.
 
    The following BNF production describes a valid sub-reference:

--- a/trick_source/sim_services/Collect/collect.cpp
+++ b/trick_source/sim_services/Collect/collect.cpp
@@ -5,7 +5,7 @@
 
 /**
 @brief
-Adds the addess, collectee, to the list pointed to by collector.  Returns a new pointer
+Adds the address, collectee, to the list pointed to by collector.  Returns a new pointer
 to the new list.  The old list a collector will be freed.
 @details
 -# Get the current list length
@@ -46,7 +46,7 @@ void ** add_collect( void ** collector , void * collectee ) {
 
 /**
 @brief
-Deletes the addess, collectee, from the list pointed to by collector.  Returns a new pointer
+Deletes the address, collectee, from the list pointed to by collector.  Returns a new pointer
 to the new list.  The old list a collector will be freed.
 @details
 -# Get the current list length

--- a/trick_source/sim_services/DMTCP/DMTCP.cpp
+++ b/trick_source/sim_services/DMTCP/DMTCP.cpp
@@ -171,11 +171,11 @@ std::string Trick::DMTCP::getScriptName() {
         mmw_script_name = stripped_name;
     }
 
-    // User specifed a valid script name (or is using default script name)
+    // User specified a valid script name (or is using default script name)
     if ( ( mmw_script_name == default_script_name.str() ) or ( !isSpecialCharacter( mmw_script_name ) ) )
         restart_script_name = mmw_script_name;
 
-    // User specifed an invalid script name
+    // User specified an invalid script name
     else {
         std::cout << mmw_script_name.c_str() << " is not a valid name. The default DMTCP script name will be used: " << default_script_name.str() << endl;
         restart_script_name = default_script_name.str();

--- a/trick_source/sim_services/DataRecord/DRHDF5.cpp
+++ b/trick_source/sim_services/DataRecord/DRHDF5.cpp
@@ -173,7 +173,7 @@ int Trick::DRHDF5::format_specific_init() {
         hdf5_info->dataset = H5PTcreate_fl(root_group, rec_buffer[ii]->ref->reference, datatype, chunk_size, 1) ;
 
         if ( hdf5_info->dataset == H5I_BADID ) {
-            message_publish(MSG_ERROR, "An error occured in data record group \"%s\" when adding \"%s\".\n",
+            message_publish(MSG_ERROR, "An error occurred in data record group \"%s\" when adding \"%s\".\n",
              group_name.c_str() , rec_buffer[ii]->ref->reference) ;
         }
 
@@ -293,7 +293,7 @@ int Trick::DRHDF5::format_specific_write_data(unsigned int writer_offset __attri
     for (ii = 0; ii < parameters.size(); ii++) {
 
         /* Each parameters[] element contains a DataRecordBuffer class.
-         * So there is a seperate DataRecordBuffer per variable.
+         * So there is a separate DataRecordBuffer per variable.
          * Point to the value to be recorded. */
         HDF5_INFO * hi = parameters[ii] ;
         buf = hi->drb->buffer + (writer_offset * hi->drb->ref->attr->size) ;

--- a/trick_source/sim_services/DataRecord/DataRecordGroup.cpp
+++ b/trick_source/sim_services/DataRecord/DataRecordGroup.cpp
@@ -26,7 +26,7 @@
 -# The recording group is set to allocate a maximum of 100,000 records in memory
 -# The recording group is set to record at a cycle period of 0.1 seconds.
 -# The first recording parameter is assigned to simulation time.  The name of
-   the parmeter is named "sys.exec.out.time" to preserve backwards compatibility
+   the parameter is named "sys.exec.out.time" to preserve backwards compatibility
    with older %Trick releases.
 -# The call_function and call_function_double functions inherited from the SimObject
    are populated.  The data_record function is added as a job for this SimObject.

--- a/trick_source/sim_services/DataTypes/include/TypeDictionary.hh
+++ b/trick_source/sim_services/DataTypes/include/TypeDictionary.hh
@@ -22,7 +22,7 @@ class TypeDictionary {
     const DataType* getDataType(std::string typeName);
 
     /**
-     Add a type definiton to the dictionary.
+     Add a type definition to the dictionary.
      */
     void addTypeDefinition(std::string name, DataType * typeSpec)
          ;

--- a/trick_source/sim_services/DataTypes/testing/CompTypeSpecTest.cpp
+++ b/trick_source/sim_services/DataTypes/testing/CompTypeSpecTest.cpp
@@ -175,7 +175,7 @@ TEST_F(CompositeDataTypeTest, assignValue_1) {
 
 TEST_F(CompositeDataTypeTest, assignValue_2) {
 
-    /* Requirment:  */
+    /* Requirement:  */
     ClassTwo classTwo;
     classTwo.x = 0;
     classTwo.y = 0.0;
@@ -209,7 +209,7 @@ TEST_F(CompositeDataTypeTest, assignValue_2) {
 
 TEST_F(CompositeDataTypeTest, assignValue_3) {
 
-    /* Requirment:  */
+    /* Requirement:  */
     ClassThree classThree;
     classThree.pos[0] = 0.0;
     classThree.pos[1] = 0.0;
@@ -300,7 +300,7 @@ TEST_F(CompositeDataTypeTest, assignValue_5) {
 
 TEST_F(CompositeDataTypeTest, printValue_4) {
 
-    /* Requirment:  */
+    /* Requirement:  */
 
     ClassFour classFour;
     classFour.x[0] = 0.0;

--- a/trick_source/sim_services/Executive/Executive_add_jobs_to_queue.cpp
+++ b/trick_source/sim_services/Executive/Executive_add_jobs_to_queue.cpp
@@ -90,7 +90,7 @@ int Trick::Executive::add_jobs_to_queue( Trick::SimObject * in_sim_object , bool
         ret = add_job_to_queue(temp_job) ;
 
         /* If add_jobs is called during initialization, restart_flag == false,
-           calcluate the cycle/start/stop times for the job */
+           calculate the cycle/start/stop times for the job */
         if ( (restart_flag == false) and (temp_job->job_class >= scheduled_start_index) and (ret == 0 )) {
 
             temp_job->calc_cycle_tics() ;

--- a/trick_source/sim_services/Executive/Executive_call_default_data.cpp
+++ b/trick_source/sim_services/Executive/Executive_call_default_data.cpp
@@ -14,7 +14,7 @@
    -# The scheduler will immediately return if the default_data job returns a
       non-zero return code.  The return code of the default_data job will be
       returned from Trick::Executive::init().
--# If no execption is thrown return 0
+-# If no exception is thrown return 0
 */
 int Trick::Executive::call_default_data() {
 

--- a/trick_source/sim_services/Executive/Executive_call_initialization.cpp
+++ b/trick_source/sim_services/Executive/Executive_call_initialization.cpp
@@ -11,7 +11,7 @@
    -# The scheduler will immediately return if the initialization job returns a
       non-zero return code.  The return code of the initialization job will be
       returned from Trick::Executive::init().
--# If no execption is thrown return 0
+-# If no exception is thrown return 0
 */
 int Trick::Executive::call_initialization() {
 

--- a/trick_source/sim_services/Executive/Executive_call_input_processor.cpp
+++ b/trick_source/sim_services/Executive/Executive_call_input_processor.cpp
@@ -12,7 +12,7 @@
    -# The scheduler will immediately return if the default_data job returns a
       non-zero return code.  The return code of the default_data job will be
       returned from Trick::Executive::init().
--# If no execption is thrown return 0
+-# If no exception is thrown return 0
 */
 int Trick::Executive::call_input_processor() {
 

--- a/trick_source/sim_services/Executive/Executive_fpe_handler.cpp
+++ b/trick_source/sim_services/Executive/Executive_fpe_handler.cpp
@@ -28,7 +28,7 @@
 @design
 -# This signal handler processes SIGFPE
 -# Write a message to stderr that a signal has been caught.
--# In Linux print out the type of floating point error that occured.
+-# In Linux print out the type of floating point error that occurred.
 -# If attach_debugger == true, attempt to attach a debugger to the current process.
 -# Else if stack_trace == true, attempt to attach a debugger to print a stack trace.
 -# Exit the process with a -2 return.

--- a/trick_source/sim_services/Executive/Executive_init.cpp
+++ b/trick_source/sim_services/Executive/Executive_init.cpp
@@ -18,7 +18,7 @@
    Requirement [@ref r_exec_time_1].
 -# If an exception is caught, print as much error information available based
    on execption type caught and exit.
--# If no execption is caught return 0
+-# If no exception is caught return 0
 */
 int Trick::Executive::init() {
 

--- a/trick_source/sim_services/Executive/Executive_loop.cpp
+++ b/trick_source/sim_services/Executive/Executive_loop.cpp
@@ -15,11 +15,11 @@
 -# The scheduler calls Executive::loop_multi_thread() if more than one thread of
    execution is present.
    Requirement  [@ref r_exec_mode_1]
--# If an exception is caught, the return code, file where the exception occured, and the
+-# If an exception is caught, the return code, file where the exception occurred, and the
    reason for the exception is saved.  The exception return code is returned.
 -# If an unknown exception is caught, set the exception return code to -1, the file to unknown, and the
    reason for the exception as unknown.  The exception return code is returned.
--# If no execption is caught return 0
+-# If no exception is caught return 0
 */
 int Trick::Executive::loop() {
 

--- a/trick_source/sim_services/Executive/Executive_process_sim_args.cpp
+++ b/trick_source/sim_services/Executive/Executive_process_sim_args.cpp
@@ -21,7 +21,7 @@
 /**
 @details
 -# If there are command line arguments
-   -# If the argument is "trick_version" print out the verion of Trick used to build the
+   -# If the argument is "trick_version" print out the version of Trick used to build the
       simulation and exit.
    -# If the argument is "help" print out a help message about the possible command line
       arguments and exit.

--- a/trick_source/sim_services/Executive/fpe_handler.cpp
+++ b/trick_source/sim_services/Executive/fpe_handler.cpp
@@ -21,7 +21,7 @@
 /**
  * @relates Trick::Executive
  * C binded function to handle the SIGFPE signal.  The handler prints which type of
- * floating point error has occured and calls exec_terminate()
+ * floating point error has occurred and calls exec_terminate()
  * @return void
  */
 #if (__APPLE__ | __CYGWIN__ | __INTERIX )

--- a/trick_source/sim_services/InputProcessor/MTV.cpp
+++ b/trick_source/sim_services/InputProcessor/MTV.cpp
@@ -18,7 +18,7 @@ Adds an event to mtv list.
 
 -# Check to see if the event is already in the mtv list, return if it is.
 -# Increment the number of events in the mtv list.
--# Reallocate the mtv_list to accomodate the new event.
+-# Reallocate the mtv_list to accommodate the new event.
 -# Assign the last element of mtv_list to the incoming event.
 -# Increment the update ticker so mtv knows something changed.
 */

--- a/trick_source/sim_services/Integrator/src/IntegLoopManager.cpp
+++ b/trick_source/sim_services/Integrator/src/IntegLoopManager.cpp
@@ -157,7 +157,7 @@ void Trick::IntegrationManager::create_sim_object_info (
 
 /**
  Transfer the relegated jobs in a SimObjectIntegInfo to the SimObjectIntegInfo
- specfied by the relegated job's sup_class_data handle.
+ specified by the relegated job's sup_class_data handle.
  @param sim_obj_info A member of the manager's sim_objects_info vector.
  */
 void Trick::IntegrationManager::transfer_relegated_jobs (

--- a/trick_source/sim_services/JSONVariableServer/JSONVariableServer.cpp
+++ b/trick_source/sim_services/JSONVariableServer/JSONVariableServer.cpp
@@ -116,7 +116,7 @@ int Trick::JSONVariableServer::check_and_move_listen_device() {
 /*
 @details
 -# Loop forever for new connections
- -# create a new VariableServerThread when new conection found
+ -# create a new VariableServerThread when new connection found
  -# create new VariableServerThread thread
 */
 void * Trick::JSONVariableServer::thread_body() {

--- a/trick_source/sim_services/MasterSlave/MSSharedMem.cpp
+++ b/trick_source/sim_services/MasterSlave/MSSharedMem.cpp
@@ -66,7 +66,7 @@ int Trick::MSSharedMem::accept() {
     tsm_dev.size = sizeof(MSSharedMemData);
     ret = tsm_init(&tsm_dev);
     shm_addr = (MSSharedMemData*) tsm_dev.addr;
-    /** @li Save master process id so we can keep master and slave data seperate. */
+    /** @li Save master process id so we can keep master and slave data separate. */
     // (the master calls accept)
     if (ret==TSM_SUCCESS) {
         shm_addr->master_pid = getpid();

--- a/trick_source/sim_services/MemoryManager/ref_to_value.c
+++ b/trick_source/sim_services/MemoryManager/ref_to_value.c
@@ -2,7 +2,7 @@
    PURPOSE: (Returns value of parameter referenced by right side parameter.)
 
    ASSUMPTIONS AND LIMITATIONS: ((Handles only the following 'C' types: char, unsigned char, char*, int, unsigned int,
-   long, unsinged long, short, unsigned short, float, double))
+   long, unsigned long, short, unsigned short, float, double))
 
    PROGRAMMERS: (((Alex Lin) (NASA) (9/00))) */
 

--- a/trick_source/sim_services/MemoryManager/test/MM_write_checkpoint_hexfloat.cc
+++ b/trick_source/sim_services/MemoryManager/test/MM_write_checkpoint_hexfloat.cc
@@ -59,7 +59,7 @@ TEST_F(MM_write_checkpoint_hexfloat, dbl_singleton) {
     *dbl_p = 3.1415;
 
     // 3. Tell the MemoryManager that when checkpointing, floating point values
-    // are to be represented as hexidecimal values (to preserve precision).
+    // are to be represented as hexadecimal values (to preserve precision).
     memmgr->set_hexfloat_checkpoint(1);
 
     // 4. Write a checkpoint to the stream.
@@ -92,7 +92,7 @@ TEST_F(MM_write_checkpoint_hexfloat, dbl_array) {
     dbl_p[2] = 3.3;
 
     // 3. Tell the MemoryManager that when checkpointing, floating point values
-    // are to be represented as hexidecimal values (to preserve precision).
+    // are to be represented as hexadecimal values (to preserve precision).
     memmgr->set_hexfloat_checkpoint(1);
 
     // 4. Write a checkpoint to the stream.

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_run_queue.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_run_queue.cpp
@@ -12,7 +12,7 @@
    -# The scheduler will immediately return if the job returns a
       non-zero return code.  The return code of the job will be
       returned from Trick::Executive::init().
--# If no execption is thrown return 0
+-# If no exception is thrown return 0
 */
 int Trick::MonteCarlo::run_queue(Trick::ScheduledJobQueue* queue, std::string in_string) {
     int ret = 0 ;

--- a/trick_source/sim_services/ThreadBase/ThreadBase.cpp
+++ b/trick_source/sim_services/ThreadBase/ThreadBase.cpp
@@ -207,7 +207,7 @@ int Trick::ThreadBase::execute_priority() {
 
     int ret;
 
-    /* Declare scheduling paramters. */
+    /* Declare scheduling parameters. */
     int max_priority;
     int min_priority;
     int prev_priority;

--- a/trick_source/trick_utils/math/src/eigen_jacobi.c
+++ b/trick_source/trick_utils/math/src/eigen_jacobi.c
@@ -18,7 +18,7 @@ int eigen_jacobi(double **k,    /* In: Input stiffness matrix */
                  double **v,    /* Out: Output a set of eigen vectors */
                  double *alpha, /* Out: Output a set of eigen values */
                  int m,         /* In: Input dimension of matrix */
-                 int mmax,      /* In: Input maximun dimension of matrix */
+                 int mmax,      /* In: Input maximum dimension of matrix */
                  int sort)
 {                                      /* In: Input sorting flag */
     int i, ip1, j, n, jmin, loop;

--- a/trick_source/trick_utils/math/src/eigen_jacobi_4.c
+++ b/trick_source/trick_utils/math/src/eigen_jacobi_4.c
@@ -17,7 +17,7 @@ void eigen_jacobi_4(double k[4][4],     /* In: input stiffness matrix */
                     double v[4][4],     /* Out: output a set of eigen vectors */
                     double alpha[4],    /* Out: output a set of eigen values */
                     int m,      /* In: input dimension of matrix */
-                    int mmax,   /* In: input maximun dimension of matrix */
+                    int mmax,   /* In: input maximum dimension of matrix */
                     int sort)
 {                                      /* In: input sorting flag */
     int i, ip1, j, n, jmin, loop;

--- a/trick_source/trick_utils/math/src/uniform_rnd_1.c
+++ b/trick_source/trick_utils/math/src/uniform_rnd_1.c
@@ -32,7 +32,7 @@
 #include "trick/trick_math.h"
 
 #ifndef HZ
-#define HZ 100                         /* This is a kludge to accomodate for Darwin. On Darwin HZ is actually a kernal
+#define HZ 100                         /* This is a kludge to accommodate for Darwin. On Darwin HZ is actually a kernal
                                           global variable. I suppose I should use that but this will suffice. */
 #endif
 

--- a/trick_source/trick_utils/unicode/test/unicode_utils_test.cpp
+++ b/trick_source/trick_utils/unicode/test/unicode_utils_test.cpp
@@ -304,7 +304,7 @@ TEST(unescape_to_utf8, non_ascii_chars) {
 }
 
 TEST(unescape_to_utf8, insufficient_hex_digits_1) {
-    /* The \U escape code expects exactly 8 hexidecimal digits to follow.
+    /* The \U escape code expects exactly 8 hexadecimal digits to follow.
        If fewer than 8 are present, then an error message should result.
        Note: "\U10110" will fail in a C/C++ literal at compile time too,
        because it is incomplete. It should be "\U00010110".
@@ -319,7 +319,7 @@ TEST(unescape_to_utf8, insufficient_hex_digits_1) {
 }
 
 TEST(unescape_to_utf8, insufficient_hex_digits_2) {
-    /* The \u escape code expects exactly 4 hexidecimal digits to follow.
+    /* The \u escape code expects exactly 4 hexadecimal digits to follow.
        If fewer than 4 are present, then an error message should result.
        Note: "\u3d5" will fail in a C/C++ literal at compile time too,
        because it is incomplete. It should be "\u03d5".

--- a/trick_source/trick_utils/units/test/UnitTestSuite.cpp
+++ b/trick_source/trick_utils/units/test/UnitTestSuite.cpp
@@ -777,7 +777,7 @@ TEST_F(UnitConversion, InvalidFootPound)
 }
 
 //Invalid Conversion Tests
-//Should throw an exception (exeption = PASS)
+//Should throw an exception (exception = PASS)
 
 TEST_F(UnitConversion, NewtonMeterToInvalidFootPound)
 {


### PR DESCRIPTION
fixing typo spelling grammar and replace to correct word with reference from [merriam webster](merriam-webster.com)