### PR TITLE
Updated to skip unit conversion for bool with swig typemap.

### DIFF
--- a/include/trick/swig/swig_int_templates.hh
+++ b/include/trick/swig/swig_int_templates.hh
@@ -218,6 +218,25 @@ template<typename T > static int typemap_in_scalar( T & output , PyObject *input
     return ret ;
 }
 
+template<> static int typemap_in_scalar<bool>( bool & output , PyObject *input , const char * /*symname*/ ) {
+    // bool is unitless — skip get_units() lookup and convert_and_set() unit conversion
+    void * my_argp ;
+    if (SWIG_IsOK(SWIG_ConvertPtr(input, &my_argp,SWIG_TypeQuery("_p_swig_int"), 0 ))) {
+        swig_int * si = reinterpret_cast<swig_int *>(my_argp) ;
+        output = (si->value != 0) ;
+    } else if (SWIG_IsOK(SWIG_ConvertPtr(input, &my_argp,SWIG_TypeQuery("_p_swig_double"), 0 ))) {
+        swig_double * sd = reinterpret_cast<swig_double *>(my_argp) ;
+        output = (sd->value != 0.0) ;
+    } else if ( PyFloat_Check(input) ) {
+        output = (bool)PyFloat_AsDouble(input) ;
+    } else if ( PyInt_Check(input) ) {
+        output = (bool)PyInt_AsLong(input) ;
+    } else {
+        return -1 ;
+    }
+    return 0 ;
+}
+
 template<typename T > static T * typemap_in_1d( PyObject *input , unsigned int out_size, const char * symname ) {
 
     void * argp2 ;
@@ -912,13 +931,14 @@ template <> struct StrTraits<std::wstring>
 };
 
 // str_typemap_in_1d — Python sequence -> new T[out_size]()
