### PR TITLE
Patch for #1409

### DIFF
--- a/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
+++ b/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
@@ -198,7 +198,8 @@ int vs_format_ascii(Trick::VariableReference * var, char *value, size_t value_si
             unit_str << " {" << ref->units << "}";
 
         }
-        strncat(value, unit_str.str().c_str(), value_size);
+        size_t max_copy_size = value_size - strlen(value) - 1;
+        strncat(value, unit_str.str().c_str(), max_copy_size);
     }
 
     return (0);

--- a/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
+++ b/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
@@ -198,7 +198,7 @@ int vs_format_ascii(Trick::VariableReference * var, char *value, size_t value_si
             unit_str << " {" << ref->units << "}";
 
         }
-        strlcat(value, unit_str.str().c_str(), value_size);
+        strncat(value, unit_str.str().c_str(), value_size);
     }
 
     return (0);

--- a/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
+++ b/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
@@ -198,7 +198,7 @@ int vs_format_ascii(Trick::VariableReference * var, char *value, size_t value_si
             unit_str << " {" << ref->units << "}";
 
         }
-        strcat(value, unit_str.str().c_str());
+        strlcat(value, unit_str.str().c_str(), value_size);
     }
 
     return (0);

--- a/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
+++ b/trick_source/sim_services/VariableServer/vs_format_ascii.cpp
@@ -9,6 +9,7 @@ PROGRAMMERS: (((Keith Vetter) (LinCom) (September 2001) (--)))
 #include <ctype.h>
 #include <limits>
 #include <udunits2.h>
+#include <sstream>
 
 #include "trick/parameter_types.h"
 #include "trick/attributes.h"
@@ -190,11 +191,14 @@ int vs_format_ascii(Trick::VariableReference * var, char *value, size_t value_si
     } //end while
 
     if (ref->units) {
+        std::stringstream unit_str;
         if ( ref->attr->mods & TRICK_MODS_UNITSDASHDASH ) {
-            snprintf(value, value_size, "%s {--}", value);
+            unit_str << " {--}";
         } else {
-            snprintf(value, value_size, "%s {%s}", value, ref->units);
+            unit_str << " {" << ref->units << "}";
+
         }
+        strcat(value, unit_str.str().c_str());
     }
 
     return (0);


### PR DESCRIPTION
Using the same buffer for the destination and as a parameter for sprintf is undefined behavior. We were doing this previously all over vs_format_ascii without issue:
```
sprintf(value, "%s {%s}", value, ref->units);
```
However, snprintf seems to handle that undefined behavior differently, and was overwriting anything else in value in this specific place. 

This pull request is meant to be a hotfix, but this whole section of the variable server really needs to be refactored.

Link #1409 