### PR TITLE
Additional debugging when adding monte carlo nodes

### DIFF
--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_slave_init.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_slave_init.cpp
@@ -34,10 +34,10 @@ int Trick::MonteCarlo::slave_init() {
 
     /** <li> Connect to the master and write the port over which we are listening for new runs. */
     connection_device.port = master_port;
-    if (tc_connect(&connection_device) != TC_SUCCESS) {
+    int error = tc_connect(&connection_device);
+    if (error != TC_SUCCESS) {
         if (verbosity >= MC_ERROR) {
-            message_publish(MSG_ERROR, "Monte [%s:%d] Failed to initialize communication sockets.\nTerminating.\n",
-                            machine_name.c_str(), slave_id) ;
+            message_publish(MSG_ERROR, "Monte [%s:%d:%d] Failed to initialize communication sockets.\nTerminating.\n", machine_name.c_str(), slave_id, error) ;
         }
         exit(-1);
     }

--- a/trick_source/sim_services/MonteCarlo/MonteCarlo_spawn_slaves.cpp
+++ b/trick_source/sim_services/MonteCarlo/MonteCarlo_spawn_slaves.cpp
@@ -31,6 +31,10 @@ void Trick::MonteCarlo::initialize_slave(Trick::MonteSlave* slave_to_init) {
         slave_to_init->remote_shell_args = "";
     }
     std::string buffer;
+    if (verbosity >= MC_INFORMATIONAL) {
+        message_publish(MSG_INFO, "Monte: Status of custom_slave_dispatch, custom_pre_text, and custom_post_text %d:%s:%s",
+                        custom_slave_dispatch, custom_pre_text, custom_post_text) ;
+    }
     /** <li> If this is a custom slave dispatch: add the #custom_pre_text. */
     if (custom_slave_dispatch) {
         buffer = custom_pre_text;


### PR DESCRIPTION
I am in the midst of setting up monte carlo simulations within a containerized kubernetes environment and had to work through a few different network-based gotchas.   It became helpful for me to fork the repo and add this simple additional debug value to the socket initialization error in order to track down a connection issue (which helped quite a bit!).  I thought it might be advantageous to add something _like_ this to the upstream code base, but most likely perhaps a much more though-through design (perhaps with some sort of explanation of error given the return code, etc).  

I mostly wanted to bring this to the attention of the community as a discussion point.  If there is interest and thought around what we would like to see here, I might be able to help contribute.