### PR TITLE
Allow integ_loop to be reordered

### DIFF
--- a/libexec/trick/pm/parse_s_define.pm
+++ b/libexec/trick/pm/parse_s_define.pm
@@ -946,7 +946,7 @@ sub preparse_job_class_order($$) {
     }
 
     # Scheduled loop classes that should not be reordered
-    my @non_reorderable_classes = qw(logging data_record system_checkpoint system_advance_sim_time system_moding);
+    my @non_reorderable_classes = qw(system_checkpoint system_advance_sim_time system_moding);
 
     # get a list of classes
     ($class_text) = @{$job_class_order_structs}[0] =~ /{(.*?)}/sx ;
@@ -977,6 +977,14 @@ sub preparse_job_class_order($$) {
 
     if ( !exists $temp_hash{automatic_last} ) {
         push @{$$sim_ref{user_class_order}} , "automatic_last" ;
+    }
+
+    if ( !exists $temp_hash{logging} ) {
+        push @{$$sim_ref{user_class_order}} , "logging" ;
+    }
+
+    if ( !exists $temp_hash{data_record} ) {
+        push @{$$sim_ref{user_class_order}} , "data_record" ;
     }
 
     # Push on the rest of the non-reorderable system job classes

--- a/libexec/trick/pm/parse_s_define.pm
+++ b/libexec/trick/pm/parse_s_define.pm
@@ -946,7 +946,7 @@ sub preparse_job_class_order($$) {
     }
 
     # Scheduled loop classes that should not be reordered
-    my @non_reorderable_classes = qw(logging data_record system_checkpoint system_advance_sim_time system_moding integ_loop);
+    my @non_reorderable_classes = qw(logging data_record system_checkpoint system_advance_sim_time system_moding);
 
     # get a list of classes
     ($class_text) = @{$job_class_order_structs}[0] =~ /{(.*?)}/sx ;
@@ -982,6 +982,10 @@ sub preparse_job_class_order($$) {
     # Push on the rest of the non-reorderable system job classes
     foreach my $c ( @non_reorderable_classes ) {
         push @{$$sim_ref{user_class_order}} , $c ;
+    }
+
+    if ( !exists $temp_hash{integ_loop} ) {
+        push @{$$sim_ref{user_class_order}} , "integ_loop" ;
     }
 }
 

--- a/test/SIM_job_class_order/S_define
+++ b/test/SIM_job_class_order/S_define
@@ -37,6 +37,7 @@ StarterSimObject starterSimObject;
 
 job_class_order {
    my_class ,
+   integ_loop,
    scheduled 
 };
 


### PR DESCRIPTION
Broke some existing sims that reorder the integ_loop with #1465 . This fixes that.