### PR TITLE
Resolves potential-for-fpe-in-run_ratio-sample-calcs 

### DIFF
--- a/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
+++ b/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
@@ -259,29 +259,41 @@ class Run_Ratio {
     Run_Ratio() : num_samples(0) {}
     Run_Ratio& operator()(long long sample, double in_rt_ratio)
     {
-        if(sample == samples[(num_samples-1) % N]) {
-            return *this;
-        } else {
-            samples[num_samples++ % N] = sample;
-            rt_ratio = in_rt_ratio;
-            return *this;
-        }
+        samples[num_samples++ % N] = sample;
+        rt_ratio = in_rt_ratio;
+        return *this;
     }
 
     operator double() const {
         if ( num_samples <= 1 ) {
             return 0.0 ;
         } else if ( num_samples < N ) {
-            return round(exec_get_software_frame() * (num_samples-1) * exec_get_time_tic_value() * rt_ratio / (double)(samples[num_samples - 1] - samples[0])*100.0)/100.0 ;
+            const long long currSampleVal = samples[num_samples - 1];
+            const long long firstSampleVal = samples[0];
+            const long long deltaVal = currSampleVal -firstSampleVal;
+            if(deltaVal == 0)
+            {
+                return 1.0;
+            } else {
+                return round(exec_get_software_frame() * (num_samples-1) * exec_get_time_tic_value() * rt_ratio / (double)(deltaVal)*100.0)/100.0 ;
+            }
         } else {
-            return round(exec_get_software_frame() * (N-1) * exec_get_time_tic_value() * rt_ratio / (double)(samples[(num_samples - 1) % N] - samples[num_samples % N])*100.0)/100.0 ;
+            const long long prevSampleVal = samples[(num_samples - 1) % N];
+            const long long currSampleVal = samples[num_samples % N];
+            const long long deltaVal = prevSampleVal -currSampleVal;
+            if(deltaVal == 0)
+            {
+                return 1.0;
+            } else {
+                return round(exec_get_software_frame() * (N-1) * exec_get_time_tic_value() * rt_ratio / (double)(deltaVal)*100.0)/100.0 ;
+            }
         }
     }
 
   private:
-    long long samples[N];
-    size_t num_samples;
-    double rt_ratio;
+    long long samples[N]{};
+    size_t num_samples{};
+    double rt_ratio{};
 };
 
 /**

--- a/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
+++ b/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
@@ -259,9 +259,17 @@ class Run_Ratio {
     Run_Ratio() : num_samples(0) {}
     Run_Ratio& operator()(long long sample, double in_rt_ratio)
     {
-        samples[num_samples++ % N] = sample;
-        rt_ratio = in_rt_ratio;
-        return *this;
+        if(sample == samples[num_samples]) {
+            return *this;
+        } else {
+            ++num_samples;
+            if(num_samples >= N) {
+                num_samples = 0;
+            }
+            samples[num_samples] = sample;
+            rt_ratio = in_rt_ratio;
+            return *this;
+        }
     }
 
     operator double() const {

--- a/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
+++ b/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
@@ -259,14 +259,10 @@ class Run_Ratio {
     Run_Ratio() : num_samples(0) {}
     Run_Ratio& operator()(long long sample, double in_rt_ratio)
     {
-        if(sample == samples[num_samples]) {
+        if(sample == samples[num_samples % N]) {
             return *this;
         } else {
-            ++num_samples;
-            if(num_samples >= N) {
-                num_samples = 0;
-            }
-            samples[num_samples] = sample;
+            samples[num_samples++ % N] = sample;
             rt_ratio = in_rt_ratio;
             return *this;
         }

--- a/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
+++ b/trick_source/sim_services/RealtimeSync/RealtimeSync.cpp
@@ -259,7 +259,7 @@ class Run_Ratio {
     Run_Ratio() : num_samples(0) {}
     Run_Ratio& operator()(long long sample, double in_rt_ratio)
     {
-        if(sample == samples[num_samples % N]) {
+        if(sample == samples[(num_samples-1) % N]) {
             return *this;
         } else {
             samples[num_samples++ % N] = sample;


### PR DESCRIPTION
Protect against a repeated sample values which can result in a divide by zero. Use an if-check instead of modulo operator (possibly faster)?

fixes #1957 