### PR TITLE
Updated trickops.yml to use a newer Ubuntu

### DIFF
--- a/.github/workflows/trickops.yml
+++ b/.github/workflows/trickops.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install dependencies
         # Note that perl is for trick-gte which TrickOps runs and qt and everything after it is for koviz
         run: |
-          export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y git python3 python3-venv perl perl-modules-5.30 qtbase5-dev wget unzip g++ make flex bison
+          export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y git python3 python3-venv perl perl-modules-5.34 qtbase5-dev wget unzip g++ make flex bison
       - name: create virtual environment
         run: |
           cd share/trick/trickops/

--- a/.github/workflows/trickops.yml
+++ b/.github/workflows/trickops.yml
@@ -8,9 +8,9 @@ defaults:
 
 jobs:
   trickops-tests-ubuntu:
-    name: Unit Tests Ubuntu:20.04
-    runs-on: ubuntu-20.04
-    container: ubuntu:20.04
+    name: Unit Tests Ubuntu:22.04
+    runs-on: ubuntu-22.04
+    container: ubuntu:22.04
     steps:
       - uses: actions/checkout@master
       - name: install dependencies
@@ -41,7 +41,7 @@ jobs:
 
   trickops-tests-rockylinux8:
     name: Unit Tests RockyLinux8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: rockylinux:8
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
trickops.yml needs to be updated to use a newer Ubuntu than Ubuntu 20 since the latest koviz removed deprecated calls from an older Qt on Ubuntu 20. The koviz update is necessary to keep up with Qt changes.