### PR TITLE
Updated to transmit sie files from the proper directory

### DIFF
--- a/trick_source/sim_services/FrameLog/FrameLog.cpp
+++ b/trick_source/sim_services/FrameLog/FrameLog.cpp
@@ -759,6 +759,11 @@ int Trick::FrameLog::create_DP_files() {
 int Trick::FrameLog::create_DP_Product_dir() {
     int ret=0;
     DP_dir = "DP_Product";
+    if (std::string(command_line_args_get_user_output_dir()) != std::string(command_line_args_get_output_dir())) {
+        if (!std::string(command_line_args_get_user_output_dir()).empty()) {
+            DP_dir = std::string(command_line_args_get_user_output_dir()) + "/DP_Product";
+        }
+    } 
     ret = mkdir(DP_dir.c_str(), 0777);
     if (ret == -1) {
         if (errno == EEXIST) {

--- a/trick_source/sim_services/VariableServer/VariableServerSession_commands.cpp
+++ b/trick_source/sim_services/VariableServer/VariableServerSession_commands.cpp
@@ -373,20 +373,32 @@ int Trick::VariableServerSession::send_file(std::string file_name) {
 
 int Trick::VariableServerSession::send_sie_resource() {
     sie_append_runtime_objs() ;
-    return transmit_file(std::string(command_line_args_get_default_dir()) + "/S_sie.resource") ;
+    //return transmit_file(std::string(command_line_args_get_default_dir()) + "/S_sie.resource") ;
+    // Use the runtime sie dir instead of the default dir as sie_append_runtime_objs() 
+    // may have moved the sie resource file and also always uses the runtime sie dir.
+    return transmit_file(std::string(sie_get_runtime_sie_dir()) + "/S_sie.resource") ;
 }
 
 int Trick::VariableServerSession::send_sie_class() {
     sie_class_attr_map_print_xml() ;
-    return transmit_file(std::string(command_line_args_get_default_dir()) + "/" + "S_sie_class.xml") ;
+    //return transmit_file(std::string(command_line_args_get_default_dir()) + "/" + "S_sie_class.xml") ;
+    // Use the runtime sie dir instead of the default dir as sie_class_attr_map_print_xml()
+    // always uses the runtime sie dir.
+    return transmit_file(std::string(sie_get_runtime_sie_dir()) + "/" + "S_sie_class.xml") ;
 }
 
 int Trick::VariableServerSession::send_sie_enum() {
     sie_enum_attr_map_print_xml() ;
-    return transmit_file(std::string(command_line_args_get_default_dir()) + "/" + "S_sie_enum.xml") ;
+    //return transmit_file(std::string(command_line_args_get_default_dir()) + "/" + "S_sie_enum.xml") ;
+    // Use the runtime sie dir instead of the default dir as sie_enum_attr_map_print_xml()
+    // always uses the runtime sie dir.
+    return transmit_file(std::string(sie_get_runtime_sie_dir()) + "/" + "S_sie_enum.xml") ;
 }
 
 int Trick::VariableServerSession::send_sie_top_level_objects() {
     sie_top_level_objects_print_xml() ;
-    return transmit_file(std::string(command_line_args_get_default_dir()) + "/" + "S_sie_top_level_objects.xml") ;
+    //return transmit_file(std::string(command_line_args_get_default_dir()) + "/" + "S_sie_top_level_objects.xml") ;
+    // Use the runtime sie dir instead of the default dir as sie_top_level_objects_print_xml()
+    // always uses the runtime sie dir.
+    return transmit_file(std::string(sie_get_runtime_sie_dir()) + "/" + "S_sie_top_level_objects.xml") ;
 }


### PR DESCRIPTION
Updated to transmit sie files from the runtime sie dir instead of the default dir as the runtime sie dir is the default dir if no output dir is specified otherwise is the specified output dir. Meanwhile, restored the code inFrameLog.cpp for having DP_Product created in the specified output dir.