### PR TITLE
Place Trickified code in the correct Python module

### DIFF
--- a/libexec/trick/make_makefile_swig
+++ b/libexec/trick/make_makefile_swig
@@ -364,7 +364,7 @@ all: $swig_sim_zip
     foreach my $dir ( keys %python_module_dirs ) {
         system("mkdir -p $swig_sim_dir/$dir");
         open MODULE_INITFILE, ">$swig_sim_dir/$dir/__init__.py";
-        foreach my $file ( @files_to_process ) {
+        foreach my $file ( @files_to_process, @ext_lib_files ) {
             if ( exists $trick_headers{$file}{python_module_dir} and $trick_headers{$file}{python_module_dir} eq $dir ) {
                 print MODULE_INITFILE "# $file\n" ;
                 print MODULE_INITFILE "import _m$md5s{$file}\n" ;

--- a/trick_sims/SIM_trickified_demo/RUN_test/input.py
+++ b/trick_sims/SIM_trickified_demo/RUN_test/input.py
@@ -50,6 +50,10 @@ def main():
     #trick_sie.enum_attr_map.print_xml()
     #trick.exec_set_trap_sigfpe(True)
 
+    # Test accessing Trickified code that was placed in a different Python module.
+    test_ball_state = trick.ball_state.BallStateInput()
+    test_ball_state.mass = trick.attach_units('kg', 10.0)
+
 
 if __name__ == "__main__":
     main()

--- a/trick_sims/SIM_trickified_demo/models/Support_Code/BallState.hh
+++ b/trick_sims/SIM_trickified_demo/models/Support_Code/BallState.hh
@@ -14,6 +14,7 @@ ASSUMPTIONS AND LIMITATIONS:
     ((2 dimensional space)
      (Constant force)
      (Always toward a stationary point))
+PYTHON MODULE: (ball_state)
 LIBRARY DEPENDENCY:
      ((BallState.o) (BallState_default_data.o))
 PROGRAMMERS:


### PR DESCRIPTION
Addresses an issue where Trickified code was not placed into the `PYTHON_MODULE` specified in its header files.

Closes #2101.