### PR TITLE
fixing doc typo for tutorial

### DIFF
--- a/docs/tutorial/ATutMonteCarlo.md
+++ b/docs/tutorial/ATutMonteCarlo.md
@@ -416,7 +416,7 @@ trick.stop(15)
 ```
 
 ### Simulation Definition
-The last the we need to do is modify our simulation definition file and add the two new Trick jobs. As you can see, we have added a new library dependency, a new ## inclusion, and two new constructor jobs.
+The last thing that we need to do is modify our simulation definition file and add the two new Trick jobs. As you can see, we have added a new library dependency, a new ## inclusion, and two new constructor jobs.
 ```C++
 /*
 PURPOSE: Monte tutorial simulation definition.


### PR DESCRIPTION
Hi, I found a typo in the documentation for the Monte Carlo Simulation in the Tutorial Section.

Here is the [link](https://nasa.github.io/trick/tutorial/ATutMonteCarlo#simulation-definition-1).

