### PR TITLE
Fix ICG errors while processing system header files #1189

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/HeaderSearchDirs.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/HeaderSearchDirs.cpp
@@ -380,8 +380,28 @@ void HeaderSearchDirs::addDefines ( std::vector<std::string> & defines ) {
 
     // Add -D command line arguments as well as "#define TRICK_ICG" to the preprocessor
     unsigned int ii ;
-    std::string predefines("#define TRICK_ICG\n") ;
-    predefines += "#define __STRICT_ANSI__\n" ;
+    std::string predefines("#define TRICK_ICG\n");
+    predefines += "#define __STRICT_ANSI__\n";
+
+    // These defines come from running "clang -dM -E - < /dev/null".  Can't find how they get added in normal
+    // compilation.  This isn't the prettiest, but it gets the defines defined.
+    predefines += "#define __GCC_ASM_FLAG_OUTPUTS__ 1\n";
+    predefines += "#define __GCC_ATOMIC_BOOL_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_CHAR_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_INT_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_LLONG_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_LONG_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_POINTER_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_SHORT_LOCK_FREE 2\n";
+    predefines += "#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1\n";
+    predefines += "#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2\n";
+    predefines += "#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1\n";
+    predefines += "#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1\n";
+    predefines += "#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1\n";
+    predefines += "#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1\n";
+
     for ( ii = 0 ; ii < defines.size() ; ii++ ) {
         size_t found = defines[ii].find("=") ;
         if ( found != defines[ii].npos ) {

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -51,6 +51,23 @@ llvm::cl::alias compat15_alias ("compat15" , llvm::cl::desc("Alias for -c") , ll
 llvm::cl::opt<bool> m32("m32", llvm::cl::desc("Generate io code for use with 32bit mode"), llvm::cl::init(false), llvm::cl::ZeroOrMore) ;
 
 
+void set_lang_opts(clang::CompilerInstance & ci) {
+    ci.getLangOpts().CXXExceptions = true ;
+    // Activate C++11 parsing
+    ci.getLangOpts().Bool = true ;
+    ci.getLangOpts().WChar = true ;
+    ci.getLangOpts().CPlusPlus = true ;
+    ci.getLangOpts().CPlusPlus11 = true ;
+    ci.getLangOpts().CXXOperatorNames = true ;
+#if (LIBCLANG_MAJOR >= 6)
+    ci.getLangOpts().CPlusPlus14 = true ;
+    ci.getLangOpts().DoubleSquareBracketAttributes = true ;
+#endif
+    // Activate C++17 parsing
+#if (LIBCLANG_MAJOR >= 10)
+    ci.getLangOpts().CPlusPlus17 = true ;
+#endif
+}
 /**
 Most of the main program is pieced together from examples on the web. We are doing the following:
 
@@ -99,19 +116,7 @@ int main(int argc, char * argv[]) {
     ci.createDiagnostics();
     ci.getDiagnosticOpts().ShowColors = 1 ;
     ci.getDiagnostics().setIgnoreAllWarnings(true) ;
-    ci.getLangOpts().CXXExceptions = true ;
-    // Activate C++11 parsing
-    ci.getLangOpts().Bool = true ;
-    ci.getLangOpts().WChar = true ;
-    ci.getLangOpts().CPlusPlus = true ;
-    ci.getLangOpts().CPlusPlus11 = true ;
-#if (LIBCLANG_MAJOR >= 6)
-    ci.getLangOpts().CPlusPlus14 = true ;
-#endif
-    ci.getLangOpts().CXXOperatorNames = true ;
-#if (LIBCLANG_MAJOR >= 6)
-    ci.getLangOpts().DoubleSquareBracketAttributes = true ;
-#endif
+    set_lang_opts(ci);
 
     // Create all of the necessary managers.
     ci.createFileManager();
@@ -157,13 +162,16 @@ int main(int argc, char * argv[]) {
 #else
     clang::CompilerInvocation::setLangDefaults(ci.getLangOpts(), clang::IK_CXX, trip, ppo) ;
 #endif
-    // setting the language defaults clears the c++11 flag.
-    ci.getLangOpts().CPlusPlus11 = true ;
-#if (LIBCLANG_MAJOR >= 6)
-    ci.getLangOpts().CPlusPlus14 = true ;
-#endif
+
+    // setting the language defaults clears some of the language opts, set them again.
+    set_lang_opts(ci);
+
 #endif
     clang::Preprocessor& pp = ci.getPreprocessor();
+
+#if (LIBCLANG_MAJOR >= 10)
+    clang::InitializePreprocessor(pp, ppo, ci.getPCHContainerReader(), ci.getFrontendOpts());
+#endif
 
     // Add all of the include directories to the preprocessor
     HeaderSearchDirs hsd(ci.getPreprocessor().getHeaderSearchInfo(), ci.getHeaderSearchOpts(), pp, sim_services_flag);


### PR DESCRIPTION
Found an InitPreprocessor call and am using it.  Not sure which version
of clang it was added, just using for the version I'm on (10) and above.
Also found some GCC defines that are used during normal compilation.
Added these to our list of defines during ICG.  This clears up all of
the errors I've been seeing.