### PR TITLE
Fix bug dereferencing namespaces in convert_swig

### DIFF
--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -622,7 +622,7 @@ sub process_class($$$$$) {
        my $sanitized_namespace = $split_namespaces[-1] ;
        my @namespace_split = split /namespace\s*$sanitized_namespace/, $$new_contents_ref;
        $save_namespace_content = 'namespace ' . $sanitized_namespace . $namespace_split[-1];
-       $$new_contents_ref = join('namespace ' . $sanitized_namespace, $namespace_split[0 .. $#namespace_split-1]);
+       $$new_contents_ref = join('namespace ' . $sanitized_namespace, @namespace_split[0 .. $#namespace_split-1]);
     }
 
     # SWIG doesn't like "const static".  Change it to "static const"


### PR DESCRIPTION
Changed to many perl arrays to lists.