### PR TITLE
TrickOps: Use usedforsecurity=False when calling hashlib.md5 for compare mechanism

### DIFF
--- a/share/trick/trickops/TrickWorkflow.py
+++ b/share/trick/trickops/TrickWorkflow.py
@@ -1284,8 +1284,8 @@ class TrickWorkflow(WorkflowCommon):
                   self.status = Job.Status.FAILED
             if self.missing:
                 return  self.status
-            if (hashlib.md5(open(self.test_data,'rb').read()).hexdigest() !=
-               hashlib.md5(open(self.baseline_data,'rb').read()).hexdigest()):
+            if (hashlib.md5(open(self.test_data,'rb').read(), usedforsecurity=False).hexdigest() !=
+               hashlib.md5(open(self.baseline_data,'rb').read(), usedforsecurity=False).hexdigest()):
                 self.status = Job.Status.FAILED
             else:
                 self.status = Job.Status.SUCCESS


### PR DESCRIPTION
This clears the "ValueError: ...  disabled for FIPS" exception for systems with FIPS mechanisms enabled. This is safe because hashlib is only used to compare baseline data to test data in trickops, it's not used for any security mechanisms.

FYI @hchen99 @jmpenn @sharmeye 

Closes #1661