### PR TITLE
Disable unneeded SimObjects from default_trick_sys.sm in Trick exampl…

### DIFF
--- a/trick_sims/SIM_aircraft/S_define
+++ b/trick_sims/SIM_aircraft/S_define
@@ -7,7 +7,14 @@ LIBRARY DEPENDENCIES:
         (Aircraft/src/Waypoint.cpp)
     )
 **************************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "Aircraft/include/Aircraft.hh"
 ##include "Aircraft/include/Waypoint.hh"
 

--- a/trick_sims/SIM_aircraft/S_define
+++ b/trick_sims/SIM_aircraft/S_define
@@ -12,7 +12,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "Aircraft/include/Aircraft.hh"

--- a/trick_sims/SIM_balloon/S_define
+++ b/trick_sims/SIM_balloon/S_define
@@ -10,7 +10,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "balloon/include/Balloon.hh"

--- a/trick_sims/SIM_balloon/S_define
+++ b/trick_sims/SIM_balloon/S_define
@@ -5,7 +5,14 @@ LIBRARY DEPENDENCIES:
     ((balloon/src/Balloon.cpp)
      (atmosphere/src/atmosphere.c))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "balloon/include/Balloon.hh"
 
 class BalloonSimObject : public Trick::SimObject {

--- a/trick_sims/SIM_billiards/S_define
+++ b/trick_sims/SIM_billiards/S_define
@@ -4,7 +4,14 @@ PURPOSE:
 LIBRARY DEPENDENCIES:
     ((pool_table/src/pool_table.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "pool_table/include/pool_table.hh"
 
 class PoolTableSimObject : public Trick::SimObject {

--- a/trick_sims/SIM_billiards/S_define
+++ b/trick_sims/SIM_billiards/S_define
@@ -9,7 +9,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "pool_table/include/pool_table.hh"

--- a/trick_sims/SIM_contact/S_define
+++ b/trick_sims/SIM_contact/S_define
@@ -9,7 +9,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "contact/include/Contact.hh"

--- a/trick_sims/SIM_contact/S_define
+++ b/trick_sims/SIM_contact/S_define
@@ -4,7 +4,14 @@ PURPOSE:
 LIBRARY DEPENDENCIES:
     ((contact/src/Contact.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "contact/include/Contact.hh"
 class ContactSimObject : public Trick::SimObject {
     public:

--- a/trick_sims/SIM_lander/S_define
+++ b/trick_sims/SIM_lander/S_define
@@ -5,7 +5,14 @@ LIBRARY DEPENDENCIES:
     ((lander/src/Lander.cpp)
      (PIDController/src/PIDController.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "lander/include/Lander.hh"
 class LanderSimObject : public Trick::SimObject {
     public:

--- a/trick_sims/SIM_lander/S_define
+++ b/trick_sims/SIM_lander/S_define
@@ -10,7 +10,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "lander/include/Lander.hh"

--- a/trick_sims/SIM_msd/S_define
+++ b/trick_sims/SIM_msd/S_define
@@ -16,7 +16,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 // #include "sim_objects/WebServer.sm"

--- a/trick_sims/SIM_msd/S_define
+++ b/trick_sims/SIM_msd/S_define
@@ -11,8 +11,14 @@ LIBRARY DEPENDENCIES:
       (msd/src/msd_shutdown.cpp)
     )
 *************************************************************/
-
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 // #include "sim_objects/WebServer.sm"
 ##include "msd/include/msd.hh"
 
@@ -33,3 +39,4 @@ class MSDSimObject : public Trick::SimObject {
 
 MSDSimObject dyn ;
 IntegLoop dyn_integloop (0.01) dyn ;
+

--- a/trick_sims/SIM_parachute/S_define
+++ b/trick_sims/SIM_parachute/S_define
@@ -9,7 +9,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "parachute/include/Parachutist.hh"

--- a/trick_sims/SIM_parachute/S_define
+++ b/trick_sims/SIM_parachute/S_define
@@ -4,7 +4,12 @@ PURPOSE:
 LIBRARY DEPENDENCIES:
     ((parachute/src/Parachutist.cpp))
 *************************************************************/
-
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "parachute/include/Parachutist.hh"

--- a/trick_sims/SIM_robot/S_define
+++ b/trick_sims/SIM_robot/S_define
@@ -11,7 +11,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "include/trick/exec_proto.h"

--- a/trick_sims/SIM_robot/S_define
+++ b/trick_sims/SIM_robot/S_define
@@ -6,8 +6,14 @@ LIBRARY DEPENDENCIES:
         (manipulator/manipulator.cc)
     )
 *************************************************************/
-
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "include/trick/exec_proto.h"
 ##include "manipulator/manipulator.hh"
 

--- a/trick_sims/SIM_rocket/S_define
+++ b/trick_sims/SIM_rocket/S_define
@@ -4,7 +4,14 @@ PURPOSE:
 LIBRARY DEPENDENCIES:
     ((rocket/src/Rocket.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "rocket/include/Rocket.hh"
 class ModelRocketSimObject : public Trick::SimObject {
     public:

--- a/trick_sims/SIM_rocket/S_define
+++ b/trick_sims/SIM_rocket/S_define
@@ -9,7 +9,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "rocket/include/Rocket.hh"

--- a/trick_sims/SIM_sat2d/S_define
+++ b/trick_sims/SIM_sat2d/S_define
@@ -9,7 +9,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "satellite/include/Satellite.hh"

--- a/trick_sims/SIM_sat2d/S_define
+++ b/trick_sims/SIM_sat2d/S_define
@@ -4,7 +4,14 @@ PURPOSE:
 LIBRARY DEPENDENCIES:
     ((satellite/src/Satellite.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "satellite/include/Satellite.hh"
 class SatelliteSimObject : public Trick::SimObject {
     public:

--- a/trick_sims/SIM_satellite/S_define
+++ b/trick_sims/SIM_satellite/S_define
@@ -5,8 +5,13 @@ LIBRARY DEPENDENCIES:
 (
 )
 *************************************************************/
-
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "Satellite/include/Satellite.hh"
 ##include "Satellite/include/SatGraphicsComm.hh"
 

--- a/trick_sims/SIM_splashdown/S_define
+++ b/trick_sims/SIM_splashdown/S_define
@@ -5,7 +5,13 @@ LIBRARY DEPENDENCIES:
     ((CrewModule/src/CrewModuleDynamics.o)
      (CrewModule/src/CrewModuleShape.o))
 **************************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "CrewModule/include/CrewModuleDynamics.hh"
 
 class CrewModuleSimObject : public Trick::SimObject {

--- a/trick_sims/SIM_submarine/S_define
+++ b/trick_sims/SIM_submarine/S_define
@@ -9,7 +9,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "submarine/include/Submarine.hh"

--- a/trick_sims/SIM_submarine/S_define
+++ b/trick_sims/SIM_submarine/S_define
@@ -4,7 +4,14 @@ PURPOSE:
 LIBRARY DEPENDENCIES:
     ((submarine/src/Submarine.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "submarine/include/Submarine.hh"
 
 class SubmarineSimObject : public Trick::SimObject {

--- a/trick_sims/SIM_sun/S_define
+++ b/trick_sims/SIM_sun/S_define
@@ -20,7 +20,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "Sun/include/sun_pred.h"

--- a/trick_sims/SIM_sun/S_define
+++ b/trick_sims/SIM_sun/S_define
@@ -15,9 +15,13 @@ LIBRARY DEPENDENCIES:
      (Sun/src/sun_pred_slow_display.c)
     )
 *************************************************************/
-
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
-
 
 ##include "Sun/include/sun_pred.h"
 ##include "sim_services/MemoryManager/include/wcs_ext.h"

--- a/trick_sims/SIM_waterclock/S_define
+++ b/trick_sims/SIM_waterclock/S_define
@@ -13,7 +13,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "waterclock/include/waterclock_numeric.h"

--- a/trick_sims/SIM_waterclock/S_define
+++ b/trick_sims/SIM_waterclock/S_define
@@ -8,8 +8,14 @@ LIBRARY DEPENDENCIES:
       (waterclock/src/waterclock_shutdown.c)
     )
 *************************************************************/
-
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 #include "sim_objects/default_trick_sys.sm"
+
 ##include "waterclock/include/waterclock_numeric.h"
 
 class WaterClockSimObject : public Trick::SimObject {

--- a/trick_sims/SIM_wheelbot/S_define
+++ b/trick_sims/SIM_wheelbot/S_define
@@ -5,6 +5,12 @@ LIBRARY DEPENDENCIES:
     ((Vehicle/src/vehicleOne.cpp)
     (Control/src/PIDController.cpp))
 *************************************************************/
+#define TRICK_NO_MONTE_CARLO
+#define TRICK_NO_MASTERSLAVE
+#define TRICK_NO_INSTRUMENTATION
+#define TRICK_NO_REALTIMEINJECTOR
+#define TRICK_NO_ZEROCONF
+#define TRICK_NO_UNITTEST
 
 #include "sim_objects/default_trick_sys.sm"
 

--- a/trick_sims/SIM_wheelbot/S_define
+++ b/trick_sims/SIM_wheelbot/S_define
@@ -10,8 +10,6 @@ LIBRARY DEPENDENCIES:
 #define TRICK_NO_INSTRUMENTATION
 #define TRICK_NO_REALTIMEINJECTOR
 #define TRICK_NO_ZEROCONF
-#define TRICK_NO_UNITTEST
-
 #include "sim_objects/default_trick_sys.sm"
 
 ##include "Vehicle/include/vehicleOne.hh"


### PR DESCRIPTION
…e sims.

This is us following our own advice from [Realtime-Best-Practices](https://nasa.github.io/trick/howto_guides/Realtime-Best-Practices#disable-trick-run-time-components-that-your-sim-doesnt-need) in our example sims.
