### PR TITLE
ci: declare workflow-level `contents: read` on the 11 remaining workflows

### DIFF
--- a/.github/workflows/alt_linux_distros.yml
+++ b/.github/workflows/alt_linux_distros.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,10 @@ name: Test Docker Hub Images
 on:
   schedule:
     - cron:  '0 0 * * 0'
-  
+
+permissions:
+  contents: read
+
 jobs:
   latest:
     runs-on: ubuntu-18.04

--- a/.github/workflows/report_alt_linux_distros.yml
+++ b/.github/workflows/report_alt_linux_distros.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["More Linux"] # runs after CI workflow
     types:
       - completed
+
+permissions:
+  contents: read
+
 jobs:
   report:
     strategy:

--- a/.github/workflows/report_linux.yml
+++ b/.github/workflows/report_linux.yml
@@ -4,6 +4,10 @@ on:
     workflows: ["Linux"] # runs after CI workflow
     types:
       - completed
+
+permissions:
+  contents: read
+
 jobs:
   report:
     strategy:

--- a/.github/workflows/report_linux_py2.yml
+++ b/.github/workflows/report_linux_py2.yml
@@ -5,6 +5,10 @@ on:
     workflows: ['Linux Python 2']                     # runs after CI workflow
     types:
       - completed
+
+permissions:
+  contents: read
+
 jobs:
   report:
     strategy:

--- a/.github/workflows/test_32_oracle.yml
+++ b/.github/workflows/test_32_oracle.yml
@@ -5,6 +5,9 @@ on:
   - cron:  '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trick_32bit_oracle:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/test_linux_py2.yml
+++ b/.github/workflows/test_linux_py2.yml
@@ -5,6 +5,9 @@ on:
   - cron:  '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     runs-on: macos-15

--- a/.github/workflows/trickops.yml
+++ b/.github/workflows/trickops.yml
@@ -30,6 +30,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   trickops-tests-ubuntu:
     name: Unit Tests Ubuntu:22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 11 workflows in `.github/workflows/` that don't actually need any write scope:

- `alt_linux_distros.yml`, `docker.yml`, `test_32_oracle.yml`, `test_linux.yml`, `test_linux_py2.yml`, `test_macos.yml`, `trickops.yml`: build and test workflows, no GitHub API mutation.
- `report_alt_linux_distros.yml`, `report_linux.yml`, `report_linux_py2.yml`: status-report workflows that read CI artifacts and post no comments.
- `code_coverage.yml`: uploads to Coveralls via `coverallsapp/github-action`. The `github-token` passed to that action is used to identify with coveralls.io, not for any GitHub API mutation, so `contents: read` is sufficient.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.