### PR TITLE
Revert changes to trickops test yml file from Sept 2023 to fix trickops unit tests

### DIFF
--- a/.github/workflows/trickops.yml
+++ b/.github/workflows/trickops.yml
@@ -31,7 +31,7 @@ jobs:
           source ../.venv/bin/activate
           export PATH="/tmp/koviz-master/bin:${PATH}"
           ./run_tests.py
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3.0.0
         if: ${{ always() }}
         with:
           name: doctests
@@ -63,7 +63,7 @@ jobs:
           source ../.venv/bin/activate
           export PATH="/tmp/koviz-master/bin:${PATH}"
           ./run_tests.py
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3.0.0
         if: ${{ always() }}
         with:
           name: doctests

--- a/.github/workflows/trickops.yml
+++ b/.github/workflows/trickops.yml
@@ -1,9 +1,6 @@
 name: TrickOps
 # This workflow is triggered on pushes to the repository.
-on:
-  schedule:
-  - cron:  '0 0 * * 0'
-  workflow_dispatch:
+on: [pull_request]
 
 defaults:
   run:

--- a/share/trick/trickops/TrickWorkflow.py
+++ b/share/trick/trickops/TrickWorkflow.py
@@ -1284,8 +1284,11 @@ class TrickWorkflow(WorkflowCommon):
                   self.status = Job.Status.FAILED
             if self.missing:
                 return  self.status
-            if (hashlib.md5(open(self.test_data,'rb').read(), usedforsecurity=False).hexdigest() !=
-               hashlib.md5(open(self.baseline_data,'rb').read(), usedforsecurity=False).hexdigest()):
+            td = hashlib.new('md5', usedforsecurity=False)
+            bd = hashlib.new('md5', usedforsecurity=False)
+            td.update(open(self.test_data,'rb').read())
+            bd.update(open(self.baseline_data,'rb').read())
+            if (td.hexdigest() != bd.hexdigest()):
                 self.status = Job.Status.FAILED
             else:
                 self.status = Job.Status.SUCCESS

--- a/share/trick/trickops/tests/trick_sims.yml
+++ b/share/trick/trickops/tests/trick_sims.yml
@@ -146,12 +146,12 @@ SIM_test_templates:
       - unit_test
     runs:
         RUN_test/unit_test.py:
-# SIM_test_varserv:
-#     path: test/SIM_test_varserv
-#     labels:
-#       - unit_test
-#     runs:
-#         RUN_test/unit_test.py:
+SIM_test_varserv:
+    path: test/SIM_test_varserv
+    labels:
+      - unit_test
+    runs:
+        RUN_test/unit_test.py:
 SIM_threads:
     path: test/SIM_threads
     labels:
@@ -189,8 +189,8 @@ SIM_ball_L2:
     runs:
 SIM_ball_L3:
     path: trick_sims/Ball/SIM_ball_L3
-# SIM_amoeba:
-#     path: trick_sims/Cannon/SIM_amoeba
+SIM_amoeba:
+    path: trick_sims/Cannon/SIM_amoeba
 SIM_cannon_aero:
     path: trick_sims/Cannon/SIM_cannon_aero
 SIM_cannon_analytic:


### PR DESCRIPTION
trick_sims.yml was "accidentally changed" to remove unstable sims in Sept 2023, breaking the TrickOps unit tests. This reverts that change.