### PR TITLE
Add capability to save input file used during run #1928

### DIFF
--- a/include/trick/InputProcessor.hh
+++ b/include/trick/InputProcessor.hh
@@ -15,6 +15,7 @@ namespace Trick {
         public:
 
             int verify_input ;                    /* -- verify input */
+            int save_input;                       /* -- save input while running */
 
             std::string input_file ;              /* -- Simulation input data file name */
 

--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -136,6 +136,12 @@ int Trick::IPPython::init() {
         PyRun_SimpleString("sys.settrace(trick.traceit)") ;
     }
 
+    /* Read and parse the input file. */
+    if ( save_input ) {
+        PyRun_SimpleString("trick.open_input_file_log()") ;
+        PyRun_SimpleString("sys.settrace(trick.traceittofile)") ;
+    }
+
     if ( (ret = PyRun_SimpleFile(input_fp, input_file.c_str())) !=  0 ) {
         exec_terminate_with_return(ret , __FILE__ , __LINE__ , "Input Processor error\n" ) ;
     }
@@ -147,6 +153,10 @@ int Trick::IPPython::init() {
        ss << "print('{0} SHA1: {1}'.format(input_file,hashlib.sha1(open(input_file, 'rb').read()).hexdigest()))" << std::endl ;
        PyRun_SimpleString(ss.str().c_str()) ;
        exec_terminate_with_return(ret , __FILE__ , __LINE__ , "Input file verification complete\n" ) ;
+    }
+
+    if ( save_input ) {
+       PyRun_SimpleString("trick.close_input_file_log()") ;
     }
 
     fclose(input_fp) ;

--- a/trick_source/sim_services/InputProcessor/InputProcessor.cpp
+++ b/trick_source/sim_services/InputProcessor/InputProcessor.cpp
@@ -19,7 +19,10 @@
 
 Trick::InputProcessor * the_ip ;
 
-Trick::InputProcessor::InputProcessor() {
+Trick::InputProcessor::InputProcessor()
+ : verify_input(0)
+ , save_input(0)
+{
 
     the_ip = this ;
 
@@ -45,6 +48,11 @@ int Trick::InputProcessor::process_sim_args() {
         if (!strcmp("-d", argv[i])) {
             /* Set the 'input verification only' and echo input flags */
             verify_input = 1 ;
+        }
+
+        if (!strcmp("--save-input-file", argv[i])) {
+            /* Set the 'save processed input file lines' flag */
+            save_input = 1 ;
         }
     }
 

--- a/trick_source/trick_swig/sim_services.i
+++ b/trick_source/trick_swig/sim_services.i
@@ -186,5 +186,28 @@ def traceit(frame, event, arg):
             line = linecache.getline(filename, lineno)
             print (filename,":",lineno,": ",line.rstrip())
     return traceit
+
+file_object = None
+
+def open_input_file_log():
+    global file_object
+    file_object = open(command_line_args_get_output_dir()+"/S_input_file.log", "w")
+
+def close_input_file_log():
+    global file_object
+    file_object.close()
+
+def traceittofile(frame, event, arg):
+    global file_object
+    if event == "line":
+        lineno = frame.f_lineno
+        filename = frame.f_code.co_filename
+        if ( not filename.startswith(exclude_dir) and not filename.startswith("/usr") and not filename.startswith("/opt") and not filename.startswith("<") and not filename.startswith(".trick/") ):
+            if (filename.endswith(".pyc") or
+                filename.endswith(".pyo")):
+                filename = filename[:-1]
+            line = linecache.getline(filename, lineno)
+            file_object.write(filename+":"+str(lineno)+": "+line.rstrip()+"\n")
+    return traceittofile
 %}
 


### PR DESCRIPTION
Added a command line argument to the input processor, "--save-input-file".  When set the method for verifying the input file is executed and the results are directed to a file <output_dir>/S_input_file.log.