### PR TITLE
ci: pin third-party Actions to commit SHAs (CWE-829)

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -83,7 +83,7 @@ jobs:
           cd ../../../
           make code-coverage
       - name: Upload to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # master
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report_macos.yml
+++ b/.github/workflows/report_macos.yml
@@ -13,7 +13,7 @@ jobs:
       checks: write # Allow creating check runs
     steps:
       - name: Publish Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
         with:
           # Match artifact from the specific attempt that triggered this report
           artifact: Trick_macos_attempt_${{ github.event.workflow_run.run_attempt }}


### PR DESCRIPTION
## Summary

Pin both third-party GitHub Actions in `.github/workflows/` to immutable
40-character commit SHAs, addressing [CWE-829: Inclusion of Functionality
from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html).

## Why

A third-party Action pinned to a mutable tag (`@v2`) or a moving branch
(`@master`) executes whatever the upstream maintainer pushes to that ref
at workflow run time. A maintainer compromise or a tag/branch rewrite
causes the action to run attacker code with `${{ secrets.* }}` in scope.

The **March 2025 tj-actions/changed-files** supply-chain incident
([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)) was
exactly this shape: 23,000+ workflows compromised because they used
`@v45` instead of a SHA. GitHub's hardening guidance:
[Security hardening for GitHub Actions — using third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Changes

| File:Line | Action | Was | Now |
|---|---|---|---|
| `.github/workflows/code_coverage.yml:86` | coverallsapp/github-action | `@master` | `@<sha> # master` |
| `.github/workflows/report_macos.yml:16` | dorny/test-reporter | `@v2` | `@<sha> # v2` |

`coverallsapp/github-action@master` is the higher-risk of the two (HEAD
moves on every push to master in the upstream repo). The dorny/test-reporter
v2 pin moves any time the v2 tag is rewritten.

Each SHA was resolved via `gh api` against the tag/branch previously in
use; the human-readable ref is preserved as a `# <ref>` comment.

## Test plan

- [ ] `code_coverage.yml` continues to upload to Coveralls on a PR build.
- [ ] `report_macos.yml` continues to publish test reports on macOS builds.

## Provenance

Discovered by [Kulvex Code (KCode)](https://github.com/AstrolexisAI/KCode),
a deterministic SAST scanner. Pattern: `cloud-006-gha-third-party-no-sha`.

Per common AI-assist disclosure practice: **AI tooling was used.** Discovery
via KCode (deterministic regex+AST patterns + LLM verifier). Fix generation
via KCode agentic mode. Each SHA resolution was done by `gh api` calls,
not invented.

— Bruno Aiub · AstroLexis · Kulvex Code · contact@astrolexis.space
