### PR TITLE
Added the same stop for unarrayed struct as the arrayed struct when getting the composite sub reference.

### DIFF
--- a/trick_source/sim_services/CheckPointAgent/ClassicCheckPointerAgent.cpp
+++ b/trick_source/sim_services/CheckPointAgent/ClassicCheckPointerAgent.cpp
@@ -322,6 +322,11 @@ static int getCompositeSubReference(
     }
 /*if member is an unarrayed struct, continue to call getCompositeSubReference.*/
     if (Ai->num_index == 0) {
+        /* if left_type specifies the current member, stop here */
+        if ( (left_type != NULL) && (*left_type != NULL) && (Ai->attr == (*left_type)->attr)) {
+            return 0;
+        }
+
         char buf[256];
         ret = getCompositeSubReference( rAddr, left_type, sAddr + Ai->offset, (ATTRIBUTES *) Ai->attr, buf);
 


### PR DESCRIPTION
Added the same stop for unarrayed struct as the arrayed struct when getting the composite sub reference.