### PR TITLE
Change 32 bit pipeline to only build part of the test suite

### DIFF
--- a/.github/workflows/test_32.yml
+++ b/.github/workflows/test_32.yml
@@ -66,4 +66,4 @@ jobs:
         python3 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip3 install -r requirements.txt        
         cd ../../../
         echo $MAKEFLAGS $CXXFLAGS $CFLAGS 
-        make test 
+        make test32

--- a/.github/workflows/test_32_oracle.yml
+++ b/.github/workflows/test_32_oracle.yml
@@ -72,4 +72,4 @@ jobs:
         export CFLAGS="-m32"
         export CXXFLAGS="-m32"
         export MAKEFLAGS=-j`nproc`
-        make test 
+        make test32

--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,8 @@ premade:
 test: unit_test sim_test
 	@ echo "All tests completed sucessfully"
 
+test32: sim_test32
+
 .PHONY: $(UNIT_TEST_DIRS)
 $(UNIT_TEST_DIRS):
 	@ $(MAKE) -C $@ test
@@ -310,6 +312,9 @@ $(DPX_UNIT_TEST_DIR):
 
 sim_test:
 	@ $(MAKE) -f test_overrides.mk sim_test
+
+sim_test32:
+	@ $(MAKE) -f test_overrides.mk sim_test32
 
 pytest:
 	make -C share/trick/pymods/trick

--- a/test_overrides.mk
+++ b/test_overrides.mk
@@ -7,3 +7,6 @@ unexport TRICK_PYTHON_PATH
 
 sim_test:
 	python3 trickops.py
+
+sim_test32:
+	python3 trickops.py --config_file=test_sims32.yml

--- a/test_sims32.yml
+++ b/test_sims32.yml
@@ -1,0 +1,35 @@
+# Compile only sims
+SIM_alloc_test:
+  path: test/SIM_alloc_test
+SIM_alloc_test:
+  path: test/SIM_alloc_test
+SIM_anon_enum:
+  path: test/SIM_anon_enum
+SIM_default_member_initializer:
+  path: test/SIM_default_member_initializer
+SIM_delete_default_constructor:
+  path: test/SIM_delete_default_constructor
+SIM_demo_inputfile:
+  path: test/SIM_demo_inputfile
+SIM_exclusion_mechanisms:
+  path: test/SIM_exclusion_mechanisms
+SIM_isystem:
+  path: test/SIM_isystem
+SIM_measurement_units:
+  path: test/SIM_measurement_units
+SIM_parse_s_define:
+  path: test/SIM_parse_s_define
+SIM_target_specific_variables:
+  path: test/SIM_target_specific_variables
+SIM_test_abstract:
+  path: test/SIM_test_abstract
+SIM_test_inherit:
+  path: test/SIM_test_inherit
+SIM_test_ip2:
+  path: test/SIM_test_ip2
+SIM_threads_simple:
+  path: test/SIM_threads_simple
+SIM_trickcomm:
+  path: test/SIM_trickcomm
+SIM_satellite:
+  path: trick_sims/SIM_satellite

--- a/trickops.py
+++ b/trickops.py
@@ -10,7 +10,7 @@ from WorkflowCommon import Job
 max_retries = 5
 
 class SimTestWorkflow(TrickWorkflow):
-    def __init__( self, quiet, trick_top_level, cpus):
+    def __init__( self, quiet, trick_top_level, cpus, config_file):
         self.cpus = cpus
         # Create the trick_test directory if it doesn't already exist
         if not os.path.exists(trick_top_level + "/trick_test"):
@@ -18,7 +18,7 @@ class SimTestWorkflow(TrickWorkflow):
 
         # Base Class initialize, this creates internal management structures
         TrickWorkflow.__init__(self, project_top_level=(trick_top_level), log_dir=(trick_top_level +'/trickops_logs/'),
-            trick_dir=trick_top_level, config_file=(trick_top_level + "/test_sims.yml"), cpus=self.cpus, quiet=quiet)
+            trick_dir=trick_top_level, config_file=(trick_top_level + "/" + config_file), cpus=self.cpus, quiet=quiet)
     def run( self ):
       build_jobs      = self.get_jobs(kind='build')
 
@@ -80,6 +80,8 @@ if __name__ == "__main__":
     parser.add_argument( "--cpus", type=int, default=(os.cpu_count() if os.cpu_count() is not None else 8),
       help="Number of cpus to use for testing. For builds this number is used for MAKEFLAGS *and* number of "
         "concurrent builds (cpus^2). For sim runs this controls the maximum number of simultaneous runs.")
+    parser.add_argument( "--config_file", type=str, help="Run configuration file to use, relative to trick_top_level", default="test_sims.yml")
+
     myargs = parser.parse_args()
     should_be_quiet = myargs.quiet or os.getenv('CI') is not None
-    sys.exit(SimTestWorkflow(quiet=should_be_quiet, trick_top_level=myargs.trick_top_level, cpus=myargs.cpus).run())
+    sys.exit(SimTestWorkflow(quiet=should_be_quiet, trick_top_level=myargs.trick_top_level, cpus=myargs.cpus, config_file=myargs.config_file).run())


### PR DESCRIPTION
The 32 bit pipeline frequently has issues that are only related to the test suite itself and its dependencies, which makes it require more maintenance than value provided. Change this pipeline to only build trick and a handful of example sims.