### PR TITLE
Add make spotless at root makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,10 +370,11 @@ clean_ICG :
 	$(MAKE) -C ${TRICK_HOME}/trick_source/codegen/Interface_Code_Gen  clean
 
 clean_unit_test:
-	@/bin/rm -rf ${TRICK_HOME}/trick_test/*.xml
+	@/bin/rm -rf ${TRICK_HOME}/trick_test/
 	@ for i in $(UNIT_TEST_DIRS) ; do \
 	    $(MAKE) -C $$i clean ; \
 	done
+	$(MAKE) -C $(DPX_UNIT_TEST_DIR) clean
 
 clean_doxygen:
 	@ $(MAKE) -C ${TRICK_HOME}/doxygen clean
@@ -394,8 +395,16 @@ clean_sim_serv_xml:
 clean_test: clean_unit_test
 	-@ $(MAKE) -C trick_sims clean
 	-@ $(MAKE) -C test clean
+	@/bin/rm -rf ${TRICK_HOME}/trickops_logs
 
 clean_gui: clean_java
+
+spotless: clean clean_test
+	rm -f config.log config.status share/trick/makefiles/config_user.mk
+
+apocalypse: spotless
+	@echo "[31mI love the smell of napalm in the morning[0m"
+
 
 ################################################################################
 #                                 INSTALL Targets

--- a/libexec/trick/pm/gte.pm
+++ b/libexec/trick/pm/gte.pm
@@ -59,7 +59,7 @@ sub gte (@) {
                 # remove possible ccache from TRICK_CC
                 my ($temp) = $ENV{TRICK_CC} ;
                 $temp =~ s/.*?ccache\s+// ;
-                $ret = `$temp --dumpfullversion dumpversion` ;
+                $ret = `$temp -dumpfullversion dumpversion` ;
             }
         }
         else {

--- a/share/trick/makefiles/Makefile.common
+++ b/share/trick/makefiles/Makefile.common
@@ -81,8 +81,9 @@ TRICK_RANLIB      =
 
 
 ifndef CONFIG_MK
-    ifneq ($(MAKECMDGOALS), clean)
-        $(error Please run $(TRICK_HOME)/configure before running make)
+# These are the targets that are allowed to run without configure
+    ifeq ($(filter $(MAKECMDGOALS), clean real_clean spotless apocalypse),)
+        $(error Please run $(TRICK_HOME)/configure before running make $(MAKECMDGOALS))
     endif
 endif
 

--- a/trick_source/data_products/DPX/makefile
+++ b/trick_source/data_products/DPX/makefile
@@ -52,6 +52,7 @@ clean:
 	$(MAKE) -C TESTING spotless
 	$(MAKE) -C APPS spotless
 	$(MAKE) -C XML clean
+	$(MAKE) -C test clean
 	${RM} *~
 	${RM} *.o
 

--- a/trick_source/sim_services/CommandLineArguments/test/Makefile
+++ b/trick_source/sim_services/CommandLineArguments/test/Makefile
@@ -34,6 +34,7 @@ test: $(TESTS)
 
 clean :
 	rm -f $(TESTS) *.o *.gcno *.gcda
+	rm -rf a pre_existing_output_dir/a ../a
 
 create_path_test.o : create_path_test.cpp
 	$(TRICK_CXX) $(TRICK_CXXFLAGS) -c $<


### PR DESCRIPTION
Add a `make spotless` target to clean up config info so that upgrades can be done (hopefully) seamlessly without git clean -xdf or re-cloning.