### PR TITLE
Updated the MacOS CI workflow so that bash won't exit with brew upgrade exits with non-zero exit code.

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -23,6 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         # sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /
+        brew update
+        brew upgrade || true
         brew install --cask xquartz
         brew install udunits openmotif maven
         brew install swig


### PR DESCRIPTION
Updated the MacOS CI workflow so that bash won't exit with brew upgrade exits with non-zero exit code.