### PR TITLE
Adding Trick sim examples of simple ROS2 Pub/Sub

### DIFF
--- a/trick_sims/ROS2/TrickPublisher/RUN_publish/input.py
+++ b/trick_sims/ROS2/TrickPublisher/RUN_publish/input.py
@@ -1,0 +1,8 @@
+trick.real_time_enable()
+trick.exec_set_software_frame(0.1)
+trick.itimer_enable()
+
+simControlPanel = trick.SimControlPanel()
+trick.add_external_application(simControlPanel)
+
+

--- a/trick_sims/ROS2/TrickPublisher/S_define
+++ b/trick_sims/ROS2/TrickPublisher/S_define
@@ -1,0 +1,18 @@
+#include "sim_objects/default_trick_sys.sm"
+##include "trick_publisher/include/PubNode.hh"
+
+class TrickPublisherSimObject : public Trick::SimObject
+{
+    public:
+        PubNode publish_node;
+
+        TrickPublisherSimObject()
+        {
+            ("default_data")   publish_node.defaults();
+            ("initialization") publish_node.init_ros();
+            (1.0, "scheduled") publish_node.yellIntoTheVoid();
+            ("shutdown")       publish_node.shutItDown(); 
+        }
+};
+
+TrickPublisherSimObject TrickPublisher;

--- a/trick_sims/ROS2/TrickPublisher/S_overrides.mk
+++ b/trick_sims/ROS2/TrickPublisher/S_overrides.mk
@@ -1,0 +1,32 @@
+TRICK_CXXFLAGS += -g -I./
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rclcpp
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcl
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcutils
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rmw
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcl_yaml_param_parser
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rosidl_runtime_c
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rosidl_typesupport_interface
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcpputils
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/builtin_interfaces
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rosidl_runtime_cpp
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/tracetools
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcl_interfaces
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/libstatistics_collector
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/statistics_msgs
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/std_msgs
+
+TRICK_CFLAGS=${TRICK_CXXFLAGS}
+TRICK_USER_LINK_LIBS += -L/opt/ros/humble/lib -L/opt/ros/humble/share
+TRICK_USER_LINK_LIBS += -lrclcpp
+TRICK_USER_LINK_LIBS += -lrcl
+TRICK_USER_LINK_LIBS += -lrmw
+TRICK_USER_LINK_LIBS += -lrcutils
+TRICK_USER_LINK_LIBS += -lrcpputils
+TRICK_USER_LINK_LIBS += -lstd_msgs__rosidl_typesupport_cpp
+TRICK_USER_LINK_LIBS += -lrmw_fastrtps_cpp
+TRICK_USER_LINK_LIBS += -lrmw_fastrtps_dynamic_cpp
+TRICK_USER_LINK_LIBS += -ltracetools
+
+TRICK_EXCLUDE += /opt/ros/humble/include/
+

--- a/trick_sims/ROS2/TrickPublisher/trick_publisher/include/PubNode.hh
+++ b/trick_sims/ROS2/TrickPublisher/trick_publisher/include/PubNode.hh
@@ -1,0 +1,34 @@
+#ifndef __PUBNODE_HH_
+#define __PUBNODE_HH_
+/*******************************************
+PURPOSE: Trick model for ROS2 publisher node
+LIBRARY DEPENDENCY:
+(
+    (trick_publisher/src/PubNode.cc)
+)
+*******************************************/
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include <iostream>
+
+class PubNode
+{
+    public:
+        std::string whatToYell;
+
+        std::string nodeName;
+        std::string publicationName;
+
+        rclcpp::Node::SharedPtr  node;
+        rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub;
+
+        void defaults();
+        void init_ros();
+        void yellIntoTheVoid();
+        void shutItDown();
+
+};
+
+
+#endif

--- a/trick_sims/ROS2/TrickPublisher/trick_publisher/src/PubNode.cc
+++ b/trick_sims/ROS2/TrickPublisher/trick_publisher/src/PubNode.cc
@@ -1,0 +1,58 @@
+#include "trick_publisher/include/PubNode.hh"
+
+
+void SubNode::defaults()
+{
+    nodeName        = "trick_publisher_node";
+    publicationName = "Trick_says";
+}
+
+void PubNode::init_ros()
+{
+
+    whatToYell = "Trick is screaming.";
+
+    int argc=0;
+    char **argv = 0x0;
+
+    rclcpp::init(argc,argv);
+    node = std::make_shared<rclcpp::Node>(nodeName);
+    pub = node->create_publisher<std_msgs::msg::String>(publicationName,10);
+
+}
+
+
+void PubNode::yellIntoTheVoid()
+{
+
+    if(!pub)
+    {
+        std::cout << "No publisher detected.\n" << std::endl;
+        return;
+    }
+    else if(!node)
+    {
+        std::cout << "No node detected.\n" << std::endl;
+        return;
+    }
+    else
+    {
+        std_msgs::msg::String msg;
+        msg.data = whatToYell;
+
+        pub->publish(msg);
+    }
+
+    if(node)
+    {
+        rclcpp::spin_some(node);
+    }
+}
+
+void PubNode::shutItDown()
+{
+
+    pub.reset();
+    node.reset();
+    rclcpp::shutdown();
+}

--- a/trick_sims/ROS2/TrickSubscriber/RUN_subscribe/input.py
+++ b/trick_sims/ROS2/TrickSubscriber/RUN_subscribe/input.py
@@ -1,0 +1,9 @@
+trick.real_time_enable()
+trick.exec_set_software_frame(0.1)
+trick.itimer_enable()
+
+simControlPanel = trick.SimControlPanel()
+trick.add_external_application(simControlPanel)
+
+#TrickSubscriber.subscribe_node.subscriptionName = "topic"
+TrickSubscriber.subscribe_node.subscriptionName = "chatter"

--- a/trick_sims/ROS2/TrickSubscriber/S_define
+++ b/trick_sims/ROS2/TrickSubscriber/S_define
@@ -1,0 +1,18 @@
+#include "sim_objects/default_trick_sys.sm"
+##include "trick_subscriber/include/SubNode.hh"
+
+class TrickSubscriberSimObject : public Trick::SimObject
+{
+    public:
+        SubNode subscribe_node;
+
+        TrickSubscriberSimObject()
+        {
+            ("default_data")   subscribe_node.defaults();
+            ("initialization") subscribe_node.init_ros();
+            (0.5, "scheduled") subscribe_node.earToTheVoid();
+            ("shutdown")       subscribe_node.shutItDown(); 
+        }
+};
+
+TrickSubscriberSimObject TrickSubscriber;

--- a/trick_sims/ROS2/TrickSubscriber/S_overrides.mk
+++ b/trick_sims/ROS2/TrickSubscriber/S_overrides.mk
@@ -1,0 +1,33 @@
+TRICK_CXXFLAGS += -g -I./
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rclcpp
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcl
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcutils
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rmw
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcl_yaml_param_parser
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rosidl_runtime_c
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rosidl_typesupport_interface
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcpputils
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/builtin_interfaces
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rosidl_runtime_cpp
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/tracetools
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/rcl_interfaces
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/libstatistics_collector
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/statistics_msgs
+TRICK_CXXFLAGS += -I/opt/ros/humble/include/std_msgs
+
+TRICK_CFLAGS=${TRICK_CXXFLAGS}
+TRICK_USER_LINK_LIBS += -L/opt/ros/humble/lib -L/opt/ros/humble/share
+TRICK_USER_LINK_LIBS += -lrclcpp
+TRICK_USER_LINK_LIBS += -lrcl
+TRICK_USER_LINK_LIBS += -lrmw
+TRICK_USER_LINK_LIBS += -lrcutils
+TRICK_USER_LINK_LIBS += -lrcpputils
+TRICK_USER_LINK_LIBS += -lstd_msgs__rosidl_typesupport_cpp
+TRICK_USER_LINK_LIBS += -lrmw_fastrtps_cpp
+TRICK_USER_LINK_LIBS += -lrmw_fastrtps_dynamic_cpp
+TRICK_USER_LINK_LIBS += -ltracetools
+TRICK_USER_LINK_LIBS += -llibstatistics_collector
+TRICK_USER_LINK_LIBS += -lstatistics_msgs__rosidl_typesupport_cpp
+
+TRICK_EXCLUDE += /opt/ros/humble/include/

--- a/trick_sims/ROS2/TrickSubscriber/trick_subscriber/include/SubNode.hh
+++ b/trick_sims/ROS2/TrickSubscriber/trick_subscriber/include/SubNode.hh
@@ -1,0 +1,34 @@
+#ifndef __SUBNODE_HH_
+#define __SUBNODE_HH_
+/*******************************************
+PURPOSE: Trick model for ROS2 subscriber node
+LIBRARY DEPENDENCY:
+(
+    (trick_subscriber/src/SubNode.cc)
+)
+*******************************************/
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include <iostream>
+
+class SubNode
+{
+    public:
+        std::string darkEchoes;
+
+        std::string nodeName;
+        std::string subscriptionName;
+
+        rclcpp::Node::SharedPtr  node;
+        rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub;
+
+        void defaults();
+        void init_ros();
+        void earToTheVoid();
+        void shutItDown();
+
+};
+
+
+#endif

--- a/trick_sims/ROS2/TrickSubscriber/trick_subscriber/src/SubNode.cc
+++ b/trick_sims/ROS2/TrickSubscriber/trick_subscriber/src/SubNode.cc
@@ -1,0 +1,52 @@
+#include "trick_subscriber/include/SubNode.hh"
+
+void SubNode::defaults()
+{
+    nodeName         = "trick_subscriber_node";
+    subscriptionName = "Trick_says";
+}
+
+void SubNode::init_ros()
+{
+
+    int argc=0;
+    char **argv = 0x0;
+
+    rclcpp::init(argc,argv);
+    node = std::make_shared<rclcpp::Node>(nodeName);
+    sub = node->create_subscription<std_msgs::msg::String>(
+            subscriptionName, 10,
+            [this](std_msgs::msg::String::ConstSharedPtr msg) {
+                std::cout << "The void speaks: " << msg->data << std::endl;
+            }
+        );
+}
+
+
+void SubNode::earToTheVoid()
+{
+
+    if(!sub)
+    {
+        std::cout << "No subscriber detected.\n" << std::endl;
+        return;
+    }
+    else if(!node)
+    {
+        std::cout << "No subscription node detected.\n" << std::endl;
+        return;
+    }
+    else
+    {
+        rclcpp::spin_some(node);
+    }
+
+}
+
+void SubNode::shutItDown()
+{
+
+    sub.reset();
+    node.reset();
+    rclcpp::shutdown();
+}


### PR DESCRIPTION
Simple example Trick sims that utilize ROS2 headers and library calls to create a simple pub/sub simulation set.  ROS2 libraries and headers required at compile.  Tested with ROS Humble natively on RHEL8