### PR TITLE
Add capability to save input file used during run #1928

### DIFF
--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -156,7 +156,8 @@ int Trick::IPPython::init() {
     }
 
     if ( save_input ) {
-       PyRun_SimpleString("trick.close_input_file_log()") ;
+        PyRun_SimpleString("trick.close_input_file_log()") ;
+        PyRun_SimpleString("sys.settrace(None)") ;
     }
 
     fclose(input_fp) ;


### PR DESCRIPTION
Need to clear the python trace function after the input file has been read completely.