### PR TITLE
Restore ROBoT image in Related Projects

### DIFF
--- a/docs/related_projects/Related-Projects.md
+++ b/docs/related_projects/Related-Projects.md
@@ -37,7 +37,9 @@ The Virtual Reality Laboratory is an immersive training facility that provides r
 
 ## Robotics On-Board Trainer (ROBoT)
 <p align="center">
+  
 ![ROBoT](images/ROBoT.jpg)
+
 </p>
 
 The Robotics On-Board Trainer (ROBoT) is an on-orbit version of the ground-based Dynamics Skills Trainer (DST) that astronauts use for training on a frequent basis.


### PR DESCRIPTION
Updates image reference to ROBoT.

Current: 

![image](https://github.com/nasa/trick/assets/53410876/f5538822-8276-4511-addc-b489ae74acfb)

Proposed:

![image](https://github.com/nasa/trick/assets/53410876/8d1c24f8-aab4-4ab0-a602-64999cde6ec8)