### PR TITLE
Modify .gitattributes for line endings and exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,25 @@
+# Normalize line endings to LF in the repo; check out as LF on all platforms
+* text=auto eol=lf
+
+# Windows batch files require CRLF to work correctly with cmd.exe
+*.bat  text eol=crlf
+
+# Binary files — suppress line-ending conversion and text diffs
+# Office/presentation formats are excluded from git archive exports
+*.png  binary
+*.gif  binary
+*.jpg  binary
+*.pdf  binary export-ignore
+*.ppt  binary export-ignore
+*.pptx binary export-ignore
+*.doc  binary export-ignore
+
+# Exclude from git archive exports
 .gitattributes export-ignore
 .gitignore export-ignore
-make_changelog export-ignore
-Basics_of_Program_Memory_and_Variables.ppt export-ignore
-Compiling_and_Linking_Overview.ppt export-ignore
-Trick_Advanced_Topics.pptx export-ignore
-Trick_Software_Design_Document.doc export-ignore
-Trick_Software_Development_Plan.doc export-ignore
-Trick_Software_Quality_Assurance_Plan.doc export-ignore
-Trick_Software_Requirement_Specification.doc export-ignore
-Trick_Tutorial_Review.pptx export-ignore
-design.doc export-ignore
-tutorial.doc export-ignore
-users_guide.html export-ignore
-MonteCarlo_Presentation.pptx export-ignore
-Trick_07_to_10.pptx export-ignore
-trick_source/data_products/DPX/test export-ignore
+trick_source/data_products/DPX/test/** export-ignore
+share/doc/trick/users_guide.html export-ignore
+
+# GitHub Linguist
 configure linguist-generated=true
 *.dr linguist-language=Python

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,8 @@
 # Exclude from git archive exports
 .gitattributes export-ignore
 .gitignore export-ignore
+.github/** export-ignore
+libexec/trick/make_changelog export-ignore
 trick_source/data_products/DPX/test/** export-ignore
 share/doc/trick/users_guide.html export-ignore
 


### PR DESCRIPTION
Updated .gitattributes to normalize line endings and exclude additional files from git archive exports.

changes:
- All text files: LF in the repo, checked out as LF on all platforms (`* text=auto eol=lf`)
- `.bat` files: CRLF (required by `cmd.exe`)
- Images, PDFs, Office docs: treated as binary (no conversion)