### PR TITLE
Fix IP shut down for no saved state for JIT input.

### DIFF
--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -220,7 +220,13 @@ int Trick::IPPython::shutdown() {
 
     if ( Py_IsInitialized() ) {
         // Obtain the GIL so that we can shut down properly
-        Py_BLOCK_THREADS
+        // Check if the thread state is actually saved before trying to restore it
+        // Python thread state is NULL when using JIT Input
+        if ( _save != NULL ) 
+        {
+            Py_BLOCK_THREADS
+            _save = NULL ;
+        }
         Py_Finalize();
     }
     return(0) ;

--- a/trick_source/sim_services/InputProcessor/IPPython.cpp
+++ b/trick_source/sim_services/InputProcessor/IPPython.cpp
@@ -222,10 +222,9 @@ int Trick::IPPython::shutdown() {
         // Obtain the GIL so that we can shut down properly
         // Check if the thread state is actually saved before trying to restore it
         // Python thread state is NULL when using JIT Input
-        if ( _save != NULL ) 
+        if (_save != NULL)
         {
-            Py_BLOCK_THREADS
-            _save = NULL ;
+            Py_BLOCK_THREADS _save = NULL;
         }
         Py_Finalize();
     }

--- a/trick_source/sim_services/JITInputFile/JITInputFile.cpp
+++ b/trick_source/sim_services/JITInputFile/JITInputFile.cpp
@@ -169,6 +169,9 @@ int Trick::JITInputFile::compile(std::string file_name) {
 
     // The library compile successfully.  Add library name to map
     add_library(library_fullpath_name);
+    // Add file name to map with the same lib info as the full library path
+    // This allows users to refer to the library by the file name instead of the full path.
+    file_to_libinfo_map[file_name] = file_to_libinfo_map[library_fullpath_name] ;
 
     return 0 ;
 

--- a/trick_source/sim_services/JITInputFile/JITInputFile.cpp
+++ b/trick_source/sim_services/JITInputFile/JITInputFile.cpp
@@ -171,7 +171,7 @@ int Trick::JITInputFile::compile(std::string file_name) {
     add_library(library_fullpath_name);
     // Add file name to map with the same lib info as the full library path
     // This allows users to refer to the library by the file name instead of the full path.
-    file_to_libinfo_map[file_name] = file_to_libinfo_map[library_fullpath_name] ;
+    file_to_libinfo_map[file_name] = file_to_libinfo_map[library_fullpath_name];
 
     return 0 ;
 


### PR DESCRIPTION
- When using JIT input, at IP shut down, Python thread state is NULL. This fix makes IP shut down without SIGABRT.
- Also add file name to the libinfo map in addition to the lib full path