### PR TITLE
Updated to use FileEntryRef to get name instead of FileEntry for clang18+.

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintAttributes.cpp
@@ -395,8 +395,11 @@ std::set<std::string> PrintAttributes::getEmptyFiles() {
         const clang::FileEntry * fe = (*fi).first ;
 #if (LIBCLANG_MAJOR < 4) // TODO delete when RHEL 7 no longer supported
         std::string header_file_name = fe->getName() ;
-#else
+#elif (LIBCLANG_MAJOR >= 4 && LIBCLANG_MAJOR < 18) 
         std::string header_file_name = fe->getName().str() ;
+#else
+        const clang::FileEntryRef fer = fi->first ;
+        std::string header_file_name = fer.getName().str();
 #endif
 
         if ( visited_files.find(header_file_name) != visited_files.end() ) {

--- a/trick_source/codegen/Interface_Code_Gen/Utilities.hh
+++ b/trick_source/codegen/Interface_Code_Gen/Utilities.hh
@@ -21,7 +21,7 @@ bool isInUserOrTrickCode( clang::CompilerInstance & ci , clang::SourceLocation s
 std::string getFileName( clang::CompilerInstance & ci , clang::SourceLocation sl , HeaderSearchDirs & hsd ) ;
 char * almostRealPath( const std::string& in_path ) ;
 char * almostRealPath( const char * in_path ) ;
-
+char * getResolvedPath(clang::CompilerInstance & ci , clang::SourceLocation sl);
 std::string color(const Color& color, const std::string& text);
 std::string bold(const std::string& text);
 std::string underline(const std::string& text);

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -312,7 +312,7 @@ int main(int argc, char * argv[]) {
 #if (LIBCLANG_MAJOR >= 10 && LIBCLANG_MAJOR < 18)
     const clang::FileEntry* fileEntry = ci.getFileManager().getFile(inputFilePath).get();
 #elif (LIBCLANG_MAJOR >= 18)
-    clang::FileEntryRef fileEntryRef = llvm::cantFail(ci.getFileManager().getFileRef(inputFilePath));
+    const clang::FileEntryRef fileEntryRef = llvm::cantFail(ci.getFileManager().getFileRef(inputFilePath));
 #else
     const clang::FileEntry* fileEntry = ci.getFileManager().getFile(inputFilePath);
 #endif


### PR DESCRIPTION
Since the corresponding `getName` function of FileEntry is deprecated for clang18+, using FileEntryRef `getName` instead.