### PR TITLE
CentOS 7 CI Failures - Run CentOS CI with Node 16 instead of 20

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -150,9 +150,8 @@ jobs:
       - name: Install GTest
         run: ${{matrix.install_gtest}}
       - name: Checkout repository
-        uses: >
-          node -v
-          actions/checkout@v3
+        uses: actions/checkout@v3
+        run: node -v
       - name: Configure Trick
         run: |
           export MAKEFLAGS=-j`nproc`

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -91,7 +91,7 @@ jobs:
               zlib-devel
               python2-devel
               python3-devel
-#-------- RHEL 7-based Only Dependencies ----------------
+#-------- RHEL 7-based Only Dependencies? ----------------
           - cfg: { arch: rhel, arch_ver: 7 }
             pkg_mgr: yum
             conf_pkg: |

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -150,7 +150,9 @@ jobs:
       - name: Install GTest
         run: ${{matrix.install_gtest}}
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: >
+          node -v
+          actions/checkout@v3
       - name: Configure Trick
         run: |
           export MAKEFLAGS=-j`nproc`

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -104,6 +104,7 @@ jobs:
               libXt-devel
               swig3
             install_gtest: |
+              node -v
               cd /tmp
               wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
               tar xzvf release-1.8.0.tar.gz
@@ -151,7 +152,6 @@ jobs:
         run: ${{matrix.install_gtest}}
       - name: Checkout repository
         uses: actions/checkout@v3
-        run: node -v
       - name: Configure Trick
         run: |
           export MAKEFLAGS=-j`nproc`

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   build:
     strategy:
@@ -104,7 +108,6 @@ jobs:
               libXt-devel
               swig3
             install_gtest: |
-              node -v
               cd /tmp
               wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
               tar xzvf release-1.8.0.tar.gz

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install GTest
         run: ${{matrix.install_gtest}}
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Configure Trick
         run: |
           export MAKEFLAGS=-j`nproc`

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -95,7 +95,7 @@ jobs:
               zlib-devel
               python2-devel
               python3-devel
-#-------- RHEL 7-based Only Dependencies? ----------------
+#-------- RHEL 7-based Only Dependencies ----------------
           - cfg: { arch: rhel, arch_ver: 7 }
             pkg_mgr: yum
             conf_pkg: |


### PR DESCRIPTION
Configured CentOS 7 to run with node 16.