### PR TITLE
Fix the alloc_type of allocations performed by declare_var. #1529

### DIFF
--- a/include/trick/io_alloc.h
+++ b/include/trick/io_alloc.h
@@ -7,16 +7,38 @@
 #include "trick/attributes.h"
 #include "trick/parameter_types.h"
 
+/**
+ * enum TRICK_STCL - indicates whether or not the MemoryManager allocated the object.
+ * -------------------------------------------------------------------------------------------
+ * TRICK_LOCAL  - The memory manager allocated the object, via a form of declare_var..().
+ * TRICK_EXTERN - The memory manager did not allocate the object, but was given a pointer to
+ *                an object via a form of declare_extern_var..().
+ * -------------------------------------------------------------------------------------------
+ */
 typedef enum {
    TRICK_LOCAL  = 0,
    TRICK_EXTERN = 1,
 } TRICK_STCL;
 
+
+/**
+ * enum TRICK_ALLOC_TYPE - indicates how an object that known to the MemoryManager was allocated.
+ * -------------------------------------------------------------------------------------------
+ * TRICK_ALLOC_MALLOC - indicates that the memory object described by ALLOC_INFO was allocated
+ *                      by calloc() or malloc().
+ * TRICK_ALLOC_IOSRC  - indicates that the memory object was allocated by calling an 
+ *                      io_src_allocate_<CLASS_NAME>() function that was generated
+ *                      for that objects data-type by ICG. 
+ * TRICK_ALLOC_OTHER  - indicates that the ALLOC_INFO record doesn't "know" how the the object
+ *                      was allocated. This is the case when its storage class is TRICK_EXTERN.
+ * -------------------------------------------------------------------------------------------
+ */
 typedef enum {
    TRICK_ALLOC_MALLOC = 0,
-   TRICK_ALLOC_NEW = 1,
-   TRICK_ALLOC_OTHER = 2,
+   TRICK_ALLOC_IOSRC  = 1,
+   TRICK_ALLOC_OTHER  = 2,
 } TRICK_ALLOC_TYPE;
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/trick/swig/swig_class_typedef.i
+++ b/include/trick/swig/swig_class_typedef.i
@@ -240,7 +240,7 @@
                 _sim_services.TMM_declare_ext_var(this, _sim_services.TRICK_STRUCTURED, "TYPE", 0, kwargs['TMMName'], 0, None)
             alloc_info = _sim_services.get_alloc_info_at(this)
             alloc_info.stcl = _sim_services.TRICK_LOCAL
-            alloc_info.alloc_type = _sim_services.TRICK_ALLOC_NEW
+            alloc_info.alloc_type = _sim_services.TRICK_ALLOC_IOSRC
 %}
 
 %feature("shadow") TYPE::TYPE() %{
@@ -258,7 +258,7 @@
                 _sim_services.TMM_declare_ext_var(this, _sim_services.TRICK_STRUCTURED, "TYPE", 0, kwargs['TMMName'], 0, None)
             alloc_info = _sim_services.get_alloc_info_at(this)
             alloc_info.stcl = _sim_services.TRICK_LOCAL
-            alloc_info.alloc_type = _sim_services.TRICK_ALLOC_NEW
+            alloc_info.alloc_type = _sim_services.TRICK_ALLOC_IOSRC
 %}
 
 %enddef

--- a/trick_source/sim_services/DataRecord/DataRecordGroup.cpp
+++ b/trick_source/sim_services/DataRecord/DataRecordGroup.cpp
@@ -160,7 +160,7 @@ void Trick::DataRecordGroup::register_group_with_mm(void * address , const char 
         TMM_declare_ext_var(address , TRICK_STRUCTURED, type , 0 , name.c_str() , 0 , NULL ) ;
         ALLOC_INFO * alloc_info = get_alloc_info_at(address) ;
         alloc_info->stcl = TRICK_LOCAL ;
-        alloc_info->alloc_type = TRICK_ALLOC_NEW ;
+        alloc_info->alloc_type = TRICK_ALLOC_IOSRC ;
     }
 }
 