-template<typename T>
-static T* str_typemap_in_1d(PyObject *input, unsigned int out_size) {
+template <typename T> static T *str_typemap_in_1d(PyObject *input, unsigned int out_size)
+{
     T *arr = new T[out_size]();
     if (!PySequence_Check(input)) return arr;
     Py_ssize_t n = PySequence_Length(input);
     if (n > (Py_ssize_t)out_size) n = (Py_ssize_t)out_size;
-    for (Py_ssize_t i = 0; i < n; ++i) {
+    for (Py_ssize_t i = 0; i < n; ++i)
+    {
         PyObject *item = PySequence_GetItem(input, i);
         if (item && PyUnicode_Check(item))
             arr[i] = StrTraits<T>::from_pyunicode(item);
@@ -928,18 +948,21 @@ static T* str_typemap_in_1d(PyObject *input, unsigned int out_size) {
 }
 
 // str_typemap_in_2d — Python list-of-lists -> flat new T[d0*d1]()
-template<typename T>
-static T* str_typemap_in_2d(PyObject *input, unsigned int d0, unsigned int d1) {
+template <typename T> static T *str_typemap_in_2d(PyObject *input, unsigned int d0, unsigned int d1)
+{
     T *flat = new T[d0 * d1]();
     if (!PySequence_Check(input)) return flat;
     Py_ssize_t n0 = PySequence_Length(input);
     if (n0 > (Py_ssize_t)d0) n0 = (Py_ssize_t)d0;
-    for (Py_ssize_t i = 0; i < n0; ++i) {
+    for (Py_ssize_t i = 0; i < n0; ++i)
+    {
         PyObject *row = PySequence_GetItem(input, i);
-        if (row && PySequence_Check(row)) {
+        if (row && PySequence_Check(row))
+        {
             Py_ssize_t n1 = PySequence_Length(row);
             if (n1 > (Py_ssize_t)d1) n1 = (Py_ssize_t)d1;
-            for (Py_ssize_t j = 0; j < n1; ++j) {
+            for (Py_ssize_t j = 0; j < n1; ++j)
+            {
                 PyObject *item = PySequence_GetItem(row, j);
                 if (item && PyUnicode_Check(item))
                     flat[i * d1 + j] = StrTraits<T>::from_pyunicode(item);
@@ -952,23 +975,28 @@ static T* str_typemap_in_2d(PyObject *input, unsigned int d0, unsigned int d1) {
 }
 
 // str_typemap_in_3d — Python list-of-lists-of-lists -> flat new T[d0*d1*d2]()
-template<typename T>
-static T* str_typemap_in_3d(PyObject *input, unsigned int d0, unsigned int d1, unsigned int d2) {
+template <typename T> static T *str_typemap_in_3d(PyObject *input, unsigned int d0, unsigned int d1, unsigned int d2)
+{
     T *flat = new T[d0 * d1 * d2]();
     if (!PySequence_Check(input)) return flat;
     Py_ssize_t n0 = PySequence_Length(input);
     if (n0 > (Py_ssize_t)d0) n0 = (Py_ssize_t)d0;
-    for (Py_ssize_t i = 0; i < n0; ++i) {
+    for (Py_ssize_t i = 0; i < n0; ++i)
+    {
         PyObject *row0 = PySequence_GetItem(input, i);
-        if (row0 && PySequence_Check(row0)) {
+        if (row0 && PySequence_Check(row0))
+        {
             Py_ssize_t n1 = PySequence_Length(row0);
             if (n1 > (Py_ssize_t)d1) n1 = (Py_ssize_t)d1;
-            for (Py_ssize_t j = 0; j < n1; ++j) {
+            for (Py_ssize_t j = 0; j < n1; ++j)
+            {
                 PyObject *row1 = PySequence_GetItem(row0, j);
-                if (row1 && PySequence_Check(row1)) {
+                if (row1 && PySequence_Check(row1))
+                {
                     Py_ssize_t n2 = PySequence_Length(row1);
                     if (n2 > (Py_ssize_t)d2) n2 = (Py_ssize_t)d2;
-                    for (Py_ssize_t k = 0; k < n2; ++k) {
+                    for (Py_ssize_t k = 0; k < n2; ++k)
+                    {
                         PyObject *item = PySequence_GetItem(row1, k);
                         if (item && PyUnicode_Check(item))
                             flat[i*d1*d2 + j*d2 + k] = StrTraits<T>::from_pyunicode(item);
@@ -984,8 +1012,8 @@ static T* str_typemap_in_3d(PyObject *input, unsigned int d0, unsigned int d1, u
 }
 
 // str_make_fixed_swig_ref — build a swig_ref for a fixed-size string array (1D/2D/3D)
-template<typename T>
-static swig_ref* str_make_fixed_swig_ref(void *addr, int num_dims, int d0, int d1 = 0, int d2 = 0) {
+template <typename T> static swig_ref *str_make_fixed_swig_ref(void *addr, int num_dims, int d0, int d1 = 0, int d2 = 0)
+{
     swig_ref *t = new swig_ref;
     t->ref.address = addr;
     t->ref.units = NULL;
@@ -997,9 +1025,18 @@ static swig_ref* str_make_fixed_swig_ref(void *addr, int num_dims, int d0, int d
     t->ref.attr->attr = NULL;
     t->ref.attr->io = TRICK_VAR_OUTPUT | TRICK_VAR_INPUT | TRICK_CHKPNT_OUTPUT | TRICK_CHKPNT_INPUT;
     t->ref.attr->num_index = num_dims;
-    t->ref.attr->index[0].size = d0; t->ref.attr->index[0].start = 0;
-    if (num_dims >= 2) { t->ref.attr->index[1].size = d1; t->ref.attr->index[1].start = 0; }
-    if (num_dims >= 3) { t->ref.attr->index[2].size = d2; t->ref.attr->index[2].start = 0; }
+    t->ref.attr->index[0].size = d0;
+    t->ref.attr->index[0].start = 0;
+    if (num_dims >= 2)
+    {
+        t->ref.attr->index[1].size = d1;
+        t->ref.attr->index[1].start = 0;
+    }
+    if (num_dims >= 3)
+    {
+        t->ref.attr->index[2].size = d2;
+        t->ref.attr->index[2].start = 0;
+    }
     t->ref.create_add_path = 0;
     t->ref.num_index = 0;
     t->ref.num_index_left = num_dims;
@@ -1009,8 +1046,8 @@ static swig_ref* str_make_fixed_swig_ref(void *addr, int num_dims, int d0, int d
 
 // str_make_ptr_swig_ref — build a swig_ref for a dynamically allocated string pointer,
 // querying MemoryManager for real allocation dimensions
-template<typename T>
-static swig_ref* str_make_ptr_swig_ref(T *addr, const std::string& symname, const std::string& tname) {
+template <typename T> static swig_ref *str_make_ptr_swig_ref(T *addr, const std::string &symname, const std::string &tname)
+{
     swig_ref *t = new swig_ref;
     t->ref.address = (void *)addr;
     t->ref.units = NULL;
@@ -1034,20 +1071,29 @@ static swig_ref* str_make_ptr_swig_ref(T *addr, const std::string& symname, cons
 
 // str_typemap_in_ptr — convert a Python swig_ref/REF2/void*/None to T*
 // Returns 0 on success, -1 if the input type is not recognised (caller should SWIG_exception_fail)
-template<typename T>
-static int str_typemap_in_ptr(PyObject *input, T **output) {
+template <typename T> static int str_typemap_in_ptr(PyObject *input, T **output)
+{
     void *argp2;
-    if (SWIG_IsOK(SWIG_ConvertPtr(input, &argp2, SWIG_TypeQuery("_p_swig_ref"), 0))) {
+    if (SWIG_IsOK(SWIG_ConvertPtr(input, &argp2, SWIG_TypeQuery("_p_swig_ref"), 0)))
+    {
         swig_ref *r = reinterpret_cast<swig_ref *>(argp2);
         if (r) *output = (T *)r->ref.address;
-    } else if (SWIG_IsOK(SWIG_ConvertPtr(input, &argp2, SWIG_TypeQuery("_p_REF2"), 0))) {
+    }
+    else if (SWIG_IsOK(SWIG_ConvertPtr(input, &argp2, SWIG_TypeQuery("_p_REF2"), 0)))
+    {
         REF2 *r = reinterpret_cast<REF2 *>(argp2);
         if (r) *output = (T *)r->address;
-    } else if (SWIG_IsOK(SWIG_ConvertPtr(input, &argp2, SWIG_TypeQuery("_p_void"), 0))) {
+    }
+    else if (SWIG_IsOK(SWIG_ConvertPtr(input, &argp2, SWIG_TypeQuery("_p_void"), 0)))
+    {
         *output = reinterpret_cast<T *>(argp2);
-    } else if (input == Py_None) {
+    }
+    else if (input == Py_None)
+    {
         *output = nullptr;
-    } else {
+    }
+    else
+    {
         return -1;
     }
     return 0;

--- a/include/trick/swig/swig_int_templates.hh
+++ b/include/trick/swig/swig_int_templates.hh
@@ -218,7 +218,7 @@ template<typename T > static int typemap_in_scalar( T & output , PyObject *input
     return ret ;
 }
 
-template<> static int typemap_in_scalar<bool>( bool & output , PyObject *input , const char * /*symname*/ ) {
+template<> inline int typemap_in_scalar<bool>( bool & output , PyObject *input , const char * /*symname*/ ) {
     // bool is unitless — skip get_units() lookup and convert_and_set() unit conversion
     void * my_argp ;
     if (SWIG_IsOK(SWIG_ConvertPtr(input, &my_argp,SWIG_TypeQuery("_p_swig_int"), 0 ))) {

--- a/include/trick/swig/swig_int_typemap.i
+++ b/include/trick/swig/swig_int_typemap.i
@@ -60,12 +60,20 @@
     }
 }
 
+%typemap(out) bool {
+    // BOOL OUT — bool is unitless, skip get_units()
+    swig_int* t = new swig_int;
+    t->value = (long long)result;
+    t->units = "";
+    $result = SWIG_NewPointerObj(SWIG_as_voidptr(t), SWIG_TypeQuery("_p_swig_int"), SWIG_POINTER_OWN);
+}
+
 %typemap(out) char , unsigned char , signed char ,
               short , unsigned short , signed short ,
               int , unsigned int , signed int ,
               long , unsigned long , signed long ,
               long long , unsigned long long , signed long long ,
-              enum SWIGTYPE , bool {
+              enum SWIGTYPE {
     // INT OUT
     // swig_int_typemap.i : 70
     swig_int* t = new swig_int;

--- a/trick_source/sim_services/Clock/test/Makefile
+++ b/trick_source/sim_services/Clock/test/Makefile
@@ -9,11 +9,18 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_units -ltrick_mm -ltrick_pyip -ltrick_connection_handlers -ltrick_comm
+TRICK_LIB_NAMES = trick trick_units trick_mm trick_pyip trick_connection_handlers trick_comm
+ifeq ($(TRICK_HOST_TYPE),Linux)
+    TRICK_LIBS = -L${TRICK_LIB_DIR} -Wl,--start-group $(addprefix -l,$(TRICK_LIB_NAMES)) -Wl,--end-group
+else ifeq ($(TRICK_HOST_TYPE),Darwin)
+    TRICK_LIBS = -L${TRICK_LIB_DIR} $(addprefix -l,$(TRICK_LIB_NAMES))
+else
+    $(error Unsupported platform: $(shell uname))
+endif
 LIBS = -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 
-ifeq ($(TRICK_HOST_TYPE), Linux)
+ifeq ($(TRICK_HOST_TYPE),Linux)
     LIBS += -lpthread -lrt
 endif
 

--- a/trick_source/sim_services/Executive/test/Makefile
+++ b/trick_source/sim_services/Executive/test/Makefile
@@ -63,4 +63,4 @@ Executive_test.o : Executive_test.cpp
 	$(TRICK_CXX) $(TRICK_CPPFLAGS) -c $<
 
 Executive_test : Executive_test.o
-	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)
+	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)

--- a/trick_source/sim_services/MonteCarlo/test/Makefile
+++ b/trick_source/sim_services/MonteCarlo/test/Makefile
@@ -9,7 +9,14 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CXXFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_pyip -ltrick_comm -ltrick_math -ltrick_mm -ltrick_units -ltrick_var_binary_parser -ltrick_connection_handlers -ltrick_comm
+TRICK_LIB_NAMES = trick trick_pyip trick_comm trick_math trick_mm trick_units trick_var_binary_parser trick_connection_handlers
+ifeq ($(TRICK_HOST_TYPE),Linux)
+    TRICK_LIBS = -L${TRICK_LIB_DIR} -Wl,--start-group $(addprefix -l,$(TRICK_LIB_NAMES)) -Wl,--end-group
+else ifeq ($(TRICK_HOST_TYPE),Darwin)
+    TRICK_LIBS = -L${TRICK_LIB_DIR} $(addprefix -l,$(TRICK_LIB_NAMES))
+else
+    $(error Unsupported platform: $(shell uname))
+endif
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main
 
 # All tests produced by this Makefile.  Remember to add new tests you
@@ -37,10 +44,10 @@ MonteCarlo_test.o : MonteCarlo_test.cpp
 	$(TRICK_CXX) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) -c $<
 
 MonteCarlo_test : MonteCarlo_test.o
-	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)
+	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)
 
 MonteCarlo_exceptions.o : MonteCarlo_exceptions.cpp
 	$(TRICK_CXX) $(TRICK_CXXFLAGS) $(TRICK_SYSTEM_CXXFLAGS) -c $<
 
 MonteCarlo_exceptions : MonteCarlo_exceptions.o
-	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)
+	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)

--- a/trick_source/sim_services/Timer/test/Makefile
+++ b/trick_source/sim_services/Timer/test/Makefile
@@ -9,7 +9,14 @@ include $(dir $(lastword $(MAKEFILE_LIST)))../../../../share/trick/makefiles/Mak
 
 # Flags passed to the preprocessor.
 TRICK_CPPFLAGS += -I$(GTEST_HOME)/include -I$(TRICK_HOME)/include -g ${TRICK_SYSTEM_CXXFLAGS} ${TRICK_TEST_FLAGS}
-TRICK_LIBS = -L${TRICK_LIB_DIR} -ltrick -ltrick_units -ltrick_mm -ltrick_pyip -ltrick_connection_handlers -ltrick_comm
+TRICK_LIB_NAMES = trick trick_units trick_mm trick_pyip trick_connection_handlers trick_comm
+ifeq ($(TRICK_HOST_TYPE),Linux)
+    TRICK_LIBS = -L${TRICK_LIB_DIR} -Wl,--start-group $(addprefix -l,$(TRICK_LIB_NAMES)) -Wl,--end-group
+else ifeq ($(TRICK_HOST_TYPE),Darwin)
+    TRICK_LIBS = -L${TRICK_LIB_DIR} $(addprefix -l,$(TRICK_LIB_NAMES))
+else
+    $(error Unsupported platform: $(shell uname))
+endif
 TRICK_EXEC_LINK_LIBS += -L${GTEST_HOME}/lib64 -L${GTEST_HOME}/lib -lgtest -lgtest_main -lpthread
 
 # All tests produced by this Makefile.  Remember to add new tests you
@@ -33,4 +40,4 @@ ITimer_test.o : ITimer_test.cpp
 	$(TRICK_CXX) $(TRICK_CPPFLAGS) -c $<
 
 ITimer_test : ITimer_test.o
-	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)
+	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ $(OTHER_OBJECTS) $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)


### PR DESCRIPTION
Updated to skip unit conversion for bool with swig typemap, applied formatting missed for string/wstring support update, and refactored sim_services unit tests makefiles that missed handling circular references same way as others as well as removed duplicate $(TRICK_LIBS) on the link.