### PR TITLE
Repurpose the "Sim/Real Time" field on the sim control panel #1626

### DIFF
--- a/include/trick/RealtimeSync.hh
+++ b/include/trick/RealtimeSync.hh
@@ -104,6 +104,9 @@ namespace Trick {
             /** The clock time when the sim ended.  Used for total actual time calculation.\n */
             long long sim_end_time ;           /**< trick_units(--) */
 
+            /** The actual simulation time/wall clock time ratio\n */
+            double actual_run_ratio ;           /**< trick_units(--) */
+
             /**
              @brief This is the constructor of the RealtimeSync class.  It starts the RealtimeSync as
              disabled and sets the maximum overrun parameters to basically infinity.

--- a/trick_source/java/src/main/java/trick/simcontrol/SimControlApplication.java
+++ b/trick_source/java/src/main/java/trick/simcontrol/SimControlApplication.java
@@ -765,7 +765,7 @@ public class SimControlApplication extends TrickApplication implements PropertyC
 
             status_vars = "trick.var_add(\"trick_sys.sched.time_tics\") \n" +
                           "trick.var_add(\"trick_sys.sched.mode\") \n" +
-                          "trick.var_add(\"trick_real_time.gtod_clock.rt_clock_ratio\") \n" +
+                          "trick.var_add(\"trick_real_time.rt_sync.actual_run_ratio\") \n" +
                           "trick.var_add(\"trick_real_time.rt_sync.active\") \n";
 
             if ( debug_present != 0 ) {
@@ -1650,7 +1650,7 @@ public class SimControlApplication extends TrickApplication implements PropertyC
                                 ii++ ;
                             }
 
-                            // "real_time.gtod_clock.rt_clock_ratio"
+                            // "real_time.rt_sync.actual_run_ratio"
                             if (results.length > ii && results[ii] != null && results[ii] != "") {
                                 simState.setSimRealtimeRatio(Float.parseFloat(results[ii]));
                                 ii++ ;

--- a/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
+++ b/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
@@ -9,6 +9,7 @@ PROGRAMMERS:
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <cmath>
 #include "trick/RealtimeSync.hh"
 #include "trick/exec_proto.h"
 #include "trick/sim_mode.h"


### PR DESCRIPTION
Added calculations in the realtime sync monitor job to calculate the average sim/realtime ratio for the past 100 frames.  This is saved to a new variable, actual_run_ratio.  Changed the sim control panel to display the actual_run_ratio value.