### PR TITLE
Add python virtual environment path to Input processor search path #1944

### DIFF
--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -111,6 +111,8 @@ int Trick::IPPython::init() {
      "import os\n"
      "import struct\n"
      "import binascii\n"
+     "if 'VIRTUAL_ENV' in os.environ:\n"
+     "    sys.path.append(os.path.join(os.environ['VIRTUAL_ENV'], \"lib\", f\"python{sys.version_info.major}.{sys.version_info.minor}\", \"site-packages\"))\n"
      "sys.path.append(os.getcwd() + '/trick.zip')\n"
      "sys.path.append(os.path.join(os.environ['TRICK_HOME'], 'share/trick/pymods'))\n"
      "sys.path += map(str.strip, os.environ['TRICK_PYTHON_PATH'].split(':'))\n"


### PR DESCRIPTION
Added an if check before in the python code run before the input file and test if the VIRTUAL_ENV environment variable is set.  If it is, add the path ${VIRTUAL_ENV}/python_<version>/site-packages to sys.path list.