### PR TITLE
Add `.cache` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ trickops_logs/
 coverage.info
 *.dSYM
 *.log
+.cache/


### PR DESCRIPTION
`.cache/` used by [clangd](https://clangd.llvm.org/) language server