### PR TITLE
Updated so that ICG would not generate IO ATTRIBUTES for function pointers.

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/FieldVisitor.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/FieldVisitor.cpp
@@ -664,6 +664,15 @@ bool FieldVisitor::VisitRecordType(clang::RecordType *rt) {
     return false;
 }
 
+// Suppress IO attributes for function pointer fields (e.g. double (*get_vel)()).
+// Without this, the traversal recurses into the function's return type and incorrectly
+// generates an IO attribute for the field (e.g. TRICK_DOUBLE for get_vel as if it were a double *).
+bool FieldVisitor::VisitFunctionProtoType(clang::FunctionProtoType *fpt)
+{
+    fdes->setIO(0);
+    return false;
+}
+
 bool FieldVisitor::VisitVarDecl( clang::VarDecl *v ) {
 
     fdes->setStatic(v->isStaticDataMember()) ;

--- a/trick_source/codegen/Interface_Code_Gen/FieldVisitor.hh
+++ b/trick_source/codegen/Interface_Code_Gen/FieldVisitor.hh
@@ -46,6 +46,13 @@ class FieldVisitor : public clang::RecursiveASTVisitor<FieldVisitor> {
         bool VisitFieldDecl( clang::FieldDecl *field ) ;
         bool VisitPointerType(clang::PointerType *p);
         bool VisitRecordType(clang::RecordType *rt);
+
+        /**
+         * The base RecursiveASTVisitor<Derived>::VisitFunctionProtoType is a no-op that returns true.
+         * Overriding it here allows us to check for function pointer types and set IO to 0 for them.
+         */
+        bool VisitFunctionProtoType(clang::FunctionProtoType *fpt);
+
         //bool VisitSubstTemplateTypeParmType(clang::SubstTemplateTypeParmType *sttpt);
         //bool VisitTemplateSpecializationType(clang::TemplateSpecializationType *tst);
         //bool VisitTemplateTypeParmType(clang::TemplateTypeParmType *ttp);


### PR DESCRIPTION
Updated so that ICG would not generate IO ATTRIBUTES for function pointers.