### PR TITLE
Fix various issues in scheduled CI jobs

### DIFF
--- a/.github/workflows/alt_linux_distros.yml
+++ b/.github/workflows/alt_linux_distros.yml
@@ -55,7 +55,6 @@ jobs:
               libudunits2-dev
               libgtest-dev
               default-jdk
-              python2.7-dev
               python3-dev
               python3-pip
               python3-venv

--- a/.github/workflows/alt_linux_distros.yml
+++ b/.github/workflows/alt_linux_distros.yml
@@ -113,7 +113,7 @@ jobs:
               apt-get update
               apt-get install -y tzdata
 #-------- Python2.7 dependencies ---------------------------              
-          - cfg: { os: debian }
+          - cfg: { arch: debian }
             python: 2
             python_deps: >-
               python2.7-dev

--- a/.github/workflows/alt_linux_distros.yml
+++ b/.github/workflows/alt_linux_distros.yml
@@ -112,6 +112,16 @@ jobs:
               export DEBIAN_FRONTEND=noninteractive
               apt-get update
               apt-get install -y tzdata
+#-------- Python2.7 dependencies ---------------------------              
+          - cfg: { os: debian }
+            python: 2
+            python_deps: >-
+              python2.7-dev
+#-------- Exclude bookworm on python 2 ---------------------         
+        exclude:
+          - cfg: { tag: bookworm }
+            python: 2
+            
 #-------- OS and Version Specific Dependencies ----------------
 # None
 #-------- Job definition ----------------
@@ -128,6 +138,7 @@ jobs:
           ${{matrix.arch_deps}} 
           ${{matrix.os_deps}} 
           ${{matrix.tag_deps}}
+          ${{matrix.python_deps}}
       - name: Install GTest
         run: ${{matrix.install_gtest}}
       - name: Checkout repository

--- a/.github/workflows/report_alt_linux_distros.yml
+++ b/.github/workflows/report_alt_linux_distros.yml
@@ -19,6 +19,10 @@ jobs:
           - { os: debian,      tag: bookworm, arch: debian, arch_ver: 12 }
           - { os: almalinux,   tag: 8,        arch: rhel,   arch_ver: 8  }
         python: [2, 3]
+        #-------- Exclude bookworm on python 2 ---------------------         
+        exclude:
+          - cfg: { tag: bookworm }
+            python: 2
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_32.yml
+++ b/.github/workflows/test_32.yml
@@ -27,7 +27,7 @@ jobs:
         glibc.i686 glibc-devel.i686 udunits2 udunits2-devel gtest-devel.i686
         java-11-openjdk java-11-openjdk-devel expat-devel.i686
         which gcc-gfortran git wget gsl-devel gtest-devel gsl-devel.i686
-        maven udunits2 udunits2-devel zip
+        maven udunits2 udunits2-devel zip libgcc*i686 libstdc++*i686 glibc*i686
     - name: Symlink python
       run: |
         cd /usr/lib
@@ -45,9 +45,9 @@ jobs:
         make install
     - name: Install GTest (32 bit)
       run: |
-        wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-        tar xfvz release-1.10.0.tar.gz
-        cd googletest-release-1.10.0/googletest
+        wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+        tar xfvz release-1.8.0.tar.gz
+        cd googletest-release-1.8.0/googletest
         export CFLAGS="-m32"
         export CXXFLAGS="-m32"
         cmake .

--- a/.github/workflows/test_32.yml
+++ b/.github/workflows/test_32.yml
@@ -45,9 +45,9 @@ jobs:
         make install
     - name: Install GTest (32 bit)
       run: |
-        wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
-        tar xfvz release-1.8.0.tar.gz
-        cd googletest-release-1.8.0/googletest
+        wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+        tar xfvz release-1.10.0.tar.gz
+        cd googletest-release-1.10.0/googletest
         export CFLAGS="-m32"
         export CXXFLAGS="-m32"
         cmake .

--- a/share/trick/trickops/tests/trick_sims.yml
+++ b/share/trick/trickops/tests/trick_sims.yml
@@ -150,7 +150,6 @@ SIM_test_varserv:
     labels:
       - unit_test
     runs:
-        RUN_test/realtime.py:
         RUN_test/unit_test.py:
 SIM_threads:
     path: test/SIM_threads

--- a/share/trick/trickops/tests/ut_TrickWorkflow.py
+++ b/share/trick/trickops/tests/ut_TrickWorkflow.py
@@ -42,7 +42,7 @@ class TrickWorkflowTestCase(unittest.TestCase):
         self.assertEqual(len(build_jobs), 56)
         self.assertEqual(len(self.instance.sims), 56)
         run_jobs = self.instance.get_jobs('run')
-        self.assertEqual(len(run_jobs), 38)
+        self.assertEqual(len(run_jobs), 37 )
 
     def test_init_empty_so_raises(self):
         with self.assertRaises(RuntimeError):
@@ -195,9 +195,9 @@ class TrickWorkflowTestCase(unittest.TestCase):
         builds = self.instance.get_jobs('builds')
         self.assertEqual(len(builds), 56)
         runs = self.instance.get_jobs('run')
-        self.assertEqual(len(runs), 38)
+        self.assertEqual(len(runs), 37)
         runs = self.instance.get_jobs('runs')
-        self.assertEqual(len(runs), 38)
+        self.assertEqual(len(runs), 37)
         vg = self.instance.get_jobs('valgrind')
         self.assertEqual(len(vg), 1)
         vg = self.instance.get_jobs('valgrinds')

--- a/test/SIM_test_varserv/S_overrides.mk
+++ b/test/SIM_test_varserv/S_overrides.mk
@@ -1,14 +1,13 @@
-
 TRICK_CFLAGS += -I./models
-TRICK_CXXFLAGS += -I./models
+TRICK_CXXFLAGS += -I./models -I$(GTEST_HOME)/include -std=c++11
 
 all: test_client
 clean: clean_test_client
 
-TEST_CLIENT_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main -lpthread
+TEST_CLIENT_LIBS += -L${GTEST_HOME}lib64 -L${GTEST_HOME}lib -lgtest -lgtest_main -lpthread
 
-test_client: models/test_client/test_client.cpp 
-	cd models/test_client; $(TRICK_CXX) test_client.cpp -o test_client $(TEST_CLIENT_LIBS) -std=c++11
+test_client: models/test_client/test_client.cpp
+	cd models/test_client; $(TRICK_CXX) test_client.cpp $(TRICK_SYSTEM_LDFLAGS) $(TRICK_CXXFLAGS) -o test_client $(TEST_CLIENT_LIBS) -std=c++11
 
 clean_test_client:
 	rm -f models/test_client/test_client


### PR DESCRIPTION
- Update S_overrides.mk for SIM_test_varserv so it links correctly in 32 bit (why did only that one have a problem? the world will never know)
- Stop testing Debian Bookworm on python2.7 since support was removed
- Fix some TrickOps unit tests