### PR TITLE
AttributeError not being raised in SWIG 4 when making an improper ass…

### DIFF
--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -669,6 +669,7 @@ sub process_class($$$$$) {
     push @$class_names_ref , "$curr_namespace$class_name" ;
 
     # write the class contents and semicolon to ensure any template declarations below are after the semicolon.
+    $$new_contents_ref .= "\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n" ;
     $$new_contents_ref .= $extracted . ";\n" ;
     # write out the templated variable declaration lines found in this class.
     $$new_contents_ref .= $template_typedefs ;


### PR DESCRIPTION
…ignment in input processor #1288

In convert_swig added a line to override the __setattr__ function. This makes the new SWIG behave like older SWIG versions. the _swig_setattr_nondynamic_instance_variable function is provided by SWIG and is similar to what our version of _swig_setattr_nondynamic above is. If later we need to override _swig_setattr_nondynamic_instance_variable it can be done the same way as before.