### PR TITLE
Changed the artifact name to include the run_attempt.

### DIFF
--- a/.github/workflows/report_macos.yml
+++ b/.github/workflows/report_macos.yml
@@ -2,44 +2,21 @@ name: 'Report macOS'
 
 on:
   workflow_run:
-    workflows: ['macOS']                     # runs after CI workflow
+    workflows: ['macOS']                  # runs after CI workflow
     types:
       - completed
 jobs:
   report:
     runs-on: ubuntu-latest
     permissions:
-      actions: read                      # Allow reading actions
-      checks: write                      # Allow creating check runs
+      actions: read                       # Allow reading actions
+      checks: write                       # Allow creating check runs
     steps:
-    - name: Download artifact from triggering run (latest attempt)
-      uses: dawidd6/action-download-artifact@v11
-      with:
-        # Get latest artifact from the triggering run
-        run_id: ${{ github.event.workflow_run.id }}
-        name: Trick_macos
-        path: test-results
-        allow_forks: false                # Do not download artifacts from forks
-        if_no_artifact_found: warn        # Warn if no artifact is found
-
-    - name: Check for test results
-      id: check
-      run: |
-            if [ -n "$(find test-results -name '*.xml' 2>/dev/null)" ]; then
-                echo "found=true" >> $GITHUB_OUTPUT
-            else
-                echo "found=false" >> $GITHUB_OUTPUT
-            fi
-
     - name: Publish Test Report
       uses: dorny/test-reporter@v1
-      if: steps.check.outputs.found == 'true'
       with:
+        # Match artifact from the specific attempt that triggered this report
+        artifact: Trick_macos_attempt_${{ github.event.workflow_run.run_attempt }}
         name: Results_Trick_macos         # Name of the check run which will be created
-        path: 'test-results/**/*.xml'     # Path to extracted test results
+        path: '*.xml'                     # Path to test results (inside the artifact .zip)
         reporter: java-junit              # Format of test results
-
-    # If no results found, skip report and keeps the job green
-    - name: No test results found
-      if: steps.check.outputs.found == 'false'
-      run: echo "No test results XMLs were extracted; skipping report."

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -55,6 +55,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()    # run this step even if previous step failed
       with:
-        name: Trick_macos
+        # Include run attempt in artifact name so report workflow can fetch the latest attempt
+        name: Trick_macos_attempt_${{ github.run_attempt }}
         path: trick_test/*.xml
         retention-days: 1


### PR DESCRIPTION
Changed the artifact name to include the run_attempt to avoid to use run_id in the report so no git error.