### PR TITLE
Add option to terminate sim on python event error

### DIFF
--- a/docs/documentation/running_a_simulation/Input-File.md
+++ b/docs/documentation/running_a_simulation/Input-File.md
@@ -449,6 +449,9 @@ For information on how Trick processes events during runtime, see [Event Process
 
 # Add the event to the input processor's list of events (it will be processed at top of frame before scheduled jobs)
 trick.add_event(<event name>)
+
+# Tell trick whether to terminate the sim if an error occurs while parsing Python code. Defaults to False
+trick.terminate_on_event_parse_error(<True|False>)
 ```
 
 #### Advanced Event (Malfunction) Usage

--- a/include/trick/IPPythonEvent.hh
+++ b/include/trick/IPPythonEvent.hh
@@ -185,6 +185,15 @@ namespace Trick {
             static void set_event_info_msg_off() ;
 
             /**
+             @brief @userdesc Command to set whether the sim should check error codes from
+             Python parsing and terminate if an error is detected. Set to false by default
+             @par Python Usage:
+             @code trick.terminate_on_event_parse_error(True|False) @endcode
+             @return always 0
+            */
+            static void terminate_on_event_parse_error(bool on_off);
+
+            /**
              @brief called by the event manager when the event is loaded from a checkpoint
             */
             virtual void restart() ;
@@ -402,7 +411,7 @@ namespace Trick {
                any events instantiated yet */
             static void set_python_processor(Trick::IPPython * in_ip) ;
             static void set_mtv(Trick::MTV * in_mtv) ;
-
+  
         private:
 
             /* A static pointer to the python input processor set at the S_define level */
@@ -411,6 +420,8 @@ namespace Trick {
             /* A static pointer to the MTV set at the S_define level */
             static Trick::MTV * mtv ;
 
+            /* Defaults to false */
+            static bool terminate_sim_on_event_python_error;
     } ;
 
 }

--- a/share/trick/swig/shortcuts.py
+++ b/share/trick/swig/shortcuts.py
@@ -44,6 +44,7 @@ if hasattr(top.cvar, 'trick_ip'):
 
 set_event_info_msg_on = trick.IPPythonEvent.set_event_info_msg_on
 set_event_info_msg_off = trick.IPPythonEvent.set_event_info_msg_off
+terminate_on_event_parse_error = trick.IPPythonEvent.terminate_on_event_parse_error
 
 # bind pyton input_processor event routines to shortcut names.
 new_event = trick.ippython_new_event

--- a/test/SIM_events/RUN_test/unit_test_error1.py
+++ b/test/SIM_events/RUN_test/unit_test_error1.py
@@ -1,0 +1,7 @@
+trick.stop(1.0)
+
+# print(dir(trick))
+trick.terminate_on_event_parse_error(True)
+
+# Error in add read
+trick.add_read(0.1, "a = b")

--- a/test/SIM_events/RUN_test/unit_test_error2.py
+++ b/test/SIM_events/RUN_test/unit_test_error2.py
@@ -1,0 +1,12 @@
+trick.terminate_on_event_parse_error(True)
+
+# Error in condition
+event1 = trick.new_event("event1")
+event1.condition(0, "this is a syntax error")
+event1.action(0, "print (\"event1\");")
+event1.action(1, "event1.activate()")
+event1.set_cycle(1.0)
+event1.activate() 
+trick.add_event(event1)
+
+trick.stop(10)

--- a/test/SIM_events/RUN_test/unit_test_error3.py
+++ b/test/SIM_events/RUN_test/unit_test_error3.py
@@ -1,0 +1,12 @@
+trick.terminate_on_event_parse_error(True)
+
+# Error in event action
+event1 = trick.new_event("event1")
+event1.condition(0, "True")
+event1.action(0, "this is a syntax error")
+event1.action(1, "event1.activate()")
+event1.set_cycle(1.0)
+event1.activate() 
+trick.add_event(event1)
+
+trick.stop(10)

--- a/test_sims.yml
+++ b/test_sims.yml
@@ -42,13 +42,6 @@ SIM_demo_sdefine:
   runs:
     RUN_test/unit_test.py:
       returns: 0
-SIM_events:
-  path: test/SIM_events
-  build_command: "trick-CP -t"
-  binary: "T_main_{cpu}_test.exe"
-  runs:
-    RUN_test/unit_test.py:
-      returns: 0 
 SIM_exec_set_time_tic_value:
   path: test/SIM_exec_set_time_tic_value
   build_command: "trick-CP -t"
@@ -266,6 +259,21 @@ SIM_checkpoint_data_recording:
     #   returns: 0
     #   compare: 
     #     - test/SIM_checkpoint_data_recording/RUN_test6/ref_log_foo2.csv vs. test/SIM_checkpoint_data_recording/RUN_test6/log_foo2.csv
+
+SIM_events:
+  path: test/SIM_events
+  build_command: "trick-CP -t"
+  binary: "T_main_{cpu}_test.exe"
+  runs:
+    RUN_test/unit_test.py:
+      returns: 0 
+    RUN_test/unit_test_error1.py:
+      returns: 255
+    RUN_test/unit_test_error2.py:
+      returns: 255
+    RUN_test/unit_test_error3.py:
+      returns: 255
+
 
 # The variable server client and SIM_amoeba sometimes fail to connect and need to be retried
 SIM_test_varserv:

--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -179,11 +179,11 @@ int Trick::IPPython::parse_condition(std::string in_string, int & cond_return_va
     pthread_mutex_lock(&ip_mutex);
     in_string =  std::string("trick_ip.ip.return_val = ") + in_string + "\n" ;
     // Running the simple string will set return_val.
-    PyRun_SimpleString(in_string.c_str()) ;
+    int py_ret = PyRun_SimpleString(in_string.c_str()) ;
     cond_return_val = return_val ;
     pthread_mutex_unlock(&ip_mutex);
 
-    return 0 ;
+    return py_ret ;
 
 }
 


### PR DESCRIPTION
closes #1433 
closes #693 

Adds a command to terminate the sim on event processing failure:
```python
trick.terminate_on_event_parse_error(<True|False>)
```
Tests and documentation update included.