### PR TITLE
Updated to use format method for string in .i file and %lu for tv_usec

### DIFF
--- a/trick_source/sim_services/Message/MessagePublisher.cpp
+++ b/trick_source/sim_services/Message/MessagePublisher.cpp
@@ -32,7 +32,8 @@ Trick::MessagePublisher::~MessagePublisher() {
 
 void Trick::MessagePublisher::set_print_format() {
     num_digits = (int)round(log10((double)tics_per_sec)) ;
-    snprintf(print_format, sizeof(print_format), "|L %%3d|%%s.%%06Lu|%%s|%%s|T %%d|%%lld.%%0%dlld| ", num_digits) ;
+    // use %06lu for tv_usec 
+    snprintf(print_format, sizeof(print_format), "|L %%3d|%%s.%%06lu|%%s|%%s|T %%d|%%lld.%%0%dlld| ", num_digits) ;
 }
 
 int Trick::MessagePublisher::init() {
@@ -65,7 +66,8 @@ int Trick::MessagePublisher::publish(int level , std::string message) {
     
     strftime(date_buf, (size_t) 20, "%Y/%m/%d,%H:%M:%S", localtime(&date));
     (void) gethostname(hostname, (size_t) 48);
-    snprintf(header_buf, sizeof(header_buf), print_format , level, date_buf, time_val.tv_usec, hostname,
+    // print_format has %lu for tv_usec, cast to unsigned long to avoid potential warning
+    snprintf(header_buf, sizeof(header_buf), print_format , level, date_buf, (unsigned long)time_val.tv_usec, hostname,
             sim_name.c_str(), exec_get_process_id(), tics/tics_per_sec ,
             (long long)((double)(tics % tics_per_sec) * (double)(pow(10 , num_digits)/tics_per_sec)) ) ;
     header = header_buf ;

--- a/trick_source/sim_services/Message/message_publish_standalone.cpp
+++ b/trick_source/sim_services/Message/message_publish_standalone.cpp
@@ -32,9 +32,11 @@ extern "C" int message_publish_standalone(int level, const char * format_msg, ..
     
     strftime(date_buf, (size_t) 20, "%Y/%m/%d,%H:%M:%S", localtime(&date));
     (void) gethostname(hostname, (size_t) 48);
-    fprintf(stdout, "|L %d|%s.%06Lu|  |%s|T %d|%.2f| %s" , level,
+    // use %lu for tv_usec
+    fprintf(stdout, "|L %d|%s.%06lu|  |%s|T %d|%.2f| %s" , level,
             // so that we don't call any exec routines, use process id 0 and sim time 0.0
-            date_buf, time_val.tv_usec, hostname , 0, 0.0, msg_buf) ;
+            // cast tv_usec to unsigned long to avoid potential warning
+            date_buf, (unsigned long)time_val.tv_usec, hostname , 0, 0.0, msg_buf) ;
     fflush(stdout) ;
 
     return (0);

--- a/trick_source/trick_swig/swig_double.i
+++ b/trick_source/trick_swig/swig_double.i
@@ -75,7 +75,10 @@ def _trick_setattr_nondynamic_instance_variable(set):
         elif name == "this":
             set(self, name, value)
         else:
-            msg = f'You cannot add instance attribute \'{name}\' to Trick swig_double'
+            # f-strings are available in Python 3.6 and later
+            #msg = f'You cannot add instance attribute \'{name}\' to Trick swig_double'
+            # for compatibility, use format method
+            msg = "You cannot add instance attribute '{}' to Trick swig_double".format(name)
             raise AttributeError(msg)
     return set_instance_attr
 

--- a/trick_source/trick_swig/swig_int.i
+++ b/trick_source/trick_swig/swig_int.i
@@ -98,7 +98,10 @@ def _trick_setattr_nondynamic_instance_variable(set):
         elif name == "this":
             set(self, name, value)
         else:
-            msg = f'You cannot add instance attribute \'{name}\' to Trick swig_int'
+            # f-strings are available in Python 3.6 and later
+            #msg = f'You cannot add instance attribute \'{name}\' to Trick swig_int'
+            # For compatibility, use format method
+            msg = "You cannot add instance attribute '{}' to Trick swig_double".format(name)
             raise AttributeError(msg)
     return set_instance_attr
 


### PR DESCRIPTION
Updated to use the format method instead of f-strings for Python version compatibility and %lu for tv_usec to enhance portability.