### PR TITLE
Preserved job queue currant index after pushing a job.

### DIFF
--- a/trick_source/sim_services/ScheduledJobQueue/ScheduledJobQueue.cpp
+++ b/trick_source/sim_services/ScheduledJobQueue/ScheduledJobQueue.cpp
@@ -92,10 +92,10 @@ int Trick::ScheduledJobQueue::push( JobData * new_job ) {
     /* Increment the size of the queue */
     list_size++ ;
 	
-	int new_job_index = (insert_pt - list) / sizeof(JobData**);
-	if(new_job_index < curr_index) {
-	    curr_index++;	
-	}
+    int new_job_index = (insert_pt - list) / sizeof(JobData**);
+    if(new_job_index < curr_index) {
+        curr_index++;	
+    }
 
     return(0) ;
 

--- a/trick_source/sim_services/ScheduledJobQueue/ScheduledJobQueue.cpp
+++ b/trick_source/sim_services/ScheduledJobQueue/ScheduledJobQueue.cpp
@@ -91,6 +91,11 @@ int Trick::ScheduledJobQueue::push( JobData * new_job ) {
 
     /* Increment the size of the queue */
     list_size++ ;
+	
+	int new_job_index = (insert_pt - list) / sizeof(JobData**);
+	if(new_job_index < curr_index) {
+	    curr_index++;	
+	}
 
     return(0) ;
 


### PR DESCRIPTION
The Job Queue push update did not properly track the queue's current index. I re-implemented that feature.