### PR TITLE
JIT compile call should load resulting library #1912

### DIFF
--- a/trick_source/sim_services/JITInputFile/JITInputFile.cpp
+++ b/trick_source/sim_services/JITInputFile/JITInputFile.cpp
@@ -168,9 +168,7 @@ int Trick::JITInputFile::compile(std::string file_name) {
     }
 
     // The library compile successfully.  Add library name to map
-    JITLibInfo li ;
-    li.library_name = library_fullpath_name ;
-    file_to_libinfo_map[file_name] = li ;
+    add_library(library_fullpath_name);
 
     return 0 ;
 


### PR DESCRIPTION
The compile command would track the resulting library, but didn't load the symbols.  This makes it impossible to do anything with the code.  Changed it so after successful compilation the library symbols are loaded.