### PR TITLE
Added the workaround for GitHub test report v1 to work with action v4.

### DIFF
--- a/.github/workflows/report_alt_linux_distros.yml
+++ b/.github/workflows/report_alt_linux_distros.yml
@@ -26,9 +26,18 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+    
+    - name: Download the artifact
+      uses: actions/download-artifact@v4
       with:
-        artifact: Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}} # artifact name
+        name: Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}}
+        path: . # download the artifact in the current directory
+    
+    - name: Report the test results
+      uses: dorny/test-reporter@v1
+      with:
         name: Results_Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}} # Name of the check run which will be created
         path: '*.xml'                     # Path to test results (inside artifact .zip)
         reporter: java-junit              # Format of test results

--- a/.github/workflows/report_linux.yml
+++ b/.github/workflows/report_linux.yml
@@ -20,9 +20,18 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+    
+    - name: Download the artifact
+      uses: actions/download-artifact@v4
       with:
-        artifact: Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}} # artifact name
+        name: Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}}
+        path: . # download the artifact in the current directory
+
+    - name: Report the test results
+      uses: dorny/test-reporter@v1
+      with:
         name: Results_Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}} # Name of the check run which will be created
         path: '*.xml'                     # Path to test results (inside artifact .zip)
         reporter: java-junit              # Format of test results

--- a/.github/workflows/report_linux_py2.yml
+++ b/.github/workflows/report_linux_py2.yml
@@ -20,9 +20,18 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    - name: Download the artifact
+      uses: actions/download-artifact@v4
       with:
-        artifact: Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}} # artifact name
+        name: Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}}
+        path: . # download the artifact in the current directory
+
+    - name: Report the test results
+      uses: dorny/test-reporter@v1
+      with:
         name: Results_Trick_${{matrix.cfg.os}}${{matrix.cfg.tag}}_py${{matrix.python}} # Name of the check run which will be created
         path: '*.xml'                     # Path to test results (inside artifact .zip)
         reporter: java-junit              # Format of test results

--- a/.github/workflows/report_macos.yml
+++ b/.github/workflows/report_macos.yml
@@ -12,9 +12,18 @@ jobs:
       
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    - name: Download the artifact
+      uses: actions/download-artifact@v4
       with:
-        artifact: Trick_macos # artifact name
+        name: Trick_macos
+        path: . # download the artifact in the current directory
+    
+    - name: Report the test results 
+      uses: dorny/test-reporter@v1
+      with:
         name: Results_Trick_macos # Name of the check run which will be created
         path: '*.xml'                     # Path to test results (inside artifact .zip)
         reporter: java-junit              # Format of test results


### PR DESCRIPTION
Testing the workaround for GitHub test report v1 to work with action v4 and if not working, will have to change the GitHub action version to v3 while leaving GitHub artifact version as v4 as required.