### PR TITLE
Fixed the condition for stl only case so char* or char[] size calculation gets to normal handling

### DIFF
--- a/include/trick/reference.h
+++ b/include/trick/reference.h
@@ -55,6 +55,7 @@ typedef struct {
     char* units;            /**< -- Units as specified in input runstream */
     int   num_index_left;   /**< -- FIXME OBSOLETE Number of remaining indicies to specify */
     int   pointer_present;  /**< -- 0 = no , 1 = yes (address could change) */
+    int   stl_present;      /**< -- 0 = no , 1 = yes (STL container was indexed in path) */
     int   ref_type;         /**< -- 0 = address, 1 = value. */
     void* address;          /**< ** Address of the specified reference */
     V_DATA v_data;          /**< ** Value */

--- a/test/SIM_test_varserv/models/test_client/test_client.cpp
+++ b/test/SIM_test_varserv/models/test_client/test_client.cpp
@@ -680,6 +680,53 @@ TEST_F (VariableServerTest, ListSize) {
     EXPECT_EQ(expected_bytes, actual_bytes);
 }
 
+TEST_F (VariableServerTest, NormalArrayCStringRead) {
+    if (socket_status != 0) {
+        FAIL();
+    }
+
+    // point_dyn_array contains: 3 Point elements
+    //                           Point(1.1, 2.2, PointLabel("Label 1 for Array Point 1"), PointLabel *, PointLabel [3])
+    //                           Point(3.3, 4.4, PointLabel("Label 1 for Array Point 2"), PointLabel *, PointLabel [3])
+    //                           Point(5.5, 6.6, PointLabel("Label 1 for Array Point 3"), PointLabel *, PointLabel [3])
+    // point_static_array contains: 2 Point elements (only one used in this test)
+    //                           Point(7.7, 8.8, PointLabel("Label 1 for Static Point 1"), PointLabel *, PointLabel [3])
+
+    std::string reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_dyn_array[0].x\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   1.1"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_dyn_array[0].point_label_obj.label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Label 1 for Array Point 1"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_dyn_array[0].point_dyn_label_array[0].label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Dyn Label 1 for Array Point 1"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_dyn_array[1].y\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   4.4"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_dyn_array[1].point_static_label_array[0].label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Static Label 1 for Array Point 2"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_static_array[0].point_label_obj.label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Label 1 for Static Point 1"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_static_array[0].point_dyn_label_array[0].label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Dyn Label 1 for Static Point 1"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.point_static_array[0].point_static_label_array[1].label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Static Label 1 for Static Point 2"), 0) << "Reply: " << reply;
+}
+
 /************************************/
 /*  STL Parameterized Tests         */
 /************************************/
@@ -1017,7 +1064,11 @@ TEST_F (VariableServerTest, VectorPointPtrElementRead) {
         FAIL();
     }
 
-    // vec_point_ptr contains: Point(11,22), Point(33,44), Point(55,66)
+    // vec_point_ptr contains: 3 Point* elements
+    //                         Point(11,22, PointLabel("Point 1 (11.000000, 22.000000)"), PointLabel *, PointLabel [3]),
+    //                         Point(33,44, PointLabel("Point 2 (33.000000, 44.000000)"), PointLabel *, PointLabel [3]),
+    //                         Point(55,66, PointLabel("Point 3 (55.000000, 66.000000)"), PointLabel *, PointLabel [3])
+    // Each Point in vec_point_ptr has a PointLabel object, a dynamic array of PointLabel objects, and a static array of PointLabel objects.
     std::string reply;
 
     socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[0].x\")\n";
@@ -1028,9 +1079,25 @@ TEST_F (VariableServerTest, VectorPointPtrElementRead) {
     socket >> reply;
     EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   22"), 0) << "Reply: " << reply;
 
+    socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[0].point_label_obj.label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Point 1 (11.000000, 22.000000)"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[0].point_dyn_label_array[0].label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Dyn Label 1 for Point 1"), 0) << "Reply: " << reply;
+
     socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[1].x\")\n";
     socket >> reply;
     EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   33"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[1].point_label_obj.label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Point 2 (33.000000, 44.000000)"), 0) << "Reply: " << reply;
+
+    socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[1].point_static_label_array[0].label_text\")\n";
+    socket >> reply;
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace(reply, "5   Static Label 1 for Point 2"), 0) << "Reply: " << reply;
 
     socket << "trick.var_send_once(\"vsx.vst.vec_point_ptr[2].y\")\n";
     socket >> reply;

--- a/test/SIM_test_varserv/models/varserv/include/VS.hh
+++ b/test/SIM_test_varserv/models/varserv/include/VS.hh
@@ -29,14 +29,23 @@ typedef enum {
 } Color;
 
 // Simple class for testing STL containers of structured types
+class PointLabel {
+    public:
+        char label_text[35];
+};
+
 class Point {
     public:
         double x;
         double y;
         //std::vector<double> coords;
 
-        Point() : x(0.0), y(0.0) {}
-        Point(double x_val, double y_val) : x(x_val), y(y_val) {}
+        PointLabel point_label_obj;
+        PointLabel * point_dyn_label_array;
+        PointLabel point_static_label_array[3];
+
+        Point() : x(0.0), y(0.0), point_label_obj(), point_dyn_label_array(nullptr) {}
+        Point(double x_val, double y_val) : x(x_val), y(y_val), point_label_obj(), point_dyn_label_array(nullptr) {}
 };
 
 
@@ -107,6 +116,9 @@ class VSTest {
         std::array<Point, 3> arr_point;
         
         std::vector<Point*> vec_point_ptr;
+
+        Point * point_dyn_array;
+        Point point_static_array[2];
 
 		VSTest();
 		~VSTest();

--- a/test/SIM_test_varserv/models/varserv/src/VS.cpp
+++ b/test/SIM_test_varserv/models/varserv/src/VS.cpp
@@ -55,6 +55,47 @@ int VSTest::default_vars() {
 	blocked_from_input = 500;
 	blocked_from_output = 1000;
 
+    // Initialize dynamic array of Points
+    point_dyn_array = (Point*)TMM_declare_var_s("Point[3]");
+    point_dyn_array[0] = Point(1.1, 2.2);
+    point_dyn_array[0].point_label_obj = PointLabel();
+    snprintf(point_dyn_array[0].point_label_obj.label_text, sizeof(point_dyn_array[0].point_label_obj.label_text), "Label 1 for Array Point 1");
+    point_dyn_array[0].point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    point_dyn_array[0].point_dyn_label_array[0] = PointLabel();
+    point_dyn_array[0].point_dyn_label_array[1] = PointLabel();
+    snprintf(point_dyn_array[0].point_dyn_label_array[0].label_text, sizeof(point_dyn_array[0].point_dyn_label_array[0].label_text), "Dyn Label 1 for Array Point 1");
+    snprintf(point_dyn_array[0].point_dyn_label_array[1].label_text, sizeof(point_dyn_array[0].point_dyn_label_array[1].label_text), "Dyn Label 2 for Array Point 1");
+    snprintf(point_dyn_array[0].point_static_label_array[0].label_text, sizeof(point_dyn_array[0].point_static_label_array[0].label_text), "Static Label 1 for Array Point 1");
+    snprintf(point_dyn_array[0].point_static_label_array[1].label_text, sizeof(point_dyn_array[0].point_static_label_array[1].label_text), "Static Label 2 for Array Point 1");
+
+    point_dyn_array[1] = Point(3.3, 4.4);
+    point_dyn_array[1].point_label_obj = PointLabel();
+    snprintf(point_dyn_array[1].point_label_obj.label_text, sizeof(point_dyn_array[1].point_label_obj.label_text), "Label 1 for Array Point 2");
+    point_dyn_array[1].point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    point_dyn_array[1].point_dyn_label_array[0] = PointLabel();
+    point_dyn_array[1].point_dyn_label_array[1] = PointLabel();
+    snprintf(point_dyn_array[1].point_dyn_label_array[0].label_text, sizeof(point_dyn_array[1].point_dyn_label_array[0].label_text), "Dyn Label 1 for Array Point 2");
+    snprintf(point_dyn_array[1].point_dyn_label_array[1].label_text, sizeof(point_dyn_array[1].point_dyn_label_array[1].label_text), "Dyn Label 2 for Array Point 2");
+    snprintf(point_dyn_array[1].point_static_label_array[0].label_text, sizeof(point_dyn_array[1].point_static_label_array[0].label_text), "Static Label 1 for Array Point 2");
+    snprintf(point_dyn_array[1].point_static_label_array[1].label_text, sizeof(point_dyn_array[1].point_static_label_array[1].label_text), "Static Label 2 for Array Point 2");
+
+    point_dyn_array[2] = Point(5.5, 6.6);
+    point_dyn_array[2].point_label_obj = PointLabel();
+    snprintf(point_dyn_array[2].point_label_obj.label_text, sizeof(point_dyn_array[2].point_label_obj.label_text), "Label 1 for Array Point 3");
+    point_dyn_array[2].point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    snprintf(point_dyn_array[2].point_dyn_label_array[0].label_text, sizeof(point_dyn_array[2].point_dyn_label_array[0].label_text), "Dyn Label 1 for Array Point 3");
+    snprintf(point_dyn_array[2].point_dyn_label_array[1].label_text, sizeof(point_dyn_array[2].point_dyn_label_array[1].label_text), "Dyn Label 2 for Array Point 3");
+
+    // Initialize static array of Points
+    point_static_array[0] = Point(7.7, 8.8);
+    point_static_array[0].point_label_obj = PointLabel();
+    snprintf(point_static_array[0].point_label_obj.label_text, sizeof(point_static_array[0].point_label_obj.label_text), "Label 1 for Static Point 1");
+    point_static_array[0].point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    snprintf(point_static_array[0].point_dyn_label_array[0].label_text, sizeof(point_static_array[0].point_dyn_label_array[0].label_text), "Dyn Label 1 for Static Point 1");
+    snprintf(point_static_array[0].point_dyn_label_array[1].label_text, sizeof(point_static_array[0].point_dyn_label_array[1].label_text), "Dyn Label 2 for Static Point 1");
+    snprintf(point_static_array[0].point_static_label_array[0].label_text, sizeof(point_static_array[0].point_static_label_array[0].label_text), "Static Label 1 for Static Point 1");
+    snprintf(point_static_array[0].point_static_label_array[1].label_text, sizeof(point_static_array[0].point_static_label_array[1].label_text), "Static Label 2 for Static Point 1");
+
     // Initialize vector containers
     vec_int.push_back(10);
     vec_int.push_back(20);
@@ -167,14 +208,43 @@ int VSTest::default_vars() {
     Point* p1 = (Point*)TMM_declare_var_s("Point");
     p1->x = 11.0;
     p1->y = 22.0;
+    p1->point_label_obj = PointLabel();
+    snprintf(p1->point_label_obj.label_text, sizeof(p1->point_label_obj.label_text), "Point 1 (%6.6f, %6.6f)", p1->x, p1->y);
+    p1->point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    p1->point_dyn_label_array[0] = PointLabel();
+    snprintf(p1->point_dyn_label_array[0].label_text, sizeof(p1->point_dyn_label_array[0].label_text), "Dyn Label 1 for Point 1");
+    snprintf(p1->point_static_label_array[0].label_text, sizeof(p1->point_static_label_array[0].label_text), "Static Label 1 for Point 1");
+    p1->point_dyn_label_array[1] = PointLabel();
+    snprintf(p1->point_dyn_label_array[1].label_text, sizeof(p1->point_dyn_label_array[1].label_text), "Dyn Label 2 for Point 1");
+    snprintf(p1->point_static_label_array[1].label_text, sizeof(p1->point_static_label_array[1].label_text), "Static Label 2 for Point 1");
     vec_point_ptr.push_back(p1);
+
     Point* p2 = (Point*)TMM_declare_var_s("Point");
     p2->x = 33.0;
     p2->y = 44.0;
+    p2->point_label_obj = PointLabel();
+    snprintf(p2->point_label_obj.label_text, sizeof(p2->point_label_obj.label_text), "Point 2 (%6.6f, %6.6f)", p2->x, p2->y);
+    p2->point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    p2->point_dyn_label_array[0] = PointLabel();
+    snprintf(p2->point_dyn_label_array[0].label_text, sizeof(p2->point_dyn_label_array[0].label_text), "Dyn Label 1 for Point 2");
+    snprintf(p2->point_static_label_array[0].label_text, sizeof(p2->point_static_label_array[0].label_text), "Static Label 1 for Point 2");
+    p2->point_dyn_label_array[1] = PointLabel();
+    snprintf(p2->point_dyn_label_array[1].label_text, sizeof(p2->point_dyn_label_array[1].label_text), "Dyn Label 2 for Point 2");
+    snprintf(p2->point_static_label_array[1].label_text, sizeof(p2->point_static_label_array[1].label_text), "Static Label 2 for Point 2");
     vec_point_ptr.push_back(p2);
+
     Point* p3 = (Point*)TMM_declare_var_s("Point");
     p3->x = 55.0;
     p3->y = 66.0;
+    p3->point_label_obj = PointLabel();
+    snprintf(p3->point_label_obj.label_text, sizeof(p3->point_label_obj.label_text), "Point 3 (%6.6f, %6.6f)", p3->x, p3->y);
+    p3->point_dyn_label_array = (PointLabel*)TMM_declare_var_s("PointLabel[2]");
+    p3->point_dyn_label_array[0] = PointLabel();
+    snprintf(p3->point_dyn_label_array[0].label_text, sizeof(p3->point_dyn_label_array[0].label_text), "Dyn Label 1 for Point 3");
+    snprintf(p3->point_static_label_array[0].label_text, sizeof(p3->point_static_label_array[0].label_text), "Static Label 1 for Point 3");
+    p3->point_dyn_label_array[1] = PointLabel();
+    snprintf(p3->point_dyn_label_array[1].label_text, sizeof(p3->point_dyn_label_array[1].label_text), "Dyn Label 2 for Point 3");
+    snprintf(p3->point_static_label_array[1].label_text, sizeof(p3->point_static_label_array[1].label_text), "Static Label 2 for Point 3");
     vec_point_ptr.push_back(p3);
 
 	return 0;

--- a/trick_source/sim_services/CheckPointAgent/input_parser.y
+++ b/trick_source/sim_services/CheckPointAgent/input_parser.y
@@ -397,6 +397,7 @@ param: NAME {
            $$.units = NULL;
            $$.num_index_left = 0;
            $$.pointer_present = 0;
+           $$.stl_present = 0;
            $$.ref_type = REF_INVALID;
            $$.address = NULL;
            $$.attr = NULL;

--- a/trick_source/sim_services/MemoryManager/MemoryManager_ref_dim.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_ref_dim.cpp
@@ -103,6 +103,9 @@ int Trick::MemoryManager::ref_dim( REF2* R, V_DATA* V) {
         // Get the address of the indexed element using the type-safe accessor function
         R->address = R->attr->get_stl_element(R->address, index_value);
 
+        // Mark that STL indexing was used in this reference path
+        R->stl_present = 1;
+
         // Store vector<bool> context in ref_attr for use in ref_assignment
         if (container_address != nullptr)
         {

--- a/trick_source/sim_services/MemoryManager/ref_parser.y
+++ b/trick_source/sim_services/MemoryManager/ref_parser.y
@@ -91,6 +91,7 @@ param: NAME {
     $$.num_index = 0;
     $$.units = NULL;
     $$.pointer_present = 0;
+    $$.stl_present = 0;
     $$.ref_type = REF_ADDRESS;
     $$.create_add_path = 1 ;
     $$.address_path = DLL_Create() ;
@@ -116,6 +117,7 @@ param: NAME {
       $$.num_index = 0;
       $$.units = NULL;
       $$.pointer_present = 0;
+      $$.stl_present = 0;
       $$.ref_type = REF_ADDRESS;
       $$.create_add_path = 1 ;
       $$.address_path = DLL_Create() ;


### PR DESCRIPTION
Fixed the condition for stl only case so char* or char[] size calculation gets to normal handling properly.