### PR TITLE
add workaround for legacy code (bsaf)  on modern mac with java 17

### DIFF
--- a/libexec/trick/pm/launch_java.pm
+++ b/libexec/trick/pm/launch_java.pm
@@ -37,7 +37,8 @@ sub launch_java($$) {
         $command .= "\\
              -Xdock:name=\"$name\" \\
              -Xdock:icon=$java_dir/build/classes/trick/common/resources/trick_icon.png \\
-             -Djava.net.preferIPv4Stack=true \\" ;        
+             -Djava.net.preferIPv4Stack=true \\
+             --add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED \\" ;
     }
 
     $command .= "$java_dir/build/$application.jar ";
@@ -45,7 +46,6 @@ sub launch_java($$) {
     foreach (@ARGV) {
        $command .= "$_ ";
     }
-
     system $command ;
     exit $? >> 8 ;
 }


### PR DESCRIPTION
closes #613 

Still getting a message that macOS does not support EAWT (a different exception) but no stack trace