### PR TITLE
python cast to void ptr

### DIFF
--- a/trick_source/trick_swig/extra_functions.i
+++ b/trick_source/trick_swig/extra_functions.i
@@ -9,6 +9,11 @@ void * wrap_ptr ( void * in_ptr ) {
     return(temp_ptr) ;
 }
 
+void * castAsVoidPtr( void * in_ptr)
+{
+    return in_ptr;
+}
+
 double unhex_double ( long long in_value ) {
 
     union LL2D {


### PR DESCRIPTION
Add function to allow users to cast a typed swig-python variable to a void pointer