### PR TITLE
1399 patch

### DIFF
--- a/test_sims.yml
+++ b/test_sims.yml
@@ -240,32 +240,32 @@ SIM_checkpoint_data_recording:
       returns: 0
     RUN_test5/dump.py:
       returns: 0
-    # RUN_test6/dump.py:
-    #   returns: 0
+    RUN_test6/dump.py:
+      returns: 0
 
-    # RUN_test1/unit_test.py:
-    #   returns: 0
-    #   compare: 
-    #     - test/SIM_checkpoint_data_recording/RUN_test1/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test1/log_foo.csv
-    # RUN_test2/unit_test.py:
-    #   returns: 0
-    #   analyze: './test/SIM_checkpoint_data_recording/RUN_test2/check_log.sh'
-    # RUN_test3/unit_test.py:
-    #   returns: 0
-    #   compare: 
-    #     - test/SIM_checkpoint_data_recording/RUN_test3/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test3/log_foo.csv
-    # RUN_test4/unit_test.py:
-    #   returns: 0
-    #   compare: 
-    #     - test/SIM_checkpoint_data_recording/RUN_test4/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test4/log_foo.csv
-    # RUN_test5/unit_test.py:
-    #   returns: 0
-    #   compare: 
-    #     - test/SIM_checkpoint_data_recording/RUN_test5/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test5/log_foo.csv
-    # RUN_test6/unit_test.py:
-    #   returns: 0
-    #   compare: 
-    #     - test/SIM_checkpoint_data_recording/RUN_test6/ref_log_foo2.csv vs. test/SIM_checkpoint_data_recording/RUN_test6/log_foo2.csv
+    RUN_test1/unit_test.py:
+      returns: 0
+      compare: 
+        - test/SIM_checkpoint_data_recording/RUN_test1/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test1/log_foo.csv
+    RUN_test2/unit_test.py:
+      returns: 0
+      analyze: './test/SIM_checkpoint_data_recording/RUN_test2/check_log.sh'
+    RUN_test3/unit_test.py:
+      returns: 0
+      compare: 
+        - test/SIM_checkpoint_data_recording/RUN_test3/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test3/log_foo.csv
+    RUN_test4/unit_test.py:
+      returns: 0
+      compare: 
+        - test/SIM_checkpoint_data_recording/RUN_test4/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test4/log_foo.csv
+    RUN_test5/unit_test.py:
+      returns: 0
+      compare: 
+        - test/SIM_checkpoint_data_recording/RUN_test5/ref_log_foo.csv vs. test/SIM_checkpoint_data_recording/RUN_test5/log_foo.csv
+    RUN_test6/unit_test.py:
+      returns: 0
+      compare: 
+        - test/SIM_checkpoint_data_recording/RUN_test6/ref_log_foo2.csv vs. test/SIM_checkpoint_data_recording/RUN_test6/log_foo2.csv
 
 SIM_events:
   path: test/SIM_events

--- a/trick_source/sim_services/CheckPointAgent/ClassicCheckPointerAgent.cpp
+++ b/trick_source/sim_services/CheckPointAgent/ClassicCheckPointerAgent.cpp
@@ -1015,6 +1015,16 @@ void Trick::ClassicCheckPointAgent::write_rvalue( std::ostream& chkpnt_os, void*
                     }
                 }
 
+
+                // This is necessary due to https://github.com/nasa/trick/issues/1399
+                // If there is a string array where the memory is not initialized, the code above
+                // can incorrectly decide to write it as a quoted string when it should be an
+                // empty array, causing a segfault when the checkpoint is reloaded.
+                if (attr->index[curr_dim + 1].size == 0 && ((curr_dim + 1) != attr->num_index)) {
+                    use_quoted_string = 0;
+                } 
+
+
                 if ((attr->type == TRICK_CHARACTER) && use_quoted_string)  {
 
                     write_quoted_str(chkpnt_os, src_addr);


### PR DESCRIPTION
Closes #1399 

It appears that the checkpointing bug we were seeing in #1399 was due to the checkpoint logic reading uninitialized memory  that happens when an empty array of strings is creating and deciding to write it as a string instead of an array. This patch checks to make sure that when we write as a quoted string, we are in the correct dimension.