### PR TITLE
Fix `make clean` run on distclean repo

### DIFF
--- a/libexec/trick/pm/gte.pm
+++ b/libexec/trick/pm/gte.pm
@@ -57,9 +57,9 @@ sub gte (@) {
                 }
             } else {
                 # remove possible ccache from TRICK_CC
-                my ($temp) = $ENV{TRICK_CC} ;
-                $temp =~ s/.*?ccache\s+// ;
-                $ret = `$temp -dumpfullversion dumpversion` ;
+                my ($temp) = $ENV{TRICK_CC};
+                $temp =~ s/.*?ccache\s+//;
+                $ret = `$temp -dumpfullversion -dumpversion`;
             }
         }
         else {


### PR DESCRIPTION
Typo in `gte.pm` only encountered when running `make clean` on a new checkout (i.e. before `./configure` is run)