### PR TITLE
Proposed fix for deadlock on shutdown

### DIFF
--- a/include/trick/VariableServer.hh
+++ b/include/trick/VariableServer.hh
@@ -66,6 +66,8 @@ namespace Trick {
             */
             int freeze_init() ;
 
+            void shutdownConnections();
+
             /**
              @brief Shutdown the variable server
              @return always 0

--- a/include/trick/VariableServerListenThread.hh
+++ b/include/trick/VariableServerListenThread.hh
@@ -58,6 +58,8 @@ namespace Trick {
 
             virtual void dump( std::ostream & oss = std::cout ) ;
 
+            void shutdownConnections();
+
         protected:
             void initializeMulticast();
 
@@ -82,9 +84,13 @@ namespace Trick {
             /* Multicast broadcaster */
             MulticastGroup * _multicast;     /**<  trick_io(**) trick_units(--)  */
 
+            bool allowConnections;                   /**<  trick_io(**) trick_units(--)  */
+            unsigned int pendingConnections;         /**<  trick_io(**) trick_units(--)  */
+            pthread_mutex_t connectionMutex;         /**<  trick_io(**) trick_units(--)  */
+            pthread_cond_t  noPendingConnections_cv; /**<  trick_io(**) trick_units(--)  */
+
     } ;
 
 }
 
 #endif
-

--- a/trick_source/sim_services/Clock/test/Makefile
+++ b/trick_source/sim_services/Clock/test/Makefile
@@ -9,7 +9,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_units -ltrick_mm -ltrick_pyip -ltrick_connection_handlers -ltrick_comm 
 LIBS = -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 
@@ -41,7 +41,7 @@ GetTimeOfDayClock_test.o : GetTimeOfDayClock_test.cpp
 	$(TRICK_CXX) $(TRICK_CPPFLAGS) -c $<
 
 GetTimeOfDayClock_test : ${GETTIMEOFDAY_CLOCK_OBJECTS}
-	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) $(TRICK_CPPFLAGS) -o $@ $^ ${LIBS}
+	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) $(TRICK_CPPFLAGS) -o $@ $^ $(TRICK_LIBS) ${LIBS}
 
 exec_get_rt_nap_stub.o : exec_get_rt_nap_stub.cpp
 	$(TRICK_CXX) $(TRICK_CPPFLAGS) -c $<

--- a/trick_source/sim_services/CommandLineArguments/test/Makefile
+++ b/trick_source/sim_services/CommandLineArguments/test/Makefile
@@ -17,7 +17,7 @@ TRICK_CXXFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wext
 MM_OBJECTS = $(TRICK_HOME)/trick_source/sim_services/MemoryManager/object_${TRICK_HOST_CPU}/extract_bitfield.o \
 				$(TRICK_HOME)/trick_source/sim_services/MemoryManager/object_${TRICK_HOST_CPU}/extract_unsigned_bitfield.o
 
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm 
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm -ltrick_mm -ltrick_units -ltrick
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main -lpthread
 
 

--- a/trick_source/sim_services/CommandLineArguments/test/Makefile
+++ b/trick_source/sim_services/CommandLineArguments/test/Makefile
@@ -17,7 +17,7 @@ TRICK_CXXFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wext
 MM_OBJECTS = $(TRICK_HOME)/trick_source/sim_services/MemoryManager/object_${TRICK_HOST_CPU}/extract_bitfield.o \
 				$(TRICK_HOME)/trick_source/sim_services/MemoryManager/object_${TRICK_HOST_CPU}/extract_unsigned_bitfield.o
 
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_mm -ltrick_units -ltrick
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm 
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main -lpthread
 
 

--- a/trick_source/sim_services/Executive/Executive_shutdown.cpp
+++ b/trick_source/sim_services/Executive/Executive_shutdown.cpp
@@ -64,7 +64,7 @@ int Trick::Executive::shutdown() {
         }
     }
 
-    /* Stop new connections to the Variable Server.
+    /* Stop new connections to the Variable Server. */
     the_vs->shutdownConnections();
 
     try {

--- a/trick_source/sim_services/Executive/Executive_shutdown.cpp
+++ b/trick_source/sim_services/Executive/Executive_shutdown.cpp
@@ -19,6 +19,8 @@
 #include "trick/message_type.h"
 #include "trick/release.h"
 #include "trick/SysThread.hh"
+#include "trick/VariableServer.hh"
+extern Trick::VariableServer * the_vs ;
 
 /**
 @design
@@ -61,6 +63,9 @@ int Trick::Executive::shutdown() {
             }
         }
     }
+
+    /* Stop new connections to the Variable Server.
+    the_vs->shutdownConnections();
 
     try {
 

--- a/trick_source/sim_services/Executive/test/Makefile
+++ b/trick_source/sim_services/Executive/test/Makefile
@@ -12,7 +12,7 @@ COVERAGE_FLAGS += -fprofile-arcs -ftest-coverage -O0
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
 
-TRICK_LIBS = -L ${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick_comm -ltrick_pyip -ltrick -ltrick_connection_handlers 
+TRICK_LIBS = -L ${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 TRICK_SYSTEM_LDFLAGS  += ${COVERAGE_FLAGS}
 

--- a/trick_source/sim_services/Executive/test/Makefile
+++ b/trick_source/sim_services/Executive/test/Makefile
@@ -12,7 +12,7 @@ COVERAGE_FLAGS += -fprofile-arcs -ftest-coverage -O0
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
 
-TRICK_LIBS = -L ${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick 
+TRICK_LIBS = -L ${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick_comm -ltrick_pyip -ltrick -ltrick_connection_handlers 
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 TRICK_SYSTEM_LDFLAGS  += ${COVERAGE_FLAGS}
 

--- a/trick_source/sim_services/Integrator/test/Makefile
+++ b/trick_source/sim_services/Integrator/test/Makefile
@@ -10,7 +10,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -I${TRICK_HOME}/trick_source -I${TRICK_HOME}/include/trick/compat -g -Wall -Wextra -DUSE_ER7_UTILS_INTEGRATORS=1 -DTEST ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
 
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_mm -ltrick_units -ltrick_pyip -ltrick_connection_handlers -ltrick_comm  
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_mm -ltrick_units -ltrick_mm -ltrick_pyip -ltrick_connection_handlers -ltrick_comm -ltrick_mm -ltrick_units -ltrick
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 # All tests produced by this Makefile.  Remember to add new tests you

--- a/trick_source/sim_services/Integrator/test/Makefile
+++ b/trick_source/sim_services/Integrator/test/Makefile
@@ -10,7 +10,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -I${TRICK_HOME}/trick_source -I${TRICK_HOME}/include/trick/compat -g -Wall -Wextra -DUSE_ER7_UTILS_INTEGRATORS=1 -DTEST ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
 
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_mm -ltrick_units -ltrick -ltrick_mm
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_mm -ltrick_units -ltrick_pyip -ltrick_connection_handlers -ltrick_comm  
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 # All tests produced by this Makefile.  Remember to add new tests you

--- a/trick_source/sim_services/MemoryManager/test/Makefile
+++ b/trick_source/sim_services/MemoryManager/test/Makefile
@@ -14,7 +14,7 @@ TRICK_SYSTEM_LDFLAGS  += ${COVERAGE_FLAGS}
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra -Wno-sign-compare ${COVERAGE_FLAGS} ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_mm -ltrick_units -ltrick
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_mm -ltrick_units -ltrick -ltrick_connection_handlers -ltrick_pyip -ltrick -ltrick_comm
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main -lpthread
 
 # ==================================================================================

--- a/trick_source/sim_services/ScheduledJobQueue/test/Makefile
+++ b/trick_source/sim_services/ScheduledJobQueue/test/Makefile
@@ -9,7 +9,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra  ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_mm -ltrick_units -ltrick
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm 
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 # All tests produced by this Makefile.  Remember to add new tests you

--- a/trick_source/sim_services/ScheduledJobQueue/test/Makefile
+++ b/trick_source/sim_services/ScheduledJobQueue/test/Makefile
@@ -9,7 +9,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra  ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm 
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick_mm -ltrick_units -ltrick -ltrick_mm -ltrick_units -ltrick -ltrick_pyip -ltrick_connection_handlers -ltrick_comm -ltrick
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 # All tests produced by this Makefile.  Remember to add new tests you

--- a/trick_source/sim_services/Timer/test/Makefile
+++ b/trick_source/sim_services/Timer/test/Makefile
@@ -9,7 +9,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g -Wall -Wextra ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_units -ltrick_mm
+TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_units -ltrick_mm -ltrick_pyip -ltrick_connection_handlers -ltrick_comm 
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main -lpthread
 
 # All tests produced by this Makefile.  Remember to add new tests you

--- a/trick_source/sim_services/VariableServer/VariableServer.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServer.cpp
@@ -19,6 +19,10 @@ Trick::VariableServer::~VariableServer() {
     the_vs = NULL;
 }
 
+void Trick::VariableServer::shutdownConnections() {
+    listen_thread.shutdownConnections();
+}
+
 std::ostream& Trick::operator<< (std::ostream& s, Trick::VariableServer& vs) {
     std::map < pthread_t , VariableServerSessionThread * >::iterator it ;
 


### PR DESCRIPTION
Issue #1656 describes a deadlock condition that can occur at shutdown.
Many thanks to Cameron Bracco (cameronbracco) for an excellent writeup!
Whereas a fix was proposed, we'd like to try different approach that does rely on timers.