### PR TITLE
Make itimer wake up earlier when necessary.

### DIFF
--- a/trick_source/sim_services/Timer/ITimer.cpp
+++ b/trick_source/sim_services/Timer/ITimer.cpp
@@ -101,12 +101,32 @@ int Trick::ITimer::start(double in_frame_time) {
         if ( frame_sec == 0 && frame_usec < 10000 ) {
             active = false ;
             return(0) ;
-        } else if ( frame_usec < 2000 && frame_sec > 0 ) {
-            // adjust times with usec < 2000 , we'll be subtracting 2ms from the frame_usec
+        }
+        // Arm the itimer slightly early so clock_spin() can busy-wait to the
+        // frame boundary.  On macOS, timer coalescing can delay SIGALRM delivery
+        // by 3-15ms, so scale the value to 5% of the frame (with a range of 2-8ms). 
+        // On Linux a fixed 2ms is sufficient.
+#if __APPLE__
+        {
+            // Frames < 10ms are already rejected above, so frame_usec >= 10000 thus >= 8000
+            // When frame_sec == 0, meaning the borrow path only triggers for frames >= 1s.
+            unsigned int scaled_usec = (unsigned int)(in_frame_time * 1000000) / 20 ; // 5% of frame
+            if ( scaled_usec < 2000 ) scaled_usec = 2000 ;
+            if ( scaled_usec > 8000 ) scaled_usec = 8000 ;
+            if ( frame_usec < scaled_usec ) 
+            {
+                frame_sec  -= 1 ;
+                frame_usec += 1000000 ;
+            }
+            frame_usec -= scaled_usec ;
+        }
+#else
+        if ( frame_usec < 2000 && frame_sec > 0 ) {
             frame_sec  -= 1 ;
             frame_usec += 1000000 ;
         }
         frame_usec -= 2000 ;
+#endif
 
         if ( in_frame_time > 0 ) {
             /* Set timer interval in micro-seconds */

--- a/trick_source/sim_services/Timer/ITimer.cpp
+++ b/trick_source/sim_services/Timer/ITimer.cpp
@@ -104,24 +104,27 @@ int Trick::ITimer::start(double in_frame_time) {
         }
         // Arm the itimer slightly early so clock_spin() can busy-wait to the
         // frame boundary.  On macOS, timer coalescing can delay SIGALRM delivery
-        // by 3-15ms, so scale the value to 5% of the frame (with a range of 2-8ms). 
+        // by 3-15ms, so scale the value to 5% of the frame (with a range of 2-8ms).
         // On Linux a fixed 2ms is sufficient.
 #if __APPLE__
         {
             // Frames < 10ms are already rejected above, so frame_usec >= 10000 thus >= 8000
             // When frame_sec == 0, meaning the borrow path only triggers for frames >= 1s.
-            unsigned int scaled_usec = (unsigned int)(in_frame_time * 1000000) / 20 ; // 5% of frame
-            if ( scaled_usec < 2000 ) scaled_usec = 2000 ;
-            if ( scaled_usec > 8000 ) scaled_usec = 8000 ;
-            if ( frame_usec < scaled_usec ) 
+            unsigned int scaled_usec = (unsigned int)(in_frame_time * 1000000) / 20; // 5% of frame
+            if (scaled_usec < 2000)
+                scaled_usec = 2000;
+            if (scaled_usec > 8000)
+                scaled_usec = 8000;
+            if (frame_usec < scaled_usec)
             {
-                frame_sec  -= 1 ;
-                frame_usec += 1000000 ;
+                frame_sec  -= 1;
+                frame_usec += 1000000;
             }
-            frame_usec -= scaled_usec ;
+            frame_usec -= scaled_usec;
         }
 #else
-        if ( frame_usec < 2000 && frame_sec > 0 ) {
+        if (frame_usec < 2000 && frame_sec > 0)
+        {
             frame_sec  -= 1 ;
             frame_usec += 1000000 ;
         }


### PR DESCRIPTION
Make itimer wake up earlier when necessary on Mac due to potential 3-15ms SIGALRM delivery delay to prevent the sim with itimer on running on Mac from getting unreasonable overruns. 