### PR TITLE
Format "Rounded" added to TVDouble for Issue #1616 Resolution

### DIFF
--- a/trick_source/java/src/main/java/trick/tv/TVDouble.java
+++ b/trick_source/java/src/main/java/trick/tv/TVDouble.java
@@ -26,7 +26,14 @@ public class TVDouble extends VSDouble implements TrickViewFluent<TVDouble.Forma
                 return Double.toString(value);
             }
         },
-
+        
+        Rounded {
+            // Rounds the double value up to .2f
+            public String format(double value) {
+                return String.format("%.2f", value);
+            }
+        },
+        
         Hexadecimal {
             public String format(double value) {
                 return Double.toHexString(value);

--- a/trick_source/java/src/main/resources/trick/tv/resources/trickView.xsd
+++ b/trick_source/java/src/main/resources/trick/tv/resources/trickView.xsd
@@ -288,6 +288,7 @@
             <xs:simpleType>
               <xs:restriction base="xs:string">
                 <xs:enumeration value="Decimal"/>
+                <xs:enumeration value="Rounded"/>
                 <xs:enumeration value="Hexadecimal"/>
               </xs:restriction>
             </xs:simpleType>


### PR DESCRIPTION
In TV, TVDouble Format, `Rounded`  added. It can round up to `.2f`     
It is a workaround for  Issue #1616 