### PR TITLE
Pin googletest after install to prevent it from being upgraded later.

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install gtest
       run: |
         brew install googletest
-    - name: Pin googletest
+    - name: Pin gtest
       run: |
         brew pin googletest
     - name: Install dependencies

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Install gtest
       run: |
         brew install googletest
+    - name: Pin googletest
+      run: |
+        brew pin googletest
     - name: Install dependencies
       run: |
         # sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.15.pkg -target /


### PR DESCRIPTION
Pin googletest after the initial install to prevent it from being upgraded later. The initial installed version is v1.16 and upgrade would change it to v1.17 which causing error if not C++17 for certain gtest header files.