### PR TITLE
Add extern C in swig autogenerated cpp files for c includes

### DIFF
--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -328,7 +328,7 @@ sub process_file() {
 #include <cstddef>
 \%}\n" ;
 
-        if ($f =~ /.hh/) { #Check if CPP file
+        if ($f =~ /.hh/ || $f =~ /.hpp/) { #Check if CPP file
         print OUT "
 \%{
 #include \"$f\"


### PR DESCRIPTION
The autogenerated *_py.cpp files do not contain the extern C guards around the C include files, causing unresolved symbols during linking.