### PR TITLE
Updated so that stars in library dependency individual item wouldn't make the list truncated.

### DIFF
--- a/libexec/trick/pm/get_lib_deps.pm
+++ b/libexec/trick/pm/get_lib_deps.pm
@@ -30,7 +30,7 @@ sub get_lib_deps ($$) {
     # library dependency regular expression will match all the way through last parenthesis followed by
     # another field in the trick header, a doxygen style keyword, or the end of comment *.
     # we capture all library dependencies at once into raw_lib_deps
-    @raw_lib_deps = ($contents =~ /LIBRARY[ _]DEPENDENC(?:Y|IES)\s*:[^(]*(.*?)\)(?:[A-Z _\t\n\r]+:|\s*[\*@])/gsi) ;
+    @raw_lib_deps = ($contents =~ /LIBRARY[ _]DEPENDENC(?:Y|IES)\s*:(.*?)(?=^[ \t]*\**[ \t]*[A-Z][A-Z _\t]*:|\*\/)/gmsi) ;
     foreach my $r ( @raw_lib_deps ) {
         # if there is preprocessor directive in the library dependencies, run the text through cpp.
         if ( $r =~ /#/ ) {
@@ -43,7 +43,9 @@ sub get_lib_deps ($$) {
             }
             $r = $temp ;
         }
-        push @lib_list , (split /\)[ \t\n\r\*]*\(/ , $r)  ;
+        # Strip leading comment markers from continuation lines before extracting '(...)' items.
+        $r =~ s/^\s*\**\s*//mg ;
+        push @lib_list , ($r =~ /\(([^()]+)\)/g) ;
     }
 
     @inc_paths = get_include_paths() ;

--- a/libexec/trick/pm/parse_s_define.pm
+++ b/libexec/trick/pm/parse_s_define.pm
@@ -456,7 +456,9 @@ sub parse_s_define ($) {
         my @lib_list ;
         %header = extract_trick_header("S_define", $i, 0, 0);
         push @{$$sim_ref{default_data}} , $header{default_data} ;
-        $header{libdep} =~ s/\s+//sg ;
+        # S_define header text keeps comment stars after html.pm flattens newlines, so remove
+        # both whitespace and '*' before extracting the inner dependency items.
+        $header{libdep} =~ s/[\s\*]+//sg ;
         $header{libdep} =~ s/\(\(/\(/ ;
         $header{libdep} =~ s/\)\)/\)/ ;
         @lib_list = $header{libdep} =~  m/\((.+?)\)/sg ;

--- a/test/SIM_test_dr/S_define
+++ b/test/SIM_test_dr/S_define
@@ -1,10 +1,10 @@
 /**************************TRICK HEADER***********************
-PURPOSE: ( S_define )
-LIBRARY DEPENDENCIES:
-(
-     (dr/src/DR.cpp)
-     (dr/src/DR_default_data.cpp)
-)
+ * PURPOSE: ( S_define )
+ * LIBRARY DEPENDENCIES:
+ * (
+ *     (dr/src/DR.cpp)
+ *     (dr/src/DR_default_data.cpp)
+ * )
 *************************************************************/
 
 #include "sim_objects/default_trick_sys.sm"

--- a/test/SIM_test_sched/models/sched/include/sched_proto.h
+++ b/test/SIM_test_sched/models/sched/include/sched_proto.h
@@ -1,26 +1,26 @@
 /************************TRICK HEADER*************************
  * PURPOSE:
-      (This comment lists out the other object files that are not included from c++ headers)
-      LIBRARY DEPENDENCIES:
-          (
-               (sched/src/sched_amf.o)
-               (sched/src/sched_async.o)
-               (sched/src/sched_deriv.o)
-               (sched/src/sched_dyn_event.o)
-               (sched/src/sched_effector.o)
-               (sched/src/sched_effector_emitter.o)
-               (sched/src/sched_effector_receiver.o)
-               (sched/src/sched_environment.o)
-               (sched/src/sched_init.o)
-               (sched/src/sched_integ.o)
-               (sched/src/sched_logging.o)
-               (sched/src/sched_scheduled.o)
-               (sched/src/sched_sensor.o)
-               (sched/src/sched_sensor_emitter.o)
-               (sched/src/sched_sensor_receiver.o)
-               (sched/src/sched_sensor_reflector.o)
-               (sched/src/sched_default_data.o)
-                                                     )
+ *     (This comment lists out the other object files that are not included from c++ headers)
+ * LIBRARY DEPENDENCIES:
+ *         (
+ *              (sched/src/sched_amf.o)
+ *              (sched/src/sched_async.o)
+ *              (sched/src/sched_deriv.o)
+ *              (sched/src/sched_dyn_event.o)
+ *              (sched/src/sched_effector.o)
+ *              (sched/src/sched_effector_emitter.o)
+ *              (sched/src/sched_effector_receiver.o)
+ *              (sched/src/sched_environment.o)
+ *              (sched/src/sched_init.o)
+ *              (sched/src/sched_integ.o)
+ *              (sched/src/sched_logging.o)
+ *              (sched/src/sched_scheduled.o)
+ *              (sched/src/sched_sensor.o)
+ *              (sched/src/sched_sensor_emitter.o)
+ *              (sched/src/sched_sensor_receiver.o)
+ *              (sched/src/sched_sensor_reflector.o)
+ *              (sched/src/sched_default_data.o)
+ *         )
 *************************************************************/
 
 #ifndef SCHED_PROTO_H


### PR DESCRIPTION
Updated so that starts in library dependency individual item wouldn't make the list truncated. See the linked issue for the example.