### PR TITLE
Update MacOS workflow to use SWIG 4.1.1 instead of the newest SWIG 4.2

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -28,6 +28,7 @@ jobs:
         brew install udunits openmotif maven
         wget https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
         tar -xvf clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
+        brew install autoconf automake libtool
         wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
         tar -xvzf v4.1.1.tar.gz
         cd swig-4.1.1

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -25,9 +25,15 @@ jobs:
       run: |
         # sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
         brew install --cask xquartz
-        brew install swig udunits openmotif maven
+        brew install udunits openmotif maven
         wget https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
         tar -xvf clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
+        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+        tar -xvzf v4.1.1.tar.gz
+        ./autogen.sh
+        ./configure
+        make
+        make install
     - name: Build Trick
       run: |
         export MAKEFLAGS=-j4

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -30,10 +30,12 @@ jobs:
         tar -xvf clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
         wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
         tar -xvzf v4.1.1.tar.gz
+        cd swig-4.1.1
         ./autogen.sh
         ./configure
         make
         make install
+        cd ..
     - name: Build Trick
       run: |
         export MAKEFLAGS=-j4


### PR DESCRIPTION
As SWIG 4.2 generates setter wrapper for C++ private constructor or operator.