### PR TITLE
Possible speedup for requesting sie file #1555

### DIFF
--- a/trick_source/sim_services/Sie/Sie.cpp
+++ b/trick_source/sim_services/Sie/Sie.cpp
@@ -186,7 +186,7 @@ void Trick::Sie::sie_append_runtime_objs() {
     const char * comment = "<!--\nRuntime Allocations\nDo not edit this comment or file content past this point\n-->\n";
     int comment_len = strlen(comment);
 
-    int curr_offset = 0;
+    int curr_offset = 1;
     int mem_size = 1000000;
     char buff[mem_size + 1];
     char * find_str = NULL;
@@ -200,7 +200,7 @@ void Trick::Sie::sie_append_runtime_objs() {
     while ( !find_str && !sie_out.eof() ) {
         curr_offset += mem_size - comment_len - 1;
         strncpy(buff, &buff[mem_size-comment_len-1], comment_len);
-        sie_out.get(&buff[comment_len-1], mem_size-comment_len, '\0');
+        sie_out.get(&buff[comment_len], mem_size-comment_len, '\0');
         find_str = strstr(buff, comment);
     }
 
@@ -210,7 +210,7 @@ void Trick::Sie::sie_append_runtime_objs() {
     }
 
     // calculate the position of the marker in the file and jump to the point after the comment ends.
-    int pos = curr_offset + (find_str - buff) + strlen(comment) + 1;
+    int pos = curr_offset + (find_str - buff) + comment_len - 1;
     sie_out.clear();
     sie_out.seekp(pos);
 

--- a/trick_source/sim_services/Sie/Sie.cpp
+++ b/trick_source/sim_services/Sie/Sie.cpp
@@ -181,14 +181,14 @@ void Trick::Sie::sie_append_runtime_objs() {
     }
 
     std::string sie_filename = get_runtime_sie_dir() + "/" + "S_sie.resource" ;
-
     sie_out.open(sie_filename.c_str(), std::fstream::in | std::fstream::out) ;
+
     const char * comment = "<!--\nRuntime Allocations\nDo not edit this comment or file content past this point\n-->\n";
     int comment_len = strlen(comment);
 
     int curr_offset = 1;
     int mem_size = 1000000;
-    char buff[mem_size + 1];
+    char * buff = new char[mem_size + 1];
     char * find_str = NULL;
 
     // initial read use the whole buffer
@@ -206,6 +206,7 @@ void Trick::Sie::sie_append_runtime_objs() {
 
     if ( !find_str ) {
         std::cerr << "Warning: Cannot add runtime/dynamic allocations to S_sie.resource. S_sie.resource is corrupted, outdated, or missing. Please be sure that SIM_*/S_sie.resource is preserved after build time if needed at runtime for trick-tv or other variable server clients. Please also rerun trick-CP." << std::endl;
+        delete[] buff;
         return;
     }
 
@@ -217,6 +218,7 @@ void Trick::Sie::sie_append_runtime_objs() {
     runtime_objects_print(sie_out);
     sie_out << "</sie>\n";
     sie_out.close();
+    delete[] buff;
 }
 
 std::string Trick::Sie::get_runtime_sie_dir() {

--- a/trick_source/sim_services/Sie/Sie.cpp
+++ b/trick_source/sim_services/Sie/Sie.cpp
@@ -183,27 +183,37 @@ void Trick::Sie::sie_append_runtime_objs() {
     std::string sie_filename = get_runtime_sie_dir() + "/" + "S_sie.resource" ;
 
     sie_out.open(sie_filename.c_str(), std::fstream::in | std::fstream::out) ;
-    sie_out.seekg(-1, sie_out.end);
     const char * comment = "<!--\nRuntime Allocations\nDo not edit this comment or file content past this point\n-->\n";
-    const int commentLength = 86;
-    char buff[commentLength + 1] = {0};
-    char last = '\0';
-    int pos;
-    while(memcmp(comment, buff, commentLength) != 0) {
-        while(last != '!' || sie_out.peek() != '<') {
-            if(sie_out.bad() || sie_out.fail() || sie_out.eof()) {
-                std::cerr << "Warning: Cannot add runtime/dynamic allocations to S_sie.resource. S_sie.resource is corrupted, outdated, or missing. Please be sure that SIM_*/S_sie.resource is preserved after build time if needed at runtime for trick-tv or other variable server clients. Please also rerun trick-CP." << std::endl;
-                return;
-            }
-            last = sie_out.peek();
-            sie_out.seekg(-1, std::ios::cur);
-            pos = sie_out.tellg();
-        }
-        sie_out.get(buff, commentLength + 1, '\0');
-        sie_out.seekg(pos - 1);
+    int comment_len = strlen(comment);
+
+    int curr_offset = 0;
+    int mem_size = 1000000;
+    char buff[mem_size + 1];
+    char * find_str = NULL;
+
+    // initial read use the whole buffer
+    sie_out.get(buff, mem_size, '\0');
+    find_str = strstr(buff, comment);
+
+    // loop through the file looking for the marker comment.  The comment could straddle 2 reads.  Copy the last bytes of
+    // the previous read to start the next search.
+    while ( !find_str && !sie_out.eof() ) {
+        curr_offset += mem_size - comment_len - 1;
+        strncpy(buff, &buff[mem_size-comment_len-1], comment_len);
+        sie_out.get(&buff[comment_len-1], mem_size-comment_len, '\0');
+        find_str = strstr(buff, comment);
     }
-    sie_out.seekg(pos - 1);
-    sie_out.seekp((int)sie_out.tellg() + commentLength + 1);
+
+    if ( !find_str ) {
+        std::cerr << "Warning: Cannot add runtime/dynamic allocations to S_sie.resource. S_sie.resource is corrupted, outdated, or missing. Please be sure that SIM_*/S_sie.resource is preserved after build time if needed at runtime for trick-tv or other variable server clients. Please also rerun trick-CP." << std::endl;
+        return;
+    }
+
+    // calculate the position of the marker in the file and jump to the point after the comment ends.
+    int pos = curr_offset + (find_str - buff) + strlen(comment) + 1;
+    sie_out.clear();
+    sie_out.seekp(pos);
+
     runtime_objects_print(sie_out);
     sie_out << "</sie>\n";
     sie_out.close();


### PR DESCRIPTION
When creating the sie file there is a marker string that Trick searches for where it writes the run time allocated memory.  The loop that was searching for the string was iterating one character at a time and reading from file each time.  This was slow.  Changed the loop to read 1Mb into memory at a time and search for the string.  Handled the case where the marker string could straddle the 1Mb boundary by copying a small portion of the previous part of the file for the next search.  For my one test point sie file generation dropped from 90+ seconds to 3.5 seconds.