### PR TITLE
Changed not to inherit from binary_function for c++11 or above.

### DIFF
--- a/include/trick/Event.hh
+++ b/include/trick/Event.hh
@@ -4,6 +4,7 @@
     PURPOSE: ( Event Class )
 */
 #include <string>
+#include <iostream>
 #include "trick/mm_macros.hh"
 #include "trick/exec_proto.h"
 
@@ -203,12 +204,16 @@ class Event {
 
 
 #ifndef SWIG
-struct CompareEventPtrs : public std::binary_function<Trick::Event *, Trick::Event *, bool> {
-    bool operator()(const Trick::Event * lhs, const Trick::Event * rhs) const {
-        return lhs->get_next_tics() < rhs->get_next_tics();
-    }
-};
-
+    // No need to inherit from binary_function for c++11 or later
+    #if __cplusplus >= 201103L
+        struct CompareEventPtrs {
+    #else
+        struct CompareEventPtrs : public std::binary_function<Trick::Event *, Trick::Event *, bool> {
+    #endif
+            bool operator()(const Trick::Event * lhs, const Trick::Event * rhs) const {
+                return lhs->get_next_tics() < rhs->get_next_tics();
+            }
+        };
 #endif
 
 }


### PR DESCRIPTION
Removed inheritance from binary_function for c++11 or later and kept the inheritance for standards earlier than c++11