### PR TITLE
Update convert_swig

### DIFF
--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -330,6 +330,16 @@ sub process_file() {
                 $class_typemap_printed{$c} = 1 ;
             }
         }
+
+        ### Include user defined interface file.
+        ### Swig will only process the file if file exist.
+        ### File path needs to be added to TRICK_SWIG_FLAGS
+        ### File must have this name <header_file_name>_userdefined.i
+        my ($ud_base_file) ;
+        $ud_base_file = basename($f) ;
+        $ud_base_file =~ s/\.[^\.]+$// ;
+        print OUT "%include \"${ud_base_file}_userdefined.i\"\n\n" ;
+
         print OUT "\n$new_contents" ;
         print OUT "$contents\n" ;
         print OUT $global_template_typedefs ;


### PR DESCRIPTION
Allow users to specify SWIG interface extensions not supported by Trick. Will broaden the python input processor support.

The current usecase for this is the following:
The project C++ source code must not contain any SWIG templating (using #ifdef SWIG)
The SWIG template extensions must live in a separate file.
The project C++ source requires additional SWIG templating (not supported by Trick) to interface with set std::array and nested classes via the input processor, to name a few.
