### PR TITLE
Revert "#1038 filter -llibxml2.tbd from llvm-config --system-libs as …

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/makefile
+++ b/trick_source/codegen/Interface_Code_Gen/makefile
@@ -15,7 +15,7 @@ CLANG_MAJOR_GTEQ10 := $(shell [ $(CLANG_MAJOR) -ge 10 ] && echo 1)
 CLANG_MAJOR_GTEQ16 := $(shell [ $(CLANG_MAJOR) -ge 16 ] && echo 1)
 ifeq ($(CLANG_MAJOR_GTEQ16),1)
 CXXFLAGS += -std=c++17
-else 
+else
 ifeq ($(CLANG_MAJOR_GTEQ10),1)
 CXXFLAGS += -std=c++14
 else
@@ -53,7 +53,7 @@ endif
 
 ifeq ($(TRICK_HOST_TYPE),Darwin)
 CLANGLIBS += $(shell $(LLVM_HOME)/bin/llvm-config --libs)
-CLANGLIBS += $(filter-out -llibxml2.tbd,$(shell $(LLVM_HOME)/bin/llvm-config --system-libs))
+CLANGLIBS += $(shell $(LLVM_HOME)/bin/llvm-config --system-libs)
 ifeq ($(CLANG_MAJOR_GTEQ16),1)
 CLANGLIBS += -lc++abi -lclang-cpp
 else


### PR DESCRIPTION
…temporary workaround for missing library (#1039)"

This reverts commit ba94c8181df07c951486264a37f13656b5ea798e.

---

Closes #1042 