### PR TITLE
Fix TRICK_HOME symlink mismatch causing Trick headers to be SWIGed

### DIFF
--- a/libexec/trick/make_makefile_swig
+++ b/libexec/trick/make_makefile_swig
@@ -64,7 +64,7 @@ sub read_files_to_process() {
             next if ( $word =~ /^\/usr\/local\/include/ ) ;
 
             # skip Trick headers
-            my $trick_home = $ENV{'TRICK_HOME'} ;
+            my $trick_home = abs_path($ENV{'TRICK_HOME'}) ;
             next if ( $word =~ /^\Q$trick_home\/include/ ) ;
             next if ( $word =~ /^\Q$trick_home\/trick_source/ ) ;
 


### PR DESCRIPTION
`TRICK_HOME` is set in `Makefile.common` using GNU Make's `$(abspath ...)`, which normalizes `.`/`..` but **does not resolve symlinks**. In `make_makefile_swig`, each header path is normalized with Perl's `abs_path()`, which **does** resolve symlinks. On systems where the Trick installation is accessed through a symlink, these two paths diverge and the prefix check that skips Trick's own headers never matches—causing internal Trick headers to be passed to SWIG and failing the build.

Fix: wrap `TRICK_HOME` in `abs_path()` before the comparison so both sides use the same canonical real path.