### PR TITLE
Fixed one warning message at shutdown after checkpoint load and kept the current multicast group after checkpoint load.

### DIFF
--- a/include/trick/ExternalApplication.hh
+++ b/include/trick/ExternalApplication.hh
@@ -295,13 +295,6 @@ namespace Trick {
         /** Command to execute when starting this application. */
         std::string command;
 
-        /** Pointer to alloc'd command c str for use with external application c_intf */
-        char * command_c_str;
-
-        /** alloc'd addresses to be deallocated during app destruction (currently only
-        used by command_c_str) */
-        std::vector<char*> allocations;
-
         private:
 
         /** Prevent SWIG from trying to invoke operator= on ostringstream. */

--- a/trick_source/sim_services/ExternalApplications/ExternalApplication.cpp
+++ b/trick_source/sim_services/ExternalApplications/ExternalApplication.cpp
@@ -19,28 +19,13 @@ Trick::ExternalApplication::ExternalApplication() :
     host_source = port_source = AUTO;
     cycle_period_set = minimum_cycle_period_set = disconnect_behavior_set = height_set =
       width_set = x_set = y_set = auto_reconnect_set = false;
-      
-      // c_intf uses char *, we manage the memory here in external application
-      command_c_str = (char*)trick_MM->declare_var("char", (command.size() + 1) );
-      strcpy(command_c_str, command.c_str());
-      allocations.push_back(command_c_str);
 }
 
 Trick::ExternalApplication::~ExternalApplication() {
-    for(std::vector<char*>::iterator it = allocations.begin(); it != allocations.end(); ++it) {
-        ALLOC_INFO * alloc_info = trick_MM->get_alloc_info_at( (void*)*it );
-        if ( alloc_info != NULL ) {
-            trick_MM->delete_var( (void*)*it );
-        }
-    }
-    allocations.clear();
 }
 
 void Trick::ExternalApplication::set_startup_command(std::string in_command) {
     command = in_command;
-    command_c_str = (char*)trick_MM->declare_var("char", (command.size() + 1) );
-    strcpy(command_c_str, command.c_str());
-    allocations.push_back((command_c_str));
 }
 
 std::string Trick::ExternalApplication::get_startup_command() {
@@ -48,7 +33,7 @@ std::string Trick::ExternalApplication::get_startup_command() {
 }
 
 const char * Trick::ExternalApplication::get_startup_command_c_str() {
-    return command_c_str;
+    return command.c_str();
 }
 
 void Trick::ExternalApplication::add_arguments(std::string args) {

--- a/trick_source/sim_services/ExternalApplications/ExternalApplication.cpp
+++ b/trick_source/sim_services/ExternalApplications/ExternalApplication.cpp
@@ -28,7 +28,10 @@ Trick::ExternalApplication::ExternalApplication() :
 
 Trick::ExternalApplication::~ExternalApplication() {
     for(std::vector<char*>::iterator it = allocations.begin(); it != allocations.end(); ++it) {
-        trick_MM->delete_var( (void*)*it );
+        ALLOC_INFO * alloc_info = trick_MM->get_alloc_info_at( (void*)*it );
+        if ( alloc_info != NULL ) {
+            trick_MM->delete_var( (void*)*it );
+        }
     }
     allocations.clear();
 }

--- a/trick_source/sim_services/VariableServer/VariableServerListenThread.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerListenThread.cpp
@@ -248,17 +248,18 @@ int Trick::VariableServerListenThread::restart() {
         message_publish(MSG_INFO, "restart variable server message port = %d\n", _listener->getPort());
     }
 
-    initializeMulticast();
+    // Don't initialize the multicast group if it's already initialized
+    if (!_multicast->isInitialized()) {
+        initializeMulticast();
+    }
 
     return 0 ;
 }
 
 void Trick::VariableServerListenThread::initializeMulticast() {
-    if (!_multicast->isInitialized()) {
-        _multicast->initialize();
-        _multicast->addAddress("239.3.14.15", 9265);
-        _multicast->addAddress("224.3.14.15", 9265);
-    }
+    _multicast->initialize();
+    _multicast->addAddress("239.3.14.15", 9265);
+    _multicast->addAddress("224.3.14.15", 9265);
 }
 
 void Trick::VariableServerListenThread::pause_listening() {

--- a/trick_source/sim_services/VariableServer/VariableServerListenThread.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerListenThread.cpp
@@ -254,9 +254,11 @@ int Trick::VariableServerListenThread::restart() {
 }
 
 void Trick::VariableServerListenThread::initializeMulticast() {
-    _multicast->initialize();
-    _multicast->addAddress("239.3.14.15", 9265);
-    _multicast->addAddress("224.3.14.15", 9265);
+    if (!_multicast->isInitialized()) {
+        _multicast->initialize();
+        _multicast->addAddress("239.3.14.15", 9265);
+        _multicast->addAddress("224.3.14.15", 9265);
+    }
 }
 
 void Trick::VariableServerListenThread::pause_listening() {


### PR DESCRIPTION
1. When an external app such as the sim control panel is configured as following in the input file, the corresponding destructor gets called at the shutdown. In turn, the MM will try to clean the memory for the vars related to the external app even those vars were already taken care of due to the shutdown. Thus there was a warning message. 
`simControlPanel = trick.SimControlPanel()`
`trick.add_external_application(simControlPanel)`
However, if having `trick.sim_control_panel_set_enabled(True)` in the input file, there was no warning message.

Deleted the unnecessary command c str pointer, thus removed the need to free its memory allocation as before. 

2. Made sure that the multicast group is not initialized before calling a function to initialize it in VariableServerListenThread.cpp. Without the check, trick-sniffer wouldn't find the sim anymore after loading a checkpoint as the multicast group got initialized again even it was already initialized.