### PR TITLE
ci: Configure spotless ratchetFrom in pom.xml / fix clang-format version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           echo "Changed Java files:"
           echo "$JAVA_FILES"
 
-          if ! mvn -f trick_source/java/pom.xml --batch-mode -q spotless:check -Dspotless.ratchetFrom="$BASE"; then
+          if ! mvn -f trick_source/java/pom.xml --batch-mode -q spotless:check; then
             echo ""
             echo "::error::Changed Java files are not correctly formatted."
             echo "::error::To fix, run: mvn -f trick_source/java/pom.xml spotless:apply"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y clang-format perltidy python3-pip maven
+          sudo apt-get install -y clang-format-20 perltidy python3-pip maven
           pip3 install --break-system-packages ruff
 
       - name: Check clang-format on changed C/C++ lines
@@ -53,7 +53,7 @@ jobs:
             BASE=$(git merge-base origin/master HEAD)
           fi
 
-          DIFF=$(git clang-format --diff "$BASE" --extensions c,h,cpp,hpp,cc,hh) || true
+          DIFF=$(/usr/lib/llvm-20/bin/git-clang-format --binary /usr/lib/llvm-20/bin/clang-format --diff "$BASE" --extensions c,h,cpp,hpp,cc,hh) || true
 
           if echo "$DIFF" | grep -q '^diff'; then
             echo "$DIFF"

--- a/trick_source/java/pom.xml
+++ b/trick_source/java/pom.xml
@@ -303,6 +303,7 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
+          <ratchetFrom>026cc6dfd201feee5845b8e19451af425824e5a2</ratchetFrom>
           <java>
             <palantirJavaFormat>
               <style>PALANTIR</style>


### PR DESCRIPTION
Moves `ratchetFrom` out of the CI command line and into the spotless plugin configuration in `pom.xml`, making it consistent for both CI and local runs.