### PR TITLE
Typo corrected in VariableServerSession_write_data.cpp

### DIFF
--- a/trick_source/sim_services/VariableServer/VariableServerSession_write_data.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerSession_write_data.cpp
@@ -164,7 +164,7 @@ int Trick::VariableServerSession::write_ascii_data(const std::vector<VariableRef
                 message_publish(MSG_DEBUG, "%p tag=<%s> var_server buffer[%d] too small (need %d), sending multiple ascii packets.\n",
                                 _connection, _connection->getClientTag().c_str(), MAX_MSG_LEN, message_size + var_size + 2);
 
-                message_publish(MSG_DEBUG, "%p tag=<%s> var_server sedning %d ascii bytes:\n%s\n",
+                message_publish(MSG_DEBUG, "%p tag=<%s> var_server sending %d ascii bytes:\n%s\n",
                                 _connection, _connection->getClientTag().c_str(), message_size, message.c_str());
             }
 
@@ -189,7 +189,7 @@ int Trick::VariableServerSession::write_ascii_data(const std::vector<VariableRef
     std::string message = message_stream.str();
 
     if (_debug >= 2) {
-        message_publish(MSG_DEBUG, "%p tag=<%s> var_server sedning %d ascii bytes:\n%s\n",
+        message_publish(MSG_DEBUG, "%p tag=<%s> var_server sending %d ascii bytes:\n%s\n",
                         _connection, _connection->getClientTag().c_str(), message.size(), message.c_str());
     }
 


### PR DESCRIPTION
*Update VariableServerSession_write_data.cpp
*There was a typo in lines 167 and 192. changed "sedning" to "sending"