### PR TITLE
Default to --report when run in batch. Also remove debug message output.

### DIFF
--- a/trick_source/java/src/main/java/trick/jobperf/JobPerf.java
+++ b/trick_source/java/src/main/java/trick/jobperf/JobPerf.java
@@ -38,6 +38,7 @@ public class JobPerf {
                 case "-x" :
                 case "--nogui" : {
                     interactive = false;
+                    printReport = true;
                 } break;
                 case "-p" :
                 case "--report" : {
@@ -72,7 +73,6 @@ public class JobPerf {
 
         // All files shall be in the same directory as the timeline file.
         String filesDir = Paths.get(timeLineFileName).toAbsolutePath().getParent().toString();
-        System.out.println( "\n\nFilesDir = " + filesDir + "\n\n");
 
         // Generate the JobSpecificationMap from information extracted from the S_job_execution
         // file, that should be in the same directory as the time-line file.

--- a/trick_source/java/src/main/java/trick/jobperf/JobSpecificationMap.java
+++ b/trick_source/java/src/main/java/trick/jobperf/JobSpecificationMap.java
@@ -16,7 +16,6 @@ public class JobSpecificationMap {
     */
     public JobSpecificationMap( File file ) throws IOException, FileNotFoundException {
         jobSpecMap = new HashMap<String, JobSpecification>();
-        System.out.println( "INSTANCIATING JobSpecificationMap("+ file.toString() +").");
         BufferedReader in = new BufferedReader( new FileReader( file.toString()) );
         String line;
         String field[];


### PR DESCRIPTION
1) Default --report to false when jperf runs in GUI mode,  and true when run in batch mode.
Rationale: reporting is the only thing you can do in batch, but in GUI mode you can see jobs stats in a GUI window any time you like.

2) Clean up left over debug messages.
