### PR TITLE
Addressed phantom frame log restart jobs

### DIFF
--- a/include/trick/DRBinary.hh
+++ b/include/trick/DRBinary.hh
@@ -93,7 +93,7 @@ namespace Trick {
              @code <my_drg> = trick.DRBinary("<in_name>") @endcode
              @copydoc Trick::DataRecordGroup::DataRecordGroup(string in_name)
              */
-            DRBinary( std::string in_name, bool register_group = true ) ;
+            DRBinary( std::string in_name, bool register_group = true, bool configure_jobs = true ) ;
 
             /**
              @copybrief Trick::DataRecordGroup::format_specific_header

--- a/include/trick/DataRecordGroup.hh
+++ b/include/trick/DataRecordGroup.hh
@@ -149,7 +149,7 @@ namespace Trick {
              @brief Constructor that creates a new data recording group with the given @c in_name.
              @param in_name - the new data recording group name
             */
-            DataRecordGroup( std::string in_name = "" ) ;
+            DataRecordGroup( std::string in_name = "", bool configure_jobs = true ) ;
 
             ~DataRecordGroup() ;
 

--- a/trick_source/sim_services/DataRecord/DRBinary.cpp
+++ b/trick_source/sim_services/DataRecord/DRBinary.cpp
@@ -22,7 +22,7 @@ PROGRAMMERS:
    Other classes inherit from DRBinary. In these cases, we don't want to register the memory as DRBinary,
    so register_group will be set to false.
 */
-Trick::DRBinary::DRBinary( std::string in_name , bool register_group ) : Trick::DataRecordGroup(in_name) {
+Trick::DRBinary::DRBinary( std::string in_name, bool register_group, bool configure_jobs ) : Trick::DataRecordGroup(in_name) {
     if ( register_group ) {
         register_group_with_mm(this, "Trick::DRBinary") ;
     }

--- a/trick_source/sim_services/DataRecord/DataRecordGroup.cpp
+++ b/trick_source/sim_services/DataRecord/DataRecordGroup.cpp
@@ -54,7 +54,7 @@ Trick::DataRecordBuffer::~DataRecordBuffer() {
     free(ref) ;
 }
 
-Trick::DataRecordGroup::DataRecordGroup( std::string in_name ) :
+Trick::DataRecordGroup::DataRecordGroup( std::string in_name, bool configure_jobs ) :
  record(true) ,
  inited(false) ,
  group_name(in_name) ,
@@ -96,18 +96,28 @@ Trick::DataRecordGroup::DataRecordGroup( std::string in_name ) :
     // sim object name
     name = std::string("trick_data_record_group_") + in_name ;
 
-    // add_jobs_to_queue will fill in job_id later
-    // make the init job run after all other initialization jobs but before the post init checkpoint
-    // job so users can allocate memory in initialization jobs and checkpointing data rec groups will work
-    add_job(0, 1, (char *)"initialization", NULL, cycle, (char *)"init", (char *)"TRK", 65534) ;
-    add_job(0, 2, (char *)"end_of_frame", NULL, 1.0, (char *)"write_data", (char *)"TRK") ;
-    add_job(0, 3, (char *)"checkpoint", NULL, 1.0, (char *)"checkpoint", (char *)"TRK") ;
-    add_job(0, 4, (char *)"post_checkpoint", NULL, 1.0, (char *)"clear_checkpoint_vars", (char *)"TRK") ;
-    // run the restart job in phase 60001
-    add_job(0, 5, (char *)"restart", NULL, 1.0, (char *)"restart", (char *)"TRK", 60001) ;
-    add_job(0, 6, (char *)"shutdown", NULL, 1.0, (char *)"shutdown", (char *)"TRK") ;
+    /*
+        By default we want to configure our jobs. 
+        Some derived classes (looking at you FrameDataRecordGroup) want to setup their jobs differently,
+        so we provide the option to disable this step
 
-    write_job = add_job(0, 99, (char *)job_class.c_str(), NULL, cycle, (char *)"data_record" , (char *)"TRK") ;
+        For context - FrameDataRecordGroup does not want to create restart jobs,
+        but rather the FrameLog object which owns those DRG's will manually retsart them from the FrameLog's restart job.
+    */
+    if(configure_jobs) {
+        // add_jobs_to_queue will fill in job_id later
+        // make the init job run after all other initialization jobs but before the post init checkpoint
+        // job so users can allocate memory in initialization jobs and checkpointing data rec groups will work
+        add_job(0, 1, (char *)"initialization", NULL, cycle, (char *)"init", (char *)"TRK", 65534) ;
+        add_job(0, 2, (char *)"end_of_frame", NULL, 1.0, (char *)"write_data", (char *)"TRK") ;
+        add_job(0, 3, (char *)"checkpoint", NULL, 1.0, (char *)"checkpoint", (char *)"TRK") ;
+        add_job(0, 4, (char *)"post_checkpoint", NULL, 1.0, (char *)"clear_checkpoint_vars", (char *)"TRK") ;
+        // run the restart job in phase 60001
+        add_job(0, 5, (char *)"restart", NULL, 1.0, (char *)"restart", (char *)"TRK", 60001) ;
+        add_job(0, 6, (char *)"shutdown", NULL, 1.0, (char *)"shutdown", (char *)"TRK") ;
+
+        write_job = add_job(0, 99, (char *)job_class.c_str(), NULL, cycle, (char *)"data_record" , (char *)"TRK") ;
+    }
 
     add_time_variable() ;
 }

--- a/trick_source/sim_services/FrameLog/FrameDataRecordGroup.cpp
+++ b/trick_source/sim_services/FrameLog/FrameDataRecordGroup.cpp
@@ -18,7 +18,6 @@ Trick::FrameDataRecordGroup::FrameDataRecordGroup( int in_thread_id , std::strin
     add_job(0, 3, (char *)"checkpoint", NULL, 1.0, (char *)"checkpoint", (char *)"TRK") ;
     add_job(0, 4, (char *)"post_checkpoint", NULL, 1.0, (char *)"clear_checkpoint_vars", (char *)"TRK") ;
     // run the restart job in phase 60001
-    add_job(0, 5, (char *)"restart", NULL, 1.0, (char *)"restart", (char *)"TRK", 60001) ;
     add_job(0, 6, (char *)"shutdown", NULL, 1.0, (char *)"shutdown", (char *)"TRK") ;
 
     write_job = add_job(0, 99, (char *)job_class.c_str(), NULL, cycle, (char *)"data_record" , (char *)"TRK") ;

--- a/trick_source/sim_services/FrameLog/FrameDataRecordGroup.cpp
+++ b/trick_source/sim_services/FrameLog/FrameDataRecordGroup.cpp
@@ -9,7 +9,20 @@
 -# All instances get the end_of_frame frame_log_clear job.
 */
 Trick::FrameDataRecordGroup::FrameDataRecordGroup( int in_thread_id , std::string in_name )
- : Trick::DRBinary(in_name, false) , thread_id(in_thread_id ) {
+ : Trick::DRBinary(in_name, false, false) , thread_id(in_thread_id ) {
+    // add_jobs_to_queue will fill in job_id later
+    // make the init job run after all other initialization jobs but before the post init checkpoint
+    // job so users can allocate memory in initialization jobs and checkpointing data rec groups will work
+    add_job(0, 1, (char *)"initialization", NULL, cycle, (char *)"init", (char *)"TRK", 65534) ;
+    add_job(0, 2, (char *)"end_of_frame", NULL, 1.0, (char *)"write_data", (char *)"TRK") ;
+    add_job(0, 3, (char *)"checkpoint", NULL, 1.0, (char *)"checkpoint", (char *)"TRK") ;
+    add_job(0, 4, (char *)"post_checkpoint", NULL, 1.0, (char *)"clear_checkpoint_vars", (char *)"TRK") ;
+    // run the restart job in phase 60001
+    add_job(0, 5, (char *)"restart", NULL, 1.0, (char *)"restart", (char *)"TRK", 60001) ;
+    add_job(0, 6, (char *)"shutdown", NULL, 1.0, (char *)"shutdown", (char *)"TRK") ;
+
+    write_job = add_job(0, 99, (char *)job_class.c_str(), NULL, cycle, (char *)"data_record" , (char *)"TRK") ;
+
     if ( thread_id > 0 ) {
         add_job(thread_id, 1000, (char *)"top_of_frame", NULL, 1.0, (char *)"start_timer", (char *)"TRK", 1) ;
         // Frame logging uses phase 65533 in FrameLog.ccp. Stop the timer just before that.


### PR DESCRIPTION
DRGs add restart jobs in their constructor. Frame log DRG do not need restart jobs (they are restarted in the frame log restart job). As a result, there is logic to remove the frame log DRG restart jobs to prevent them from running.

This is clunky, and is probably not a good practice to have phantom jobs that aren't ever meant to run. I've cut out the middle man and ensured frame log DRGs never generate a restart job.