### PR TITLE
Drhdf5 fix

### DIFF
--- a/include/trick/DRHDF5.hh
+++ b/include/trick/DRHDF5.hh
@@ -37,14 +37,11 @@ PROGRAMMERS:
 
 namespace Trick {
 
-#ifdef HDF5
-#ifndef TRICK_ICG
+typedef int64_t hid_t;
     struct HDF5_INFO {
         hid_t dataset;
         Trick::DataRecordBuffer * drb ;
     };
-#endif
-#endif
 
 
     /**
@@ -132,12 +129,10 @@ GROUP "/" {
 
         protected:
 
-#ifdef HDF5
             std::vector<HDF5_INFO *> parameters;  // trick_io(**)
 
             hid_t file;  // trick_io(**)
             hid_t root_group, header_group;  // trick_io(**)
-#endif
 
     } ;
 

--- a/trick_source/sim_services/DataRecord/DRHDF5.cpp
+++ b/trick_source/sim_services/DataRecord/DRHDF5.cpp
@@ -75,7 +75,8 @@ int Trick::DRHDF5::format_specific_init() {
     param_units_id = H5PTcreate_fl(header_group, "param_units", s256, chunk_size, 1) ;
     // Create a packet table (PT) that stores each parameter's name.
     param_names_id =  H5PTcreate_fl(header_group, "param_names", s256, chunk_size, 1) ;
-
+          
+    parameters.clear();
     // Create a table for each requested parameter.
     for (ii = 0; ii < rec_buffer.size(); ii++) {
 


### PR DESCRIPTION
The Macros in the DRHDF5 file modify the size of the DRHDF5 in only this translation unit upon compilation. This can result in buffer overflow (encountered during tests with checkpoint loading). 