### PR TITLE
Added executive time tic value information to S_job_execution.

### DIFF
--- a/trick_source/sim_services/Executive/Executive_write_s_job_execution.cpp
+++ b/trick_source/sim_services/Executive/Executive_write_s_job_execution.cpp
@@ -54,6 +54,9 @@ int Trick::Executive::write_s_job_execution(FILE *fp) {
         }
     }
 
+    fprintf(fp, "Executive time tic value (tics/second) information\n");
+    fprintf(fp, "    time tic value = %d\n\n", time_tic_value);
+
     fprintf(fp, "Thread information\n");
     for ( ii = 0 ; ii < threads.size() ; ii++ ) {
         std::stringstream oss ;


### PR DESCRIPTION
Add following information to the top of S_job_execution file:
Executive time tic value (tics/second) information
    time tic value = 1000000