--- a/trick_source/sim_services/MemoryManager/MemoryManager.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager.cpp
@@ -85,7 +85,7 @@ Trick::MemoryManager::~MemoryManager() {
         if (ai_ptr->stcl == TRICK_LOCAL) {
             if ( ai_ptr->alloc_type == TRICK_ALLOC_MALLOC ) {
                 free((char *)ai_ptr->start - ai_ptr->sentinel_bytes) ;
-            } else if ( ai_ptr->alloc_type == TRICK_ALLOC_NEW ) {
+            } else if ( ai_ptr->alloc_type == TRICK_ALLOC_IOSRC ) {
                 io_src_delete_class( ai_ptr );
             }
         }

--- a/trick_source/sim_services/MemoryManager/MemoryManager_declare_var.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_declare_var.cpp
@@ -46,6 +46,7 @@ void* Trick::MemoryManager::declare_var( TRICK_TYPE type,
     char* allocation_name;
     int n_elems;
     Language language;
+    TRICK_ALLOC_TYPE alloc_type;
     void* address;
     ATTRIBUTES* sub_attr;
     ALLOC_INFO *new_alloc;
@@ -126,6 +127,7 @@ void* Trick::MemoryManager::declare_var( TRICK_TYPE type,
             return ((void*)NULL);
         }
         language = Language_CPP;
+        alloc_type = TRICK_ALLOC_IOSRC;
 
     } else if ((type == TRICK_STRING) && (n_stars == 0 ) ) {
 
@@ -139,6 +141,7 @@ void* Trick::MemoryManager::declare_var( TRICK_TYPE type,
             return ((void*)NULL);
         }
         language = Language_CPP;
+        
     } else {
         if ( (address = calloc( (size_t)n_elems, (size_t)size ) ) == NULL) {
             emitError("Out of memory.") ;
@@ -156,6 +159,7 @@ void* Trick::MemoryManager::declare_var( TRICK_TYPE type,
         new_alloc->stcl = TRICK_LOCAL;
         new_alloc->size = size;
         new_alloc->language = language;
+        new_alloc->alloc_type = alloc_type;
         new_alloc->type = type;
 
         if ((type == TRICK_STRUCTURED) || (type == TRICK_ENUMERATED)) {

--- a/trick_source/sim_services/MemoryManager/MemoryManager_delete_var.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_delete_var.cpp
@@ -38,6 +38,9 @@ int Trick::MemoryManager::delete_var(void* address ) {
          */
         if ( alloc_info->stcl == TRICK_LOCAL ) {
             if ( alloc_info->alloc_type == TRICK_ALLOC_MALLOC ) {
+
+                // This will call a destructor ONLY if alloc_info->type is TRICK_STRUCTURED.
+                // Otherwise it does nothing.
                 io_src_destruct_class( alloc_info );
 
 		// The destructor that we just called MAY have deleted addresses
@@ -48,7 +51,7 @@ int Trick::MemoryManager::delete_var(void* address ) {
 		deleted_addr_list.push_back(address);
 
                 free( address);
-            } else if ( alloc_info->alloc_type == TRICK_ALLOC_NEW ) {
+            } else if ( alloc_info->alloc_type == TRICK_ALLOC_IOSRC ) {
                 io_src_delete_class( alloc_info );
             }
         }

--- a/trick_source/sim_services/MemoryManager/test/MM_delete_var.hh
+++ b/trick_source/sim_services/MemoryManager/test/MM_delete_var.hh
@@ -1,6 +1,7 @@
 /*
 PURPOSE: (Testing)
 */
+#include <stddef.h>
 
 class CountMe {
 public:

--- a/trick_source/sim_services/MemoryManager/test/MM_delete_var.hh
+++ b/trick_source/sim_services/MemoryManager/test/MM_delete_var.hh
@@ -1,0 +1,12 @@
+/*
+PURPOSE: (Testing)
+*/
+
+class CountMe {
+public:
+    int a;
+    static size_t count;
+     CountMe() { count ++; }
+    ~CountMe() { count --; }
+} ;
+

--- a/trick_source/sim_services/MemoryManager/test/MM_delete_var_unittest.cc
+++ b/trick_source/sim_services/MemoryManager/test/MM_delete_var_unittest.cc
@@ -4,6 +4,9 @@
 #include "MM_test.hh"
 #include <iostream>
 
+#include "MM_delete_var.hh"
+size_t CountMe::count = 0;
+
 /*
  Test Fixture.
  */
@@ -40,6 +43,27 @@ TEST_F(MM_delete_var_unittest, var_exists) {
     EXPECT_EQ(1, exists);
 
 }
+
+
+TEST_F(MM_delete_var_unittest, CXX_object_constructor_destructor) {
+
+    // ===========================================================================================
+    // This test determines:
+    // 1) whether a class's constructor is called when declare_var is called and,
+    // 2) whether a class's destructor is being called when delete_var is called.
+    // ===========================================================================================
+    EXPECT_EQ(0, CountMe::count);
+    CountMe* cm1_p = (CountMe*)memmgr->declare_var("CountMe cm1");
+    EXPECT_EQ(1, CountMe::count);
+    CountMe* cm2_p = (CountMe*)memmgr->declare_var("CountMe cm2");
+    EXPECT_EQ(2, CountMe::count);
+    memmgr->delete_var("cm1");
+    EXPECT_EQ(1, CountMe::count);
+    memmgr->delete_var("cm2");
+    EXPECT_EQ(0, CountMe::count);
+}
+
+
 
 #if 0
 TEST_F(MM_delete_var_unittest, byAddress_destroy) {

--- a/trick_source/sim_services/MemoryManager/test/Makefile
+++ b/trick_source/sim_services/MemoryManager/test/Makefile
@@ -58,7 +58,8 @@ io_headers = MM_user_defined_types.hh \
              MM_write_checkpoint.hh \
              MM_get_enumerated.hh \
              MM_ref_name_from_address.hh \
-             MM_stl_testbed.hh
+             MM_stl_testbed.hh \
+             MM_delete_var.hh
 
 # List of .cpp files produced by ICG from the io_headers.
 io_source  = $(patsubst %.hh,io_%.cpp,$(io_headers))
@@ -119,6 +120,7 @@ $(TESTS) : %: %.o
 # ----------------------------------------------------------------------------------
 # The following unittest programs are also dependent on the indicated object files.
 # ----------------------------------------------------------------------------------
+MM_delete_var_unittest :         io_MM_delete_var.o
 MM_declare_var_unittest :        io_MM_user_defined_types.o
 MM_declare_var_2_unittest :      io_MM_user_defined_types.o
 MM_declare_extern_var_unittest : io_MM_user_defined_types.o


### PR DESCRIPTION
declare_var() should indicate in ALLOC_INFO::alloc_type, how it has allocated the new object. From this we know how to delete it.

declare_var() can allocate an object in one of two ways: 1) using  malloc or calloc, or
2) using io_src_alloc_<CLASS>, which is generated by ICG.

PROBLEM 1 :
ALLOC_INFO::alloc_type was not properly set when allocating a composite type. It should have been set to TRICK_ALLOC_NEW to indicate that it was allocated by io_src_alloc_<CLASS>.

PROBLEM 2:
The enumeration value TRICK_ALLOC_NEW is mis-named and is misleading. The io_src_alloc_<CLASS> routines do not necessarily allocate memory using new. If the object is a POD type, it uses calloc.

SOLUTION:
So, THIS commit:

1) Renames TRICK_ALLOC_NEW to TRICK_ALLOC_IOSRC so as not be misleading.

2) In declare_var(), sets alloc_type = TRICK_ALLOC_IOSRC when allocating a composite type (TRICK_STRUCTURED).