### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nasa/trick)
+
 <p align=center>
 <picture>
   <a href="https://nasa.github.io/trick">


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/nasa/trick) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.