### PR TITLE
Added TRICK_LDFLAGS to the rule for linking shared library for jit input.

### DIFF
--- a/trick_source/sim_services/JITInputFile/JITInputFile.cpp
+++ b/trick_source/sim_services/JITInputFile/JITInputFile.cpp
@@ -74,8 +74,7 @@ int Trick::JITInputFile::process_sim_args() {
 -# If the compilation was unsuccessful, exec_terminate
 -# The library compile successfully.  Add library name to map
 */
-int Trick::JITInputFile::
-compile(std::string file_name) {
+int Trick::JITInputFile::compile(std::string file_name) {
 
     std::ofstream outfile ;
     std::ostringstream ss ;

--- a/trick_source/sim_services/JITInputFile/JITInputFile.cpp
+++ b/trick_source/sim_services/JITInputFile/JITInputFile.cpp
@@ -74,7 +74,8 @@ int Trick::JITInputFile::process_sim_args() {
 -# If the compilation was unsuccessful, exec_terminate
 -# The library compile successfully.  Add library name to map
 */
-int Trick::JITInputFile::compile(std::string file_name) {
+int Trick::JITInputFile::
+compile(std::string file_name) {
 
     std::ofstream outfile ;
     std::ostringstream ss ;
@@ -135,9 +136,9 @@ int Trick::JITInputFile::compile(std::string file_name) {
     // rule to link shared library
     outfile << library_fullpath_name << ": " << object_fullpath_name << std::endl ;
 #ifdef __APPLE__
-    outfile << "\t" << get_trick_env((char *)"TRICK_CXX") << " -shared -undefined dynamic_lookup -o $@ $< " << std::endl << std::endl ;
+    outfile << "\t" << get_trick_env((char *)"TRICK_CXX") << " " << get_trick_env((char *)"TRICK_LDFLAGS") << " -shared -undefined dynamic_lookup -o $@ $< " << std::endl << std::endl ;
 #else
-    outfile << "\t" << get_trick_env((char *)"TRICK_CXX") << " -shared -o $@ $< " << std::endl << std::endl ;
+    outfile << "\t" << get_trick_env((char *)"TRICK_CXX") << " " << get_trick_env((char *)"TRICK_LDFLAGS") << " -shared -o $@ $< " << std::endl << std::endl ;
 #endif
     // rule to compile cpp file
     outfile << object_fullpath_name << ": " << file_name << std::endl ;


### PR DESCRIPTION
So that users can use TRICK_LDFLAGS for linking shared library if necessary. 

For instance, if a user has `TRICK_CXXFLAGS += -fprofile-arcs -ftest-coverage -I./models` in S_overrides.mk to compile a sim with code coverage flags, they can include `TRICK_LDFLAGS += --coverage` or `TRICK_LDFLAGS += -fprofile-arcs -ftest-coverage` in S_overrides.mk for the generated shared library to be loaded correctly.