### PR TITLE
Updated to use default-jdk package instead of openjdk-11-jdk for ubuntu.

### DIFF
--- a/docs/documentation/install_guide/Install-Guide.md
+++ b/docs/documentation/install_guide/Install-Guide.md
@@ -198,6 +198,8 @@ libgtest-dev default-jdk zip
 export PYTHON_VERSION=3
 ```
 
+Note: If you need to use a specific JDK version, such as `openjdk-11-jdk`, you can replace `default-jdk` with `openjdk-11-jdk` under install packages as shown above. However, you need to check where the `java` and `javac` commands are located. For instance, Ubuntu 24 typically sets up JRE (21) headless by default, so the `java` (version 21 headless) command might be located in `/usr/bin`. When you install `openjdk-11-jdk`, both `java` (version 11) and `javac` (version 11) might be placed in `/usr/lib/jvm/java-11-openjdk-amd64/bin`, with only `javac` potentially also in `/usr/bin`. Consequently, running a Java GUI with the default PATH might use JRE 21 headless instead of JRE 11, even though you’re using JDK 11 for compiling, which may not be the desired configuration. Placing `/usr/lib/jvm/java-11-openjdk-amd64/bin` before `/usr/bin` in your PATH ensures that only JDK 11 is used.
+
 proceed to [Install Trick](#install) section of the install guide
 
 ---

--- a/docs/documentation/install_guide/Install-Guide.md
+++ b/docs/documentation/install_guide/Install-Guide.md
@@ -350,7 +350,7 @@ proceed to [Install Trick](#install) section of the install guide
 
 <a name="manual_build_clang_llvm"></a>
 ### Build Clang and LLVM
-If you come to this section because Clang+LLVM installed by the package manager on your machine does not work for your environment, you need to manually build Clang and LLVM. Following instructions show steps on building a particular release of Clang and LLVM . `cmake` is required. CMake may support multiple native build systmes on certain platforms. A generator is responsible for generating a particular build system. Below lists two approaches for your reference. The 1st approach uses `Unix Makefiles` (one of Makefile generators) and the 2nd one uses `Ninja` (one of Ninja generators). For Mac Apple Silicon user, may want to go to the 2nd approach direcly. 
+If you come to this section because Clang+LLVM installed by the package manager on your machine does not work for your environment, you need to manually build Clang and LLVM. Following instructions show steps on building a particular release of Clang and LLVM . `cmake` is required. CMake may support multiple native build systmes on certain platforms. A generator is responsible for generating a particular build system. Below lists two approaches for your reference. The first approach uses `Unix Makefiles` (one of Makefile generators) and the second one uses `Ninja` (one of Ninja generators). For Mac Apple Silicon user, may want to go to the second approach directly. 
 
 Note: Remember to add `--with-llvm=<clang+llvm-17_path>` for Trick configure if using the Clang and LLVM built in this section.
 

--- a/docs/documentation/install_guide/Install-Guide.md
+++ b/docs/documentation/install_guide/Install-Guide.md
@@ -190,7 +190,7 @@ apt-get update
 apt-get install -y bison clang flex git llvm make maven swig cmake \
 curl g++ libx11-dev libxml2-dev libxt-dev libmotif-common libmotif-dev \
 python3-dev zlib1g-dev llvm-dev libclang-dev libudunits2-dev \
-libgtest-dev openjdk-11-jdk zip
+libgtest-dev default-jdk zip
 
 # On some versions of Ubuntu (18.04 as of 04/2021), there may be multiple installations of python.
 # Our new python3-dev will be linked to python3 and python3-config in your bin.
@@ -348,9 +348,9 @@ proceed to [Install Trick](#install) section of the install guide
 
 <a name="manual_build_clang_llvm"></a>
 ### Build Clang and LLVM
-#### If you come to this section because Clang+LLVM installed by the package manager on your machine does not work for your environment, you need to manually build Clang and LLVM. Following instructions show steps on building a particular release of Clang and LLVM . `cmake` is required. CMake may support multiple native build systmes on certain platforms. A generator is responsible for generating a particular build system. Below lists two approaches for your reference. The 1st approach uses `Unix Makefiles` (one of Makefile generators) and the 2nd one uses `Ninja` (one of Ninja generators). For Mac Apple Silicon user, may want to go to the 2nd approach direcly. 
+If you come to this section because Clang+LLVM installed by the package manager on your machine does not work for your environment, you need to manually build Clang and LLVM. Following instructions show steps on building a particular release of Clang and LLVM . `cmake` is required. CMake may support multiple native build systmes on certain platforms. A generator is responsible for generating a particular build system. Below lists two approaches for your reference. The 1st approach uses `Unix Makefiles` (one of Makefile generators) and the 2nd one uses `Ninja` (one of Ninja generators). For Mac Apple Silicon user, may want to go to the 2nd approach direcly. 
 
-#### Note: Remember to add `--with-llvm=<clang+llvm-17_path>` for Trick configure if using the Clang and LLVM built in this section.
+Note: Remember to add `--with-llvm=<clang+llvm-17_path>` for Trick configure if using the Clang and LLVM built in this section.
 
 1. Using `Unix Makefiles` generator 
 


### PR DESCRIPTION
Using `default-jdk` instead of a specific JDK version so that if there is JRE installed by default, it'll be consistent with the JDK. 
Ubuntu 24 has JRE (version 21) headless set up by default in `/usr/bin`.
Installing openjdk-11-jdk in ubuntu24 does set up openjdk-11-jre however in `/usr/lib/jvm/java-11-openjdk-amd64/bin` instead of `/usr/bin`. openjdk-11-jre doesn't replace the JRE headless in `/usr/bin` probably because the default one is a newer version. 

If using openjdk-11-jdk package in ubuntu24, the user needs to set their environment path to use openjdk-11-jre (`java` command for running Java GUIs) first otherwise, they'd get an error by running Java GUIs using headless JRE from `/urs/bin` by default.
Using `default-jdk` works for ubuntu 18, 20, 22, and 24. Using openjdk-11-jdk works for 18, 20, 22 without extra work as their default `java` version is 11 and openjdk-11-jre can be set to the default path.

Trick CI uses ubuntu22 with `default-jdk` package btw. 