### PR TITLE
Fix Other Resources links in Checkpointing-Best-Practices.md

### DIFF
--- a/docs/howto_guides/Checkpointing-Best-Practices.md
+++ b/docs/howto_guides/Checkpointing-Best-Practices.md
@@ -141,6 +141,6 @@ At a simulation frame boundary, three things happen:
 
 <a id=other-resources></a>
 ## Other Resources You Might Find Useful
-* [trick.git/trick_source/sim_services/MemoryManager/test/](trick.git/trick_source/sim_services/MemoryManager/test/)
-* [trick.git/share/doc/trick/advanced/Trick_Memory_Manager_Overview.ppt](trick.git/share/doc/trick/advanced/Trick_Memory_Manager_Overview.ppt)
+* [https://github.com/nasa/trick/tree/master/trick_source/sim_services/MemoryManager/test](https://github.com/nasa/trick/tree/master/trick_source/sim_services/MemoryManager/test)
+* [https://github.com/nasa/trick/raw/master/share/doc/trick/advanced/Trick_Memory_Manager_Overview.ppt](https://github.com/nasa/trick/raw/master/share/doc/trick/advanced/Trick_Memory_Manager_Overview.ppt)
 * [https://github.com/nasa/gunns/wiki/Trick-Checkpoint-Restart](https://github.com/nasa/gunns/wiki/Trick-Checkpoint-Restart)


### PR DESCRIPTION
"Other Resources You Might Find Useful" sections have the ssh version of the repo url and not the https version.

_Originally posted by @sharmeye in https://github.com/nasa/trick/pull/1549#pullrequestreview-1577767115_