### PR TITLE
Makefile.tricklib sometimes double includes object files #1952

### DIFF
--- a/share/trick/makefiles/Makefile.tricklib
+++ b/share/trick/makefiles/Makefile.tricklib
@@ -81,7 +81,7 @@ objects: $(OBJECT_FILES)
 	@ echo "[32m$(CURDIR) object files up to date[00m"
 
 $(TRICK_LIB) : $(OBJECT_FILES) | $(TRICK_LIB_DIR)
-	ar crs $@ $(OBJECT_FILES)
+	ar crs $@ $^
 
 $(OBJ_DIR):
 	mkdir -p $@


### PR DESCRIPTION
Changed the ar command to use the $^ makefile variable that only includes prerequisites once.