### PR TITLE
Updated report macos workflow to download the artifact from the latest attempt.

### DIFF
--- a/.github/workflows/report_macos.yml
+++ b/.github/workflows/report_macos.yml
@@ -12,9 +12,15 @@ jobs:
       
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Download artifact from latest attempt
+      uses: dawidd6/action-download-artifact@v3     # This action downloads + extracts
       with:
-        artifact: Trick_macos # artifact name
-        name: Results_Trick_macos # Name of the check run which will be created
+        workflow: macOS                   # The workflow that creates the artifact
+        name: Trick_macos                 # Name of the artifact
+
+    - name: Publish Test Report
+      uses: dorny/test-reporter@v1
+      with:
+        name: Results_Trick_macos         # Name of the check run which will be created
         path: '*.xml'                     # Path to test results (inside artifact .zip)
         reporter: java-junit              # Format of test results


### PR DESCRIPTION
Updated report macos workflow to download the artifact from the latest attempt. This ensures that report reflects the most recent successful run attempt instead of always showing the result from the first attempt. This change addresses cases where the initial failed run attempt isn't related to code changes and usually another attempt is typically successful.