### PR TITLE
ci: declare workflow-level `contents: read` on test_linux, test_macos, code_coverage

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     runs-on: macos-15


### PR DESCRIPTION
Three CI workflows just run language tests / coverage. No GitHub API writes from the workflows themselves, so workflow-level `contents: read` is the appropriate cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening shape. YAML validated locally.