### PR TITLE
Use Maven to build AircraftDisplay.jar instead of directly from Makefile

### DIFF
--- a/trick_sims/SIM_aircraft/RUN_test/input.py
+++ b/trick_sims/SIM_aircraft/RUN_test/input.py
@@ -11,7 +11,7 @@ dyn.aircraft.desired_speed = 200 # meters per second
 # Start the Satellite Graphics Client
 #==========================================
 varServerPort = trick.var_server_get_port();
-AircraftDisplay_path = "models/graphics/dist/AircraftDisplay.jar"
+AircraftDisplay_path = "models/graphics/build/AircraftDisplay.jar"
 
 if (os.path.isfile(AircraftDisplay_path)) :
     AircraftDisplay_cmd = "java -jar " \

--- a/trick_sims/SIM_aircraft/models/graphics/Makefile
+++ b/trick_sims/SIM_aircraft/models/graphics/Makefile
@@ -1,36 +1,6 @@
-SHELL = /bin/sh
 
-PROJECT_NAME = AircraftDisplay
-SRC_DIR = src
-BUILD_DIR = build
-CLASSES_DIR = $(BUILD_DIR)/classes
-JAR_DIR = dist
-MAIN_CLASS = trick.AircraftDisplay
-
-all: jar
+all:
+	mvn package
 
 clean:
-	rm -rf $(BUILD_DIR)
-	rm -f manifest
-
-spotless: clean
-	rm -rf dist
-
-$(CLASSES_DIR):
-	@ mkdir -p $(CLASSES_DIR)
-
-compile: | $(CLASSES_DIR)
-	javac -sourcepath $(SRC_DIR) -d $(CLASSES_DIR) $(SRC_DIR)/trick/AircraftDisplay.java
-
-manifest:
-	@ echo "Main-Class: $(MAIN_CLASS)" > $@
-
-$(JAR_DIR):
-	@ mkdir -p $(JAR_DIR)
-
-jar: compile manifest | $(JAR_DIR)
-	jar cvfm $(JAR_DIR)/$(PROJECT_NAME).jar manifest -C $(CLASSES_DIR) .
-	@ echo "-------------------------------------------------------------------------------"
-	@ echo "                              BUILD COMPLETE"
-	@ echo "The Java jar file (the Java Executable) is located at: $(JAR_DIR)/$(PROJECT_NAME).jar"
-	@ echo "-------------------------------------------------------------------------------"
+	rm -rf build

--- a/trick_sims/SIM_aircraft/models/graphics/pom.xml
+++ b/trick_sims/SIM_aircraft/models/graphics/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>trick-java</groupId>
+  <artifactId>trick-java</artifactId>
+  <version>23.0.0-beta</version>
+
+  <name>trick-java</name>
+
+  <url>https://github.com/nasa/trick</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <finalName>AircraftDisplay</finalName>
+
+    <directory>build</directory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+          <destDir>../../share/doc/trick/java</destDir>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <configuration>
+            <compilerArgs>
+              <arg>-g</arg>
+              <arg>-Xlint:unchecked</arg>
+              <arg>-Xlint:deprecation</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <!-- Build an executable JAR -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.0</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addClasspath>true</addClasspath>
+                <classpathPrefix>lib/</classpathPrefix>
+                <mainClass>AircraftDisplay</mainClass>
+              </manifest>
+            </archive>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+
+<!--
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+-->
+
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/trick_sims/SIM_aircraft/models/graphics/src/main/java/trick/aircraftDisplay/AircraftDisplay.java
+++ b/trick_sims/SIM_aircraft/models/graphics/src/main/java/trick/aircraftDisplay/AircraftDisplay.java
@@ -3,7 +3,7 @@
  * 2016 (c) National Aeronautics and Space Administration (NASA)
  */
 
-package trick;
+/* package trick;*/
 
 import java.awt.Graphics2D;
 import java.awt.Graphics;


### PR DESCRIPTION
Getting SIM_aircraft in a good state for Trick intern. Maven is easier and more reliable than building .jar directly from Makefile.