### PR TITLE
Add declare_operatornew_var variant that allows user to set the name of the allocated variable #1970

### DIFF
--- a/include/trick/MemoryManager.hh
+++ b/include/trick/MemoryManager.hh
@@ -127,9 +127,10 @@ namespace Trick {
                                  otherwise @b class_name should be "".
              @param alloc_size - number of bytes requested by new
              @param element_size - size of underlying class
+             @param alloc_name - name of the allocation (optional)
              @return - an address to the allocated memory or NULL on failure.
              */
-            void* declare_operatornew_var( std::string class_name , unsigned int alloc_size , unsigned int element_size );
+            void* declare_operatornew_var( std::string class_name , unsigned int alloc_size , unsigned int element_size , std::string alloc_name = "" );
 
             /**
              This is a convenience version of declare_extern_var(), that declares an external variable

--- a/include/trick/memorymanager_c_intf.h
+++ b/include/trick/memorymanager_c_intf.h
@@ -19,6 +19,7 @@ void* TMM_declare_var_s( const char* declaration ) ;
 void* alloc_type( int e_elems, const char* enh_type_spec) ;
 
 void* TMM_declare_operatornew_var( const char * class_name, unsigned int alloc_size, unsigned int element_size );
+void* TMM_declare_operatornew_var_with_name( const char * class_name, unsigned int alloc_size, unsigned int element_size, const char * alloc_name );
 
 void* TMM_declare_ext_var( void* addr, TRICK_TYPE type, const char*class_name, int n_stars, const char* var_name, int n_cdims, int *cdims);
 void* TMM_declare_ext_var_1d( void* addr, const char* elem_decl, int e_elems) ;

--- a/trick_source/sim_services/MemoryManager/MemoryManager_C_Intf.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_C_Intf.cpp
@@ -80,6 +80,15 @@ extern "C" void* TMM_declare_operatornew_var( const char * class_name, unsigned 
     }
 }
 
+extern "C" void* TMM_declare_operatornew_var_with_name( const char * class_name, unsigned int alloc_size , unsigned int element_size, const char * alloc_name ) {
+    if (trick_MM != NULL) {
+        return trick_MM->declare_operatornew_var( std::string(class_name), alloc_size, element_size, std::string(alloc_name) ) ;
+    } else {
+        Trick::MemoryManager::emitError("TMM_declare_var() called before MemoryManager instantiation. Returning NULL.\n") ;
+        return (void*)NULL ;
+    }
+}
+
 /**
  @relates Trick::MemoryManager
  This is the C Language version of the 7 argument version of Trick::MemoryManager::declare_ext_var.

--- a/trick_source/sim_services/MemoryManager/MemoryManager_declare_var.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_declare_var.cpp
@@ -306,9 +306,9 @@ void* Trick::MemoryManager::declare_var( const char *element_definition, int n_e
     return ( address);
 }
 
-// PUBLIC MEMBER FUNCTION: void* Trick::MemoryManager::declare_operatornew_var(std::string user_type_name, unsigned int alloc_size , unsigned int element_size );
+// PUBLIC MEMBER FUNCTION: void* Trick::MemoryManager::declare_operatornew_var(std::string user_type_name, unsigned int alloc_size , unsigned int element_size, std::string alloc_name );
 
-void* Trick::MemoryManager::declare_operatornew_var( std::string user_type_name, unsigned int alloc_size , unsigned int element_size ) {
+void* Trick::MemoryManager::declare_operatornew_var( std::string user_type_name, unsigned int alloc_size , unsigned int element_size , std::string alloc_name ) {
     TRICK_TYPE type = TRICK_STRUCTURED ;
     int size_ref = 1 ;
     void* address;
@@ -345,7 +345,11 @@ void* Trick::MemoryManager::declare_operatornew_var( std::string user_type_name,
 
         new_alloc->start = (char *)address + aligned ;
         new_alloc->end = ( (char*)new_alloc->start) + alloc_size - 1 - aligned ;
-        new_alloc->name = NULL;
+        if (alloc_name != "") {
+            new_alloc->name = strdup(alloc_name.c_str());
+        } else {
+            new_alloc->name = NULL;
+        }
         new_alloc->stcl = TRICK_LOCAL;
         new_alloc->size = element_size ;
         new_alloc->sentinel_bytes = aligned ;


### PR DESCRIPTION
Added an optional alloc_name string parameter to declare_operatornew_var function also a new call in the C interface.