### PR TITLE
Add option to specify a C++ standard to ICG for parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,8 @@ ICG: TRICK_SYSTEM_CXXFLAGS := $(subst -isystem,-I,$(TRICK_SYSTEM_CXXFLAGS))
 ICG: $(ICG_EXE)
 	$(ICG_EXE) -f -s -m -n ${TRICK_CXXFLAGS} ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_HOME}/include/trick/files_to_ICG.hh
 
+ICG_EXE: $(ICG_EXE)
+
 # This builds a tricklib share library.
 trick_lib: $(SIM_SERV_DIRS) $(UTILS_DIRS) | $(TRICK_LIB_DIR)
 	${TRICK_CXX} $(SHARED_LIB_OPT) -o ${TRICK_LIB_DIR}/libtrick.so $(SIM_SERV_OBJS) $(UTILS_OBJS)

--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,12 @@ ICG: TRICK_SYSTEM_CXXFLAGS := $(subst -isystem,-I,$(TRICK_SYSTEM_CXXFLAGS))
 ICG: $(ICG_EXE)
 	$(ICG_EXE) -f -s -m -n ${TRICK_CXXFLAGS} ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_HOME}/include/trick/files_to_ICG.hh
 
-ICG_EXE: $(ICG_EXE)
+
+ICG_EXE: force-icg-build
+
+.PHONY: force-icg-build
+force-icg-build: 
+	$(MAKE) -C trick_source/codegen/Interface_Code_Gen
 
 # This builds a tricklib share library.
 trick_lib: $(SIM_SERV_DIRS) $(UTILS_DIRS) | $(TRICK_LIB_DIR)

--- a/docs/documentation/building_a_simulation/Making-the-Simulation.md
+++ b/docs/documentation/building_a_simulation/Making-the-Simulation.md
@@ -91,6 +91,16 @@ Edit a file called "S_overrides.mk". Append to the TRICK_EXCLUDE variable.
 TRICK_EXCLUDE += /path/to/exclude:/another/path/to/exclude
 ```
 
+### Example of how to tell ICG to parse code to a certain C++ standard
+
+Edit a file called "S_overrides.mk". Append to the TRICK_ICGFLAGS variable.
+
+```
+TRICK_ICGFLAGS += --icg-std=c++11
+```
+
+Valid options are c++11, c++14, and c++17. ICG will parse to the newest version that LLVM supports by default. 
+
 ## Cleaning Up
 
 There are several levels of clean.

--- a/docs/documentation/building_a_simulation/Making-the-Simulation.md
+++ b/docs/documentation/building_a_simulation/Making-the-Simulation.md
@@ -91,12 +91,12 @@ Edit a file called "S_overrides.mk". Append to the TRICK_EXCLUDE variable.
 TRICK_EXCLUDE += /path/to/exclude:/another/path/to/exclude
 ```
 
-### Example of how to tell ICG to parse code to a certain C++ standard
+### Example how to set a C++ standard for ICG and compilation
 
-Edit a file called "S_overrides.mk". Append to the TRICK_ICGFLAGS variable.
+Edit a file called "S_overrides.mk". Append to the TRICK_CXXFLAGS variable.
 
 ```
-TRICK_ICGFLAGS += --icg-std=c++11
+TRICK_CXXFLAGS += -std=c++11
 ```
 
 Valid options are c++11, c++14, c++17, or c++20. ICG will parse to c++17 by default, or the newest supported version if c++17 is not availible. 

--- a/docs/documentation/building_a_simulation/Making-the-Simulation.md
+++ b/docs/documentation/building_a_simulation/Making-the-Simulation.md
@@ -99,7 +99,7 @@ Edit a file called "S_overrides.mk". Append to the TRICK_ICGFLAGS variable.
 TRICK_ICGFLAGS += --icg-std=c++11
 ```
 
-Valid options are c++11, c++14, and c++17. ICG will parse to the newest version that LLVM supports by default. 
+Valid options are c++11, c++14, c++17, or c++20. ICG will parse to c++17 by default, or the newest supported version if c++17 is not availible. 
 
 ## Cleaning Up
 

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -38,7 +38,7 @@ llvm::cl::opt<bool> units_truth_is_scary("units-truth-is-scary", llvm::cl::desc(
 llvm::cl::opt<bool> sim_services_flag("sim_services", llvm::cl::desc("Gernerate io_src for Trick core headers"));
 llvm::cl::opt<bool> force("force", llvm::cl::desc("Force all io_src files to be generated"));
 llvm::cl::opt<int> attr_version("v", llvm::cl::desc("Select version of attributes to produce.  10 and 13 are valid"), llvm::cl::init(10));
-llvm::cl::opt<std::string> standard_version("icg-std", llvm::cl::desc("Set the C++ standard to use when parsing. c++11, c++14, and c++17 are valid. Default is newest supported by your LLVM version."), llvm::cl::init(""));
+llvm::cl::opt<std::string> standard_version("std", llvm::cl::desc("Set the C++ standard to use when parsing. c++11, c++14, c++17, and c++20 are valid. Default is c++17 or the newest supported by your LLVM version."), llvm::cl::init(""));
 llvm::cl::opt<int> debug_level("d", llvm::cl::desc("Set debug level"), llvm::cl::init(0), llvm::cl::ZeroOrMore);
 llvm::cl::opt<bool> create_map("m", llvm::cl::desc("Create map files"), llvm::cl::init(false));
 llvm::cl::opt<std::string> output_dir("o", llvm::cl::desc("Output directory"));

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -38,6 +38,7 @@ llvm::cl::opt<bool> units_truth_is_scary("units-truth-is-scary", llvm::cl::desc(
 llvm::cl::opt<bool> sim_services_flag("sim_services", llvm::cl::desc("Gernerate io_src for Trick core headers"));
 llvm::cl::opt<bool> force("force", llvm::cl::desc("Force all io_src files to be generated"));
 llvm::cl::opt<int> attr_version("v", llvm::cl::desc("Select version of attributes to produce.  10 and 13 are valid"), llvm::cl::init(10));
+llvm::cl::opt<std::string> standard_version("icg-std", llvm::cl::desc("Set the C++ standard to use when parsing. c++11, c++14, and c++17 are valid. Default is newest supported by your LLVM version."), llvm::cl::init(""));
 llvm::cl::opt<int> debug_level("d", llvm::cl::desc("Set debug level"), llvm::cl::init(0), llvm::cl::ZeroOrMore);
 llvm::cl::opt<bool> create_map("m", llvm::cl::desc("Create map files"), llvm::cl::init(false));
 llvm::cl::opt<std::string> output_dir("o", llvm::cl::desc("Output directory"));
@@ -74,6 +75,18 @@ const char * gcc_version = "";
     ci.getLangOpts().GNUCVersion = gccVersionToIntOrDefault(gcc_version, 40805);
     ci.getLangOpts().CPlusPlus17 = true ;
 #endif
+
+    if (standard_version != "") {
+        // Turn off according to icg-std flag
+        if (standard_version == "c++11") {
+            ci.getLangOpts().CPlusPlus14 = false ;
+            ci.getLangOpts().CPlusPlus17 = false ;
+        } else if (standard_version == "c++14") {
+            ci.getLangOpts().CPlusPlus17 = false ;
+        } else if (standard_version != "c++17" ) {
+            std::cerr << "Invalid C++ standard version specified:" << standard_version << std::endl;
+        }
+    }
 }
 /**
 Most of the main program is pieced together from examples on the web. We are doing the following:

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -38,7 +38,7 @@ llvm::cl::opt<bool> units_truth_is_scary("units-truth-is-scary", llvm::cl::desc(
 llvm::cl::opt<bool> sim_services_flag("sim_services", llvm::cl::desc("Gernerate io_src for Trick core headers"));
 llvm::cl::opt<bool> force("force", llvm::cl::desc("Force all io_src files to be generated"));
 llvm::cl::opt<int> attr_version("v", llvm::cl::desc("Select version of attributes to produce.  10 and 13 are valid"), llvm::cl::init(10));
-llvm::cl::opt<std::string> standard_version("std", llvm::cl::desc("Set the C++ standard to use when parsing. c++11, c++14, c++17, and c++20 are valid. Default is c++17 or the newest supported by your LLVM version."), llvm::cl::init(""));
+llvm::cl::opt<std::string> standard_version("std", llvm::cl::desc("Set the C++ standard to use when parsing. c++11, c++14, c++17, and c++20 are valid. Default is c++17 or the newest supported by your LLVM version."), llvm::cl::init(""), llvm::cl::ZeroOrMore);
 llvm::cl::opt<int> debug_level("d", llvm::cl::desc("Set debug level"), llvm::cl::init(0), llvm::cl::ZeroOrMore);
 llvm::cl::opt<bool> create_map("m", llvm::cl::desc("Create map files"), llvm::cl::init(false));
 llvm::cl::opt<std::string> output_dir("o", llvm::cl::desc("Output directory"));


### PR DESCRIPTION
Add an option to ICG to control the C++ standard it parses against. Currently, the default is whatever the newest version supported by LLVM is. 

```
TRICK_CXXFLAGS += -std=c++11
```

Valid options are c++11, c++14, c++17, c++20. 

Also adds a convenience target to the root Makefile for the ICG executable. 