### PR TITLE
Not to overwrite the remaining comment with an empty string during comment parsing.

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldDescription.cpp
@@ -291,8 +291,17 @@ void FieldDescription::parseComment(std::string comment) {
 
     // The rest of the comment is the description of the variable.
 
-    // remove the c comment end marker.
-    comment = get_regex_field(comment , "(.*)\\*/" , 1) ;
+    // remove the c comment end marker if present.
+    // don't overwrite the comment with an empty string
+    // when there is no "*/" (e.g. // (var_unit) var description)
+    // to preserve the description of the variable.
+    // get_regex_field returns an empty string on no match.
+    {
+        std::string tmp = get_regex_field(comment , "(.*)\\*/" , 1) ;
+        if ( ! tmp.empty() ) {
+            comment = tmp ;
+        }
+    }
 
     // posix c regular expressions are terrible. the regexes above will leave "@" signs because
     // the regular expressions are so greedy.


### PR DESCRIPTION
Avoid overwriting the remaining comment (after io and unit specs parsing) with an empty string during comment parsing. The function for removing `*/` when there is no `*/` returns an empty string. When the variable using `//` for its comment that may have io, units, and description specs, the var description could be cleared unintentionally.