### PR TITLE
FPEs don't work on Macs #1914

### DIFF
--- a/trick_source/sim_services/Executive/Executive_fpe_handler.cpp
+++ b/trick_source/sim_services/Executive/Executive_fpe_handler.cpp
@@ -36,8 +36,7 @@
 
 void Trick::Executive::fpe_handler(siginfo_t * sip __attribute__((unused)) ) {
 
-    write( 2 , "\033[31mProcess terminated by signal FPE" , 36 ) ;
-#if __linux__
+    write( 2 , "\033[31mProcess terminated by signal FPE" , 37 ) ;
     /* Determine what floating point error occurred */
     if (sip != (siginfo_t *) NULL) {
         switch (sip->si_code) {
@@ -66,7 +65,6 @@ void Trick::Executive::fpe_handler(siginfo_t * sip __attribute__((unused)) ) {
                 break;
         }
     }
-#endif
     write( 2 , "\033[0m\n" , 5 ) ;
 
     /*

--- a/trick_source/sim_services/Executive/Executive_fpe_handler.cpp
+++ b/trick_source/sim_services/Executive/Executive_fpe_handler.cpp
@@ -9,17 +9,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#ifdef __APPLE__
-#include <mach-o/dyld.h>
-#endif
-
-/*
- * FPE specific headers
- */
-#ifdef __linux__
-#include <fenv.h>
-#endif
-
 #include "trick/Executive.hh"
 #include "trick/exec_proto.h"
 #include "trick/message_proto.h"

--- a/trick_source/sim_services/Executive/Executive_init_signal_handlers.cpp
+++ b/trick_source/sim_services/Executive/Executive_init_signal_handlers.cpp
@@ -61,7 +61,7 @@ int Trick::Executive::set_trap_sigfpe(bool on_off) {
         fenv_t env;
         fegetenv(&env);
 
-        env.__fpcr = env.__fpcr | __fpcr_trap_invalid;
+        env.__fpcr = env.__fpcr | __fpcr_trap_invalid | __fpcr_trap_divbyzero | __fpcr_trap_overflow | __fpcr_trap_underflow;
         fesetenv(&env);
 #endif
         sigact.sa_flags = SA_SIGINFO;
@@ -74,7 +74,7 @@ int Trick::Executive::set_trap_sigfpe(bool on_off) {
         fenv_t env;
         fegetenv(&env);
 
-        env.__fpcr = env.__fpcr & ~__fpcr_trap_invalid;
+        env.__fpcr = env.__fpcr & ~__fpcr_trap_invalid & ~__fpcr_trap_divbyzero & ~__fpcr_trap_overflow & ~__fpcr_trap_underflow;
         fesetenv(&env);
 #endif
         sigact.sa_handler = SIG_DFL;

--- a/trick_source/sim_services/Executive/Executive_init_signal_handlers.cpp
+++ b/trick_source/sim_services/Executive/Executive_init_signal_handlers.cpp
@@ -3,9 +3,7 @@
 #include <errno.h>
 
 /* Headers for floating point exceptions */
-#ifdef __linux__
 #include <fenv.h>
-#endif
 
 #include "trick/Executive.hh"
 
@@ -15,11 +13,7 @@ void term_hand(int sig) ;
 void usr1_hand(int sig) ;
 void child_handler(int sig) ;
 
-#if (__APPLE__ | __CYGWIN__ | __INTERIX )
-void fpe_sig_handler(int sig) ;
-#else
 void fpe_sig_handler(int sig, siginfo_t * sip, void *uap) ;
-#endif
 
 /**
 @details
@@ -63,19 +57,35 @@ int Trick::Executive::set_trap_sigfpe(bool on_off) {
 #ifdef __linux__
         feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);
 #endif
-#if (__APPLE__ | __CYGWIN__ | __INTERIX )
-        sigact.sa_handler = (void (*)(int)) fpe_sig_handler;
-#else
+#if (__APPLE__ && __arm64__)
+        fenv_t env;
+        fegetenv(&env);
+
+        env.__fpcr = env.__fpcr | __fpcr_trap_invalid;
+        fesetenv(&env);
+#endif
         sigact.sa_flags = SA_SIGINFO;
         sigact.sa_sigaction = (void (*)(int, siginfo_t *, void *)) fpe_sig_handler;
-#endif
     } else {
 #ifdef __linux__
         fedisableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);
 #endif
+#if (__APPLE__ && __arm64__)
+        fenv_t env;
+        fegetenv(&env);
+
+        env.__fpcr = env.__fpcr & ~__fpcr_trap_invalid;
+        fesetenv(&env);
+#endif
         sigact.sa_handler = SIG_DFL;
     }
 
+#if (__APPLE__ )
+    // Some floating point exceptions appear as illegal instructions on Macs
+    if (sigaction(SIGILL, &sigact, NULL) < 0) {
+        perror("sigaction() failed for SIGFPE");
+    }
+#endif
     if (sigaction(SIGFPE, &sigact, NULL) < 0) {
         perror("sigaction() failed for SIGFPE");
     } else {

--- a/trick_source/sim_services/Executive/fpe_handler.cpp
+++ b/trick_source/sim_services/Executive/fpe_handler.cpp
@@ -8,13 +8,6 @@
 #include <stdio.h>
 #include <signal.h>
 
-/*
- * FPE specific headers
- */
-#ifdef __linux__
-#include <fenv.h>
-#endif
-
 #include "trick/Executive.hh"
 #include "trick/exec_proto.hh"
 

--- a/trick_source/sim_services/Executive/fpe_handler.cpp
+++ b/trick_source/sim_services/Executive/fpe_handler.cpp
@@ -24,19 +24,8 @@
  * floating point error has occured and calls exec_terminate()
  * @return void
  */
-#if (__APPLE__ | __CYGWIN__ | __INTERIX )
-void fpe_sig_handler(int sig __attribute__ ((unused)) )
-#else
-void fpe_sig_handler(int sig __attribute__ ((unused)), siginfo_t * sip __attribute__ ((unused)), void *uap __attribute__ ((unused)))
-#endif
+void fpe_sig_handler(int sig __attribute__ ((unused)), siginfo_t * sip, void *uap __attribute__ ((unused)))
 {
-
     Trick::Executive * E = exec_get_exec_cpp();
-
-#if __APPLE__
-    siginfo_t * sip = NULL ;
-#endif
-
     E->fpe_handler(sip) ;
-
 }

--- a/trick_source/sim_services/Executive/test/Executive_test.cpp
+++ b/trick_source/sim_services/Executive/test/Executive_test.cpp
@@ -21,11 +21,7 @@ void sig_hand(int sig) ;
 void ctrl_c_hand(int sig) ;
 void term_hand(int sig) ;
 void child_handler(int sig) ;
-#if (__APPLE__ | __CYGWIN__ | __INTERIX )
-void fpe_sig_handler(int sig) ;
-#else
 void fpe_sig_handler(int sig, siginfo_t * sip, void *uap) ;
-#endif
 
 namespace Trick {
 
@@ -810,11 +806,7 @@ TEST_F(ExecutiveTest , SetSignalHandlers) {
     sigaction(SIGCHLD, NULL , &sigact) ;
     EXPECT_TRUE( sigact.sa_handler == child_handler ) ;
     sigaction(SIGFPE, NULL , &sigact) ;
-#if __APPLE__
-    EXPECT_TRUE( sigact.sa_handler == fpe_sig_handler ) ;
-#else
     EXPECT_TRUE( sigact.sa_sigaction == fpe_sig_handler ) ;
-#endif
 
     exec.set_trap_sigbus(0) ;
     exec.set_trap_sigsegv(0) ;


### PR DESCRIPTION
FPE signal handling has changed since the last time this code was touched, pre-2015.  Mac FPE signal handling works similar to linux now.  Was able to remove a lot of #if __APPLE__ sections of code. There is an Arm specific call on Apples to enable FPE, fesetenv. This is like linux specific feenableexcept.  I do not know what Macs on intel chips use, so I left that out, FPEs will still be broken on that platform combination.