### PR TITLE
Fix duplicate struct cast_as generated in .i file.

### DIFF
--- a/include/trick/swig/cast_as.i
+++ b/include/trick/swig/cast_as.i
@@ -13,7 +13,7 @@
    conversion is used by the input processor to associate named allocations in the
    memory manager to names in pyton space.
  */
-TYPE * castAs##NAME( PyObject * obj1 ) {
+static TYPE * castAs##NAME( PyObject * obj1 ) {
     void *argp = NULL ;
     TYPE * ret = (TYPE *)NULL ;
 

--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -64,34 +64,29 @@ my $typedef_def = qr/typedef\s+                            # the word typedef
                \s*;                                        # semicolon
              /sx;
 
-my $typedef_enum_def =
-  qr/typedef\s+enum\s*                # the words typedef enum
+my $typedef_enum_def = qr/typedef\s+enum\s*                # the words typedef enum
                (?:\s+[_A-Za-z]\w*)?\s*                     # optional name
                {(?:\s*\d+\s*)*                             # opening brace and possible comments
                (?:.*?}\s*                                  # everything to closing brace
                [\w,\s\*]*\s*;)                             # enum name and ;
              /sx;
 
-my $typedef_const_struct =
-qr/typedef\s+const\s+(?:struct|union)\s*     # the words typedef const struct|union
+my $typedef_const_struct = qr/typedef\s+const\s+(?:struct|union)\s*     # the words typedef const struct|union
                (?:\s+[_A-Za-z]\w*)?\s*                     # optional name
                {                                           # opening brace
              /sx;
-my $typedef_struct =
-  qr/typedef\s+(?:struct|union)\s*     # the words typedef struct|union
+my $typedef_struct = qr/typedef\s+(?:struct|union)\s*     # the words typedef struct|union
                (?:\s+[_A-Za-z]\w*)?\s*                     # optional name
                {                                           # opening brace
              /sx;
 my $namespace_def = qr/namespace\s*                        # keyword namespace
              (?:\s+[_A-Za-z]\w*)                           # class name
             /sx;
-my $enum_class_def =
-qr/enum\s+(?:class|struct)\s*       # keywords enum_class or struct (alias to enum class)
+my $enum_class_def = qr/enum\s+(?:class|struct)\s*       # keywords enum_class or struct (alias to enum class)
                (?:\s+[_A-Za-z]\w*)\s*                      # class or struct name
                (?:\{|:(?!\:))                              # { or punctuator :
              /sx;
-my $class_def =
-  qr/(?:class|struct)\s*                   # keyword class or struct
+my $class_def = qr/(?:class|struct)\s*                   # keyword class or struct
                (?:\s+[_A-Za-z]\w*)\s*                      # class name
                (?:\{|:(?!\:))                              # { or punctuator :
              /sx;
@@ -106,22 +101,20 @@ my $template_var_def = qr/(?:\:\:)?[_A-Za-z][:\w]*\s*     # template name
                /sx;
 
 # This list is the list of all STL types to ignore.
-my %all_stl_names =
-  qw(vector 1 list 1 deque 1 set 1 multiset 1 map 1 unordered_map 1 multimap 1 hash_set 1
-  hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
-  array 1
-  std::vector 1 std::list 1 std::deque 1 std::set 1 std::multiset 1 std::map 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
-  std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
-  std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1);
+my %all_stl_names = qw(vector 1 list 1 deque 1 set 1 multiset 1 map 1 unordered_map 1 multimap 1 hash_set 1
+    hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
+    array 1
+    std::vector 1 std::list 1 std::deque 1 std::set 1 std::multiset 1 std::map 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
+    std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
+    std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1);
 
 # This is a partial list of STL types to ignore.  We do not ignore vector, map, list if we allow STLs
-my %stl_names =
-  qw(deque 1 set 1 multiset 1 unordered_map 1 multimap 1 hash_set 1
-  hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
-  array 1
-  std::deque 1 std::set 1 std::multiset 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
-  std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
-  std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1);
+my %stl_names = qw(deque 1 set 1 multiset 1 unordered_map 1 multimap 1 hash_set 1
+    hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
+    array 1
+    std::deque 1 std::set 1 std::multiset 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
+    std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
+    std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1);
 
 Getopt::Long::Configure("bundling");
 GetOptions(
@@ -229,26 +222,23 @@ sub process_file() {
 
         my @comment_sections = index_comments(@file_contents);
         for ( my $idx = @comment_sections - 2 ; $idx >= 0 ; $idx -= 2 ) {
-            my $comment_length =
-              @comment_sections[ $idx + 1 ] - @comment_sections[$idx] + 1;
+            my $comment_length = @comment_sections[ $idx + 1 ] - @comment_sections[$idx] + 1;
             substr $raw_contents, @comment_sections[$idx], $comment_length, "";
         }
 
 ##      The init_attr functions cause problems when we try and wrap them with SWIG.
 ##      We can safely remove them from the header files.
 ##      Remove the friend init_attr functions that appear in multiline define statements
-        $raw_contents =~
-          s/\\\n\s*friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg;
+        $raw_contents =~ s/\\\n\s*friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg;
 ##      Remove the friend init_attr functions outside of multiline define statements
-        $raw_contents =~
-          s/friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg;
+        $raw_contents =~ s/friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg;
 
         #$raw_contents =~ s/friend\s+void\s+init_attr[^;]+;//sg ;
         $raw_contents =~ s/__const/const/sg;
 
 ##      For each of the #includes in the out_of_date header file
 ##      create a corresponding %import directive.
-      outer:
+    outer:
         foreach ( split /^/, $raw_contents ) {
 
             #TODO: Rebuild multi line pp directives?
@@ -269,8 +259,7 @@ sub process_file() {
                     or $file_name =~ /trick_utils/
                     or $file_name =~ /trick\// )
                 {
-                    $contents .= "\%import(module=\"sim_services\") \"trick/"
-                      . basename($file_name) . "\"\n";
+                    $contents .= "\%import(module=\"sim_services\") \"trick/" . basename($file_name) . "\"\n";
                     next;
                 }
 
@@ -287,7 +276,7 @@ sub process_file() {
 
                 # Get the canonical path (resolve ., .., and symbolic links)
                 $file_name =
-                  abs_path( dirname($file_name) ) . "/" . basename($file_name);
+                    abs_path( dirname($file_name) ) . "/" . basename($file_name);
 
                 # Skip excluded paths
                 foreach my $i ( @exclude_paths, @swig_exclude_paths ) {
@@ -364,8 +353,8 @@ sub process_file() {
         print OUT "\n$new_contents";
         print OUT "$contents\n";
 
-# Add a trick_cast_as macro line for each class parsed in the file.  These lines must appear at the bottom of the
-# file to ensure they are not in a namespace directive and they are after the #define statements they depend on.
+       # Add a trick_cast_as macro line for each class parsed in the file.  These lines must appear at the bottom of the
+       # file to ensure they are not in a namespace directive and they are after the #define statements they depend on.
         undef %class_typemap_printed;
         foreach my $c (@class_names) {
             if ( !exists $class_typemap_printed{$c} ) {
@@ -422,8 +411,7 @@ sub usage() {
 ##
 
 sub process_contents($$$$) {
-    my ( $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref )
-      = @_;
+    my ( $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref ) = @_;
 
     while (
         $$contents_ref =~ s/^(.*?)(?:($typedef_struct)|
@@ -432,7 +420,7 @@ sub process_contents($$$$) {
                                     ($namespace_def)|
                                     ($enum_class_def)|
                                     ($class_def))//sx
-      )
+        )
     {
         my ($non_var)                     = $1;
         my ($typedef_struct_string)       = $2;
@@ -451,18 +439,14 @@ sub process_contents($$$$) {
 ## Handle the case of: typedef_struct ==> typedef (struct | union ) <name> '{' ...
 ##
         if ( $typedef_struct_string ne "" ) {
-            process_typedef_struct(
-                $typedef_struct_string, $contents_ref,
-                $new_contents_ref,      $curr_namespace,
-                $class_names_ref
-            );
+            process_typedef_struct( $typedef_struct_string, $contents_ref, $new_contents_ref, $curr_namespace,
+                $class_names_ref );
         }
 ##
 ## Handle the case of: typedef_struct ==> typedef const (struct | union ) <name> '{' ...
 ##
         if ( $typedef_const_struct_string ne "" ) {
-            process_typedef_const_struct( $typedef_const_struct_string,
-                $contents_ref );
+            process_typedef_const_struct( $typedef_const_struct_string, $contents_ref );
         }
 ##
 ## Handle the case of: template_def ==> template '<' <template-parameters> '>' class <class-name> ...
@@ -476,10 +460,7 @@ sub process_contents($$$$) {
 ## Handle the case of: namespace_def ==> namespace <name>
 ##
         if ( $namespace_string ne "" ) {
-            process_namespace(
-                $namespace_string, $contents_ref, $new_contents_ref,
-                $curr_namespace,   $class_names_ref
-            );
+            process_namespace( $namespace_string, $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref );
         }
 ##
 ##  Handle the case of: class_def ==> enum class <enum-name> ( '{' | ':' )
@@ -492,10 +473,7 @@ sub process_contents($$$$) {
 ##  Handle the case of: class_def ==> ( class | struct ) <class-name> ( '{' | ':' )
 ##
         if ( $class_string ne "" ) {
-            process_class(
-                $class_string,   $contents_ref, $new_contents_ref,
-                $curr_namespace, $class_names_ref
-            );
+            process_class( $class_string, $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref );
         }
     }
 }
@@ -525,7 +503,7 @@ sub process_template($$) {
 # Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper class attribute assingment in input processor
 # The function call is inserted after the 1st { of the class template so it is placed at the top
     $$contents_ref =~
-s/{\n/{\n\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n/m;
+        s/{\n/{\n\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n/m;
     if ( $$contents_ref =~ s/^(\s*;)//s ) {
         $$new_contents_ref .= $1;
     }
@@ -535,8 +513,7 @@ s/{\n/{\n\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swi
         $$new_contents_ref .= $1;
 
         # grab the rest of the template
-        ( $extracted, $$contents_ref ) =
-          extract_bracketed( "{" . $$contents_ref, "{}" );
+        ( $extracted, $$contents_ref ) = extract_bracketed( "{" . $$contents_ref, "{}" );
 
         # remove added extra opening "brace"
         $extracted =~ s/^\{//;
@@ -581,10 +558,7 @@ s/{\n/{\n\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swi
 ## process_contents()
 ##
 sub process_namespace($$$$$) {
-    my (
-        $namespace_string, $contents_ref, $new_contents_ref,
-        $curr_namespace,   $class_names_ref
-    ) = @_;
+    my ( $namespace_string, $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref ) = @_;
     my $extracted;
     my ($namespace_name);
 
@@ -600,8 +574,7 @@ sub process_namespace($$$$$) {
     ( $extracted, $$contents_ref ) = extract_bracketed( $$contents_ref, "{}" );
 
     # Process the contents of the namespace
-    process_contents( \$extracted, $new_contents_ref, $namespace_name,
-        $class_names_ref );
+    process_contents( \$extracted, $new_contents_ref, $namespace_name, $class_names_ref );
 
     # Append whatever wasn't matched in process contents to the new file.
     $$new_contents_ref .= $extracted;
@@ -636,10 +609,7 @@ sub process_namespace($$$$$) {
 ## <func-depend name="extract_bracketed">
 
 sub process_class($$$$$) {
-    my (
-        $class_string,   $contents_ref, $new_contents_ref,
-        $curr_namespace, $class_names_ref
-    ) = @_;
+    my ( $class_string, $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref ) = @_;
 
     my $extracted;
     my ($class_name);
@@ -647,8 +617,7 @@ sub process_class($$$$$) {
     my @unqualified_template_typedefs;
 
 ## Extract the class_name from the class_string
-    $class_string =~
-      /^(?:class|struct)\s+               # keyword class or struct
+    $class_string =~ /^(?:class|struct)\s+               # keyword class or struct
                       ([_A-Za-z]\w*)                     # class name
                       \s*[\{\:]$
                      /sx or die "Internal error";
@@ -662,10 +631,9 @@ sub process_class($$$$$) {
 
 # Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper class attribute assingment in input processor
     $my_class_contents .=
-"\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n";
+        "\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n";
 
-    ( $extracted, $$contents_ref ) =
-      extract_bracketed( "{" . $$contents_ref, "{}" );
+    ( $extracted, $$contents_ref ) = extract_bracketed( "{" . $$contents_ref, "{}" );
 
     # remove the trailing semicolon because we may append text to the class.
     $$contents_ref =~ s/^\s*;//s;
@@ -681,8 +649,8 @@ sub process_class($$$$$) {
 
     my $isSwigExcludeBlock = 0;
 
-  # templated variables need to be declared with the SWIG %template directive.
-  # This loop looks for any templated variables and creates the %template lines.
+    # templated variables need to be declared with the SWIG %template directive.
+    # This loop looks for any templated variables and creates the %template lines.
     while ( $extracted =~ s/^(.*?)(?:($template_var_def))//sx ) {
         my ($non_var)              = $1;
         my ($template_var_def_str) = $2;
@@ -694,16 +662,13 @@ sub process_class($$$$$) {
             my $ifndefSwig = $non_var;
             my $moreNonVar = 1;
 
-# search for all instances of #ifndef SWIG, #if !defined(SWIG), and #endif prior to template variable
-# update $isSwigExcludeBlock to the last instance*
-# exit when no match is found
-# *  this script does not track preprocessor scope, so any #endif will set $isSwigExcludeBlock to 0
-#    in other words we don't support SWIGing nested preprocessor if statements, use at your peril
+            # search for all instances of #ifndef SWIG, #if !defined(SWIG), and #endif prior to template variable
+            # update $isSwigExcludeBlock to the last instance*
+            # exit when no match is found
+            # *  this script does not track preprocessor scope, so any #endif will set $isSwigExcludeBlock to 0
+            #    in other words we don't support SWIGing nested preprocessor if statements, use at your peril
             while ( $moreNonVar == 1 ) {
-                if ( $ifndefSwig =~
-s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)//
-                  )
-                {
+                if ( $ifndefSwig =~ s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)// ) {
                     if ( $1 ne "" or $2 ne "" ) {
                         $isSwigExcludeBlock = 1;
                     }
@@ -736,56 +701,53 @@ s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)//
                         or ( !$stls and !exists $all_stl_names{$template_type} )
                     )
                     and $template_full_type !~ /(std::)?wstring/
-                  )
+                    )
                 {
 
                     my ($template_type_no_sp) = $template_full_type;
                     $template_type_no_sp =~ s/\s//g;
 
-                 #print "*** template_type_no_sp = $template_type_no_sp ***\n" ;
+                    #print "*** template_type_no_sp = $template_type_no_sp ***\n" ;
                     if ( !exists $processed_templates{$template_type_no_sp} ) {
 
                         my $sanitized_namespace = $curr_namespace =~ s/:/_/gr;
-                        my $identifier =
-                          "${sanitized_namespace}${class_name}_${var_name}";
-                        my $trick_swig_template =
-                          "TRICK_SWIG_TEMPLATE_$identifier";
+                        my $identifier          = "${sanitized_namespace}${class_name}_${var_name}";
+                        my $trick_swig_template = "TRICK_SWIG_TEMPLATE_$identifier";
 
                         # Insert template directive immediately before instance
                         # This is required as of SWIG 4
                         my $typedef = "\n#ifndef $trick_swig_template\n";
                         $typedef .= "#define $trick_swig_template\n";
-                        $typedef .=
-                          "\%template($identifier) $template_full_type;\n";
+                        $typedef .= "\%template($identifier) $template_full_type;\n";
                         $typedef .= "#endif\n";
 
-      # A SWIG %template directive must:
-      # 1. Appear before each template instantiation
-      # 2. Be in scope where the instantiation is declared
-      # 3. Not be enclosed within a different namespace
-      #
-      # See https://www.swig.org/Doc4.2/SWIGPlus.html#SWIGPlus_template_scoping
-      #
-      # Generally, convert_swig is not smart enough to put all %template
-      # directives in the right scope because:
-      # 1. We do not keep track of what scope each type we encounter is
-      #    declared in.
-      # 2. We cannot easily add %template directives to already-processed
-      #    scopes.
-      #
-      # As a compromise:
-      # 1. For an unqualified template instantiation, the template declaration
-      #    is necessarily in the current or a containing scope. Hope it's in the
-      #    current namespace and put the %template directive there. This will
-      #    create invalid SWIG input code for templates declared in a containing
-      #    namespace and for member templates declared in this class.
-      # 2. For a qualified template instantiation, the template declaration is
-      #    in a (possibly nested) scope contained by the current or a containing
-      #    scope. Assume the instantiation is fully qualified and put it in the
-      #    global namespace. This will create invalid SWIG code for partially-
-      #    qualified instantiations.
-      #
-      # See https://github.com/nasa/trick/issues/768
+                        # A SWIG %template directive must:
+                        # 1. Appear before each template instantiation
+                        # 2. Be in scope where the instantiation is declared
+                        # 3. Not be enclosed within a different namespace
+                        #
+                        # See https://www.swig.org/Doc4.2/SWIGPlus.html#SWIGPlus_template_scoping
+                        #
+                        # Generally, convert_swig is not smart enough to put all %template
+                        # directives in the right scope because:
+                        # 1. We do not keep track of what scope each type we encounter is
+                        #    declared in.
+                        # 2. We cannot easily add %template directives to already-processed
+                        #    scopes.
+                        #
+                        # As a compromise:
+                        # 1. For an unqualified template instantiation, the template declaration
+                        #    is necessarily in the current or a containing scope. Hope it's in the
+                        #    current namespace and put the %template directive there. This will
+                        #    create invalid SWIG input code for templates declared in a containing
+                        #    namespace and for member templates declared in this class.
+                        # 2. For a qualified template instantiation, the template declaration is
+                        #    in a (possibly nested) scope contained by the current or a containing
+                        #    scope. Assume the instantiation is fully qualified and put it in the
+                        #    global namespace. This will create invalid SWIG code for partially-
+                        #    qualified instantiations.
+                        #
+                        # See https://github.com/nasa/trick/issues/768
 
                         if ( $isSwigExcludeBlock == 0 ) {
                             if ( $template_full_type =~ /^\w*(::\w+)+</ ) {
@@ -831,14 +793,14 @@ s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)//
         }
     }
 
-# write the class contents and semicolon to ensure any template declarations below are after the semicolon.
+    # write the class contents and semicolon to ensure any template declarations below are after the semicolon.
     $$new_contents_ref .= "\n" . $my_class_contents . $extracted . ";\n";
 
     my $c_ = "$curr_namespace$class_name";
     $c_ =~ s/\:/_/g;
 
-# Add a #define line that signals that this class has been processed by swig. Classes excluded in #if 0 blocks will
-# not have this #define defined.
+    # Add a #define line that signals that this class has been processed by swig. Classes excluded in #if 0 blocks will
+    # not have this #define defined.
     $$new_contents_ref .= "#define TRICK_SWIG_DEFINED_$c_";
 }
 
@@ -875,10 +837,7 @@ s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)//
 ##
 sub process_typedef_struct($$$$$) {
 
-    my (
-        $typedef_struct_string, $contents_ref, $new_contents_ref,
-        $curr_namespace,        $class_names_ref
-    ) = @_;
+    my ( $typedef_struct_string, $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref ) = @_;
 
     my $extracted;
     my ( $tail, $my_struct_contents, $struct_names, @struct_names );
@@ -887,13 +846,11 @@ sub process_typedef_struct($$$$$) {
 
     $$new_contents_ref .= $typedef_struct_string;
 
-    $typedef_struct_string =~
-      s/((?:typedef\s+)?(struct|union)\s*   # the words typedef struct|union
+    $typedef_struct_string =~ s/((?:typedef\s+)?(struct|union)\s*   # the words typedef struct|union
          ([_A-Za-z]\w*)?\s*                                         # optional name
          {)//sx;
 
-    ( $extracted, $$contents_ref ) =
-      extract_bracketed( "{" . $$contents_ref, "{}" );
+    ( $extracted, $$contents_ref ) = extract_bracketed( "{" . $$contents_ref, "{}" );
 
     #print "*** extracted = $extracted ***\n" ;
 
@@ -913,11 +870,11 @@ sub process_typedef_struct($$$$$) {
 
 # Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper struct attribute assingment in input processor
             $my_struct_contents .=
-"\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    if '$s' in globals():\n        $s.__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n";
+                "\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    if '$s' in globals():\n        $s.__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n";
 
-   # Generate the same define that process_class generates so the #ifdef-guarded
-   # %trick_cast_as() at the bottom of the .i file generates a cast helper
-   # with the fully-qualified type name (e.g. peer::Leek * castAspeer__Leek).
+            # Generate the same define that process_class generates so the #ifdef-guarded
+            # %trick_cast_as() at the bottom of the .i file generates a cast helper
+            # with the fully-qualified type name (e.g. peer::Leek * castAspeer__Leek).
             my $c_ = "${curr_namespace}${s}";
             $c_ =~ s/\:/_/g;
             $my_struct_contents .= "\n#define TRICK_SWIG_DEFINED_$c_";
@@ -943,8 +900,7 @@ sub process_typedef_const_struct($$$$) {
     my ( $typedef_const_struct_string, $contents_ref ) = @_;
     my $extracted;
 
-    ( $extracted, $$contents_ref ) =
-      extract_bracketed( "{" . $$contents_ref, "{}" );
+    ( $extracted, $$contents_ref ) = extract_bracketed( "{" . $$contents_ref, "{}" );
     $$contents_ref =~ s/^(\s*([\w,\s\*]+)?\s*;)//sx;
 
 }

--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -361,10 +361,7 @@ sub process_file() {
                 my $c_ = $c;
                 $c_ =~ s/\:/_/g;
                 print OUT "#ifdef TRICK_SWIG_DEFINED_$c_\n";
-                print OUT "#ifndef TRICK_SWIG_CAST_DEFINED_$c_\n";
-                print OUT "#define TRICK_SWIG_CAST_DEFINED_$c_\n";
                 print OUT "\%trick_cast_as($c, $c_)\n";
-                print OUT "#endif\n";
                 print OUT "#endif\n";
                 $class_typemap_printed{$c} = 1;
             }

--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -353,7 +353,10 @@ sub process_file() {
                 my $c_ = $c ;
                 $c_ =~ s/\:/_/g ;
                 print OUT "#ifdef TRICK_SWIG_DEFINED_$c_\n" ;
+                print OUT "#ifndef TRICK_SWIG_CAST_DEFINED_$c_\n" ;
+                print OUT "#define TRICK_SWIG_CAST_DEFINED_$c_\n" ;
                 print OUT "\%trick_cast_as($c, $c_)\n" ;
+                print OUT "#endif\n" ;
                 print OUT "#endif\n" ;
                 $class_typemap_printed{$c} = 1 ;
             }

--- a/libexec/trick/convert_swig
+++ b/libexec/trick/convert_swig
@@ -1,22 +1,22 @@
 #!/usr/bin/perl
 
 use FindBin qw($RealBin);
-use strict ;
+use strict;
 use Getopt::Long;
 use Pod::Usage;
 use Pod::Text;
 use Text::Balanced qw ( extract_bracketed );
-use lib "$RealBin/pm" ;
-use File::Basename ;
-use Cwd 'abs_path' ;
-use gte ;
-use trick_version ;
-use Digest::MD5 qw(md5_hex) ;
-use File::Path qw(make_path) ;
-use html ;
-use get_paths ;
-use verbose_build ;
-use parse_s_define 'index_comments' ;
+use lib "$RealBin/pm";
+use File::Basename;
+use Cwd 'abs_path';
+use gte;
+use trick_version;
+use Digest::MD5 qw(md5_hex);
+use File::Path  qw(make_path);
+use html;
+use get_paths;
+use verbose_build;
+use parse_s_define 'index_comments';
 
 ##
 ## ================================================================================
@@ -29,7 +29,7 @@ use parse_s_define 'index_comments' ;
 ## languagues such as Perl and Python.
 ##
 
-my $usage="
+my $usage = "
 Name:
     convert_swig - Convert a C/C++ header file into a SWIG interface file.
                    SWIG (Simplified Wrapper and Interface Generator) is an
@@ -48,117 +48,126 @@ Usage:
 Examples:
     % convert_swig include/Ball.hh
     % convert_swig S_source.hh
-" ;
+";
 
+my $help = '';    # option variable with default value (false)
+my $stls = 0;     # option variable with default value (false)
 
-my $help = '';  # option variable with default value (false)
-my $stls = 0;  # option variable with default value (false)
-
-my %sim ;
-my %out_of_date ;
-my ($version, $thread, $year) ;
-my %processed_templates ;
+my %sim;
+my %out_of_date;
+my ( $version, $thread, $year );
+my %processed_templates;
 
 my $typedef_def = qr/typedef\s+                            # the word typedef
                (?:[_A-Za-z][\s\w]*\s*)                     # resolved type
                (?:[_A-Za-z]\w*)                            # new type
                \s*;                                        # semicolon
-             /sx ;
+             /sx;
 
-my $typedef_enum_def = qr/typedef\s+enum\s*                # the words typedef enum
+my $typedef_enum_def =
+  qr/typedef\s+enum\s*                # the words typedef enum
                (?:\s+[_A-Za-z]\w*)?\s*                     # optional name
                {(?:\s*\d+\s*)*                             # opening brace and possible comments
                (?:.*?}\s*                                  # everything to closing brace
                [\w,\s\*]*\s*;)                             # enum name and ;
-             /sx ;
+             /sx;
 
-my $typedef_const_struct  = qr/typedef\s+const\s+(?:struct|union)\s*     # the words typedef const struct|union
+my $typedef_const_struct =
+qr/typedef\s+const\s+(?:struct|union)\s*     # the words typedef const struct|union
                (?:\s+[_A-Za-z]\w*)?\s*                     # optional name
                {                                           # opening brace
-             /sx ;
-my $typedef_struct  = qr/typedef\s+(?:struct|union)\s*     # the words typedef struct|union
+             /sx;
+my $typedef_struct =
+  qr/typedef\s+(?:struct|union)\s*     # the words typedef struct|union
                (?:\s+[_A-Za-z]\w*)?\s*                     # optional name
                {                                           # opening brace
-             /sx ;
+             /sx;
 my $namespace_def = qr/namespace\s*                        # keyword namespace
              (?:\s+[_A-Za-z]\w*)                           # class name
-            /sx ;
-my $enum_class_def   = qr/enum\s+(?:class|struct)\s*       # keywords enum_class or struct (alias to enum class)
+            /sx;
+my $enum_class_def =
+qr/enum\s+(?:class|struct)\s*       # keywords enum_class or struct (alias to enum class)
                (?:\s+[_A-Za-z]\w*)\s*                      # class or struct name
                (?:\{|:(?!\:))                              # { or punctuator :
-             /sx ;
-my $class_def   = qr/(?:class|struct)\s*                   # keyword class or struct
+             /sx;
+my $class_def =
+  qr/(?:class|struct)\s*                   # keyword class or struct
                (?:\s+[_A-Za-z]\w*)\s*                      # class name
                (?:\{|:(?!\:))                              # { or punctuator :
-             /sx ;
-my $template_def   = qr/template\s*                        # keyword template
+             /sx;
+my $template_def = qr/template\s*                        # keyword template
             <[^{]*?>\s*                                    # template parameters (no { to avoid spanning namespaces)
             (?:class|struct)                               # keyword class or struct
             \s+[_A-Za-z]\w*\s*                             # class name
-               /sx ;
-my $template_var_def  = qr/(?:\:\:)?[_A-Za-z][:\w]*\s*     # template name
+               /sx;
+my $template_var_def = qr/(?:\:\:)?[_A-Za-z][:\w]*\s*     # template name
             <[\w\s\*,:<>\[\]]*>\s*                         # template parameters
             [_A-Za-z]\w*\s*(?:[{=].*?)?;                   # var name ;
-               /sx ;
+               /sx;
 
 # This list is the list of all STL types to ignore.
-my %all_stl_names = qw(vector 1 list 1 deque 1 set 1 multiset 1 map 1 unordered_map 1 multimap 1 hash_set 1
-     hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
-     array 1
-     std::vector 1 std::list 1 std::deque 1 std::set 1 std::multiset 1 std::map 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
-     std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
-     std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1) ;
+my %all_stl_names =
+  qw(vector 1 list 1 deque 1 set 1 multiset 1 map 1 unordered_map 1 multimap 1 hash_set 1
+  hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
+  array 1
+  std::vector 1 std::list 1 std::deque 1 std::set 1 std::multiset 1 std::map 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
+  std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
+  std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1);
 
 # This is a partial list of STL types to ignore.  We do not ignore vector, map, list if we allow STLs
-my %stl_names = qw(deque 1 set 1 multiset 1 unordered_map 1 multimap 1 hash_set 1
-     hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
-     array 1
-     std::deque 1 std::set 1 std::multiset 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
-     std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
-     std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1) ;
+my %stl_names =
+  qw(deque 1 set 1 multiset 1 unordered_map 1 multimap 1 hash_set 1
+  hash_multiset 1 hash_map 1 hash_multimap 1 stack 1 queue 1 priority_queue 1 bitset 1 auto_ptr 1
+  array 1
+  std::deque 1 std::set 1 std::multiset 1 std::unordered_map 1 std::multimap 1 std::hash_set 1
+  std::hash_multiset 1 std::hash_map 1 std::hash_multimap 1 std::stack 1 std::queue 1 std::priority_queue 1
+  std::bitset 1 std::auto_ptr 1 pair 1 std::pair 1 std::tr1::shared_ptr 1 std::array 1);
 
-Getopt::Long::Configure ("bundling");
-GetOptions ( "stl|s" => sub { $stls = 1 } ,
-             'help|h' => \$help ) or usage() ;
+Getopt::Long::Configure("bundling");
+GetOptions(
+    "stl|s"  => sub { $stls = 1 },
+    'help|h' => \$help
+) or usage();
 
-if ( $help ) {
-    usage() ;
+if ($help) {
+    usage();
 }
 
-($version, $thread) = get_trick_version() ;
-($year) = $version =~ /^(\d+)/ ;
+( $version, $thread ) = get_trick_version();
+($year) = $version =~ /^(\d+)/;
 
-my @include_dirs       = get_include_paths() ;
-my @defines            = get_defines() ;
-my @exclude_paths      = get_paths("TRICK_EXCLUDE") ;
-my @swig_exclude_paths = get_paths("TRICK_SWIG_EXCLUDE") ;
+my @include_dirs       = get_include_paths();
+my @defines            = get_defines();
+my @exclude_paths      = get_paths("TRICK_EXCLUDE");
+my @swig_exclude_paths = get_paths("TRICK_SWIG_EXCLUDE");
 
 if ( "$ENV{'TRICK_CFLAGS'} $ENV{'TRICK_CXXFLAGS'}" !~ /DTRICK_VER=/ ) {
-    push @defines , "-DTRICK_VER=$year" ;
+    push @defines, "-DTRICK_VER=$year";
 }
 
 if ( scalar @ARGV == 0 ) {
-    my ($s_library_swig) = "build/S_library_swig" ;
-    open FILE_LIST, $s_library_swig or die "Could not open $s_library_swig" ;
-    while ( <FILE_LIST> ) {
-        chomp ;
+    my ($s_library_swig) = "build/S_library_swig";
+    open FILE_LIST, $s_library_swig or die "Could not open $s_library_swig";
+    while (<FILE_LIST>) {
+        chomp;
 
-        my ($f) = $_ ;
-        my ($swig_dir , $base_file , $swig_file ) ;
+        my ($f) = $_;
+        my ( $swig_dir, $base_file, $swig_file );
 
-        $base_file = basename($f) ;
-        $base_file =~ s/\.[^\.]+$// ;
+        $base_file = basename($f);
+        $base_file =~ s/\.[^\.]+$//;
 
-        $swig_dir = dirname($f) ;
-        $swig_dir = "build/$swig_dir" ;
-        $swig_file = "$swig_dir/${base_file}_py.i" ;
+        $swig_dir  = dirname($f);
+        $swig_dir  = "build/$swig_dir";
+        $swig_file = "$swig_dir/${base_file}_py.i";
 
         #print "$swig_file\n" ;
-        $out_of_date{$f} = 1 ;
+        $out_of_date{$f} = 1;
     }
-} else {
+}
+else {
     #print "HERE I AM @ARGV\n" ;
-    map { $out_of_date{$_} = 1 } @ARGV ;
+    map { $out_of_date{$_} = 1 } @ARGV;
 }
 
 ## The global hash %out_of_date represents a list of header files whose
@@ -166,13 +175,13 @@ if ( scalar @ARGV == 0 ) {
 ##
 
 if ( scalar keys %out_of_date == 0 ) {
-    exit ;
+    exit;
 }
 
 ## Finally, call process_file() to create SWIG interface files for each of the out_of_date headers.
 ##
 
-process_file() ;
+process_file();
 
 ##
 ## ================================================================================
@@ -196,114 +205,124 @@ sub process_file() {
 
     foreach my $f ( keys %out_of_date ) {
 
-        my @class_names ;
-        my ($raw_contents , $contents , $new_contents ) ;
-        my ($curr_dir) ;
+        my @class_names;
+        my ( $raw_contents, $contents, $new_contents );
+        my ($curr_dir);
 
-        next if ( $f =~ /^$ENV{TRICK_HOME}\/include/ ) ;
-        next if ( $f =~ /^$ENV{TRICK_HOME}\/trick_source/ ) ;
+        next if ( $f =~ /^$ENV{TRICK_HOME}\/include/ );
+        next if ( $f =~ /^$ENV{TRICK_HOME}\/trick_source/ );
 
         # clear the processed templates per each file
-        undef %processed_templates ;
+        undef %processed_templates;
 
 ##      Read in the entire file contents into raw_contents.
-        open IN_FILE, $f ;
-        local $/ ;
-        $raw_contents = <IN_FILE> ;
+        open IN_FILE, $f;
+        local $/;
+        $raw_contents = <IN_FILE>;
 
         # remove all comments, they can cause all kinds of trouble
         # leave the line continuation character if present
-        my @file_contents = split ("\n", $raw_contents);
+        my @file_contents = split( "\n", $raw_contents );
         foreach my $line (@file_contents) {
-           $line = "$line\n";
+            $line = "$line\n";
         }
 
-        my @comment_sections = index_comments( @file_contents );
-        for(my $idx = @comment_sections-2 ; $idx >= 0 ; $idx-=2) {
-            my $comment_length = @comment_sections[$idx+1] - @comment_sections[$idx] + 1;
+        my @comment_sections = index_comments(@file_contents);
+        for ( my $idx = @comment_sections - 2 ; $idx >= 0 ; $idx -= 2 ) {
+            my $comment_length =
+              @comment_sections[ $idx + 1 ] - @comment_sections[$idx] + 1;
             substr $raw_contents, @comment_sections[$idx], $comment_length, "";
         }
 
 ##      The init_attr functions cause problems when we try and wrap them with SWIG.
 ##      We can safely remove them from the header files.
 ##      Remove the friend init_attr functions that appear in multiline define statements
-        $raw_contents =~ s/\\\n\s*friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg ;
+        $raw_contents =~
+          s/\\\n\s*friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg;
 ##      Remove the friend init_attr functions outside of multiline define statements
-        $raw_contents =~ s/friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg ;
+        $raw_contents =~
+          s/friend\s+void\s+init_attr[^(]+\s*\(\s*\)(\s*);?/$1/sg;
+
         #$raw_contents =~ s/friend\s+void\s+init_attr[^;]+;//sg ;
-        $raw_contents =~ s/__const/const/sg ;
+        $raw_contents =~ s/__const/const/sg;
 
 ##      For each of the #includes in the out_of_date header file
 ##      create a corresponding %import directive.
-        outer:
-        foreach (split /^/, $raw_contents) {
+      outer:
+        foreach ( split /^/, $raw_contents ) {
+
             #TODO: Rebuild multi line pp directives?
-            if ( /^\s*\#\s*include\s+([^\n]+)/ ) {
-                my $file_name = $1 ;
+            if (/^\s*\#\s*include\s+([^\n]+)/) {
+                my $file_name = $1;
 
                 # strip trailing whitespace
-                $file_name =~ s/\s+$// ;
+                $file_name =~ s/\s+$//;
 
                 # ignore <> includes
                 if ( $file_name =~ /\</ ) {
-                    next ;
+                    next;
                 }
 
                 # normalize trick includes
-                $file_name =~ s/"//g ;
-                if ( $file_name =~ /sim_services/ or $file_name =~ /trick_utils/ or $file_name =~ /trick\//)  {
-                    $contents .= "\%import(module=\"sim_services\") \"trick/" . basename($file_name) . "\"\n" ;
-                    next ;
+                $file_name =~ s/"//g;
+                if (   $file_name =~ /sim_services/
+                    or $file_name =~ /trick_utils/
+                    or $file_name =~ /trick\// )
+                {
+                    $contents .= "\%import(module=\"sim_services\") \"trick/"
+                      . basename($file_name) . "\"\n";
+                    next;
                 }
 
                 # Convert relative paths to absolute paths
                 if ( $file_name !~ /^\// ) {
-                    foreach my $i ( dirname($f) , @include_dirs ) {
-                        my $candidate_path = "$i/$file_name" ;
+                    foreach my $i ( dirname($f), @include_dirs ) {
+                        my $candidate_path = "$i/$file_name";
                         if ( -e $candidate_path ) {
-                            $file_name = $candidate_path ;
-                            last ;
+                            $file_name = $candidate_path;
+                            last;
                         }
                     }
                 }
 
                 # Get the canonical path (resolve ., .., and symbolic links)
-                $file_name = abs_path(dirname($file_name)) . "/" . basename($file_name) ;
-
+                $file_name =
+                  abs_path( dirname($file_name) ) . "/" . basename($file_name);
 
                 # Skip excluded paths
                 foreach my $i ( @exclude_paths, @swig_exclude_paths ) {
                     if ( $file_name =~ /^\Q$i/ ) {
-                        next outer ;
+                        next outer;
                     }
                 }
-                $file_name = "build" . $file_name ;
-                $file_name =~ s/\.[^\.]+?$/\_py.i/ ;
-                $contents .= "\%import \"$file_name\"\n" ;
-            } else {
-                $contents .= $_ ;
+                $file_name = "build" . $file_name;
+                $file_name =~ s/\.[^\.]+?$/\_py.i/;
+                $contents .= "\%import \"$file_name\"\n";
+            }
+            else {
+                $contents .= $_;
             }
         }
 
 ##      Process the contents of the out_of_date header file to create the corresponding SWIG interface.
 
-        process_contents( \$contents , \$new_contents , "" , \@class_names ) ;
+        process_contents( \$contents, \$new_contents, "", \@class_names );
 
 ##      Generate a module name and path for the SWIG interface file.
 
-        my $md5_sum = md5_hex($f) ;
+        my $md5_sum = md5_hex($f);
 
-        my ($out_dir) = dirname($f) ;
-        $out_dir = "build$out_dir" ;
+        my ($out_dir) = dirname($f);
+        $out_dir = "build$out_dir";
 
-        my $out_file ;
-        $out_file = basename($f) ;
-        $out_file =~ s/(\.h|\.H|\.hh|\.h\+\+|\.hxx|\.hpp)$/_py\.i/ ;
+        my $out_file;
+        $out_file = basename($f);
+        $out_file =~ s/(\.h|\.H|\.hh|\.h\+\+|\.hxx|\.hpp)$/_py\.i/;
 
-        $out_file = "$out_dir/${out_file}" ;
+        $out_file = "$out_dir/${out_file}";
 
-        if ( ! -e $out_dir ) {
-            make_path($out_dir) ;
+        if ( !-e $out_dir ) {
+            make_path($out_dir);
         }
 
 ##      Open the SWIG interface file.
@@ -316,11 +335,11 @@ sub process_file() {
 ##      Write the SWIG interface code (processed header file) and the header file contents.
 ##      Close the SWIG interface file.
 
-        open OUT, ">$out_file" ;
+        open OUT, ">$out_file";
 
-        print OUT "\%module m$md5_sum\n\n" ;
+        print OUT "\%module m$md5_sum\n\n";
 
-        print OUT "%include \"trick/swig/trick_swig.i\"\n\n" ;
+        print OUT "%include \"trick/swig/trick_swig.i\"\n\n";
 
         print OUT "
 \%insert(\"begin\") \%{
@@ -330,47 +349,47 @@ sub process_file() {
 
 \%{
 #include \"$f\"
-\%}\n" ;
+\%}\n";
 
-        print OUT "\n" ;
-        my %class_typemap_printed ;
-        foreach my $c ( @class_names ) {
-            if ( ! exists $class_typemap_printed{$c} ) {
-                my $c_ = $c ;
-                $c_ =~ s/\:/_/g ;
-                print OUT "\%trick_swig_class_typemap($c, $c_)\n" ;
-                $class_typemap_printed{$c} = 1 ;
+        print OUT "\n";
+        my %class_typemap_printed;
+        foreach my $c (@class_names) {
+            if ( !exists $class_typemap_printed{$c} ) {
+                my $c_ = $c;
+                $c_ =~ s/\:/_/g;
+                print OUT "\%trick_swig_class_typemap($c, $c_)\n";
+                $class_typemap_printed{$c} = 1;
             }
         }
-        print OUT "\n$new_contents" ;
-        print OUT "$contents\n" ;
+        print OUT "\n$new_contents";
+        print OUT "$contents\n";
 
-        # Add a trick_cast_as macro line for each class parsed in the file.  These lines must appear at the bottom of the
-        # file to ensure they are not in a namespace directive and they are after the #define statements they depend on.
-        undef %class_typemap_printed ;
-        foreach my $c ( @class_names ) {
-            if ( ! exists $class_typemap_printed{$c} ) {
-                my $c_ = $c ;
-                $c_ =~ s/\:/_/g ;
-                print OUT "#ifdef TRICK_SWIG_DEFINED_$c_\n" ;
-                print OUT "#ifndef TRICK_SWIG_CAST_DEFINED_$c_\n" ;
-                print OUT "#define TRICK_SWIG_CAST_DEFINED_$c_\n" ;
-                print OUT "\%trick_cast_as($c, $c_)\n" ;
-                print OUT "#endif\n" ;
-                print OUT "#endif\n" ;
-                $class_typemap_printed{$c} = 1 ;
+# Add a trick_cast_as macro line for each class parsed in the file.  These lines must appear at the bottom of the
+# file to ensure they are not in a namespace directive and they are after the #define statements they depend on.
+        undef %class_typemap_printed;
+        foreach my $c (@class_names) {
+            if ( !exists $class_typemap_printed{$c} ) {
+                my $c_ = $c;
+                $c_ =~ s/\:/_/g;
+                print OUT "#ifdef TRICK_SWIG_DEFINED_$c_\n";
+                print OUT "#ifndef TRICK_SWIG_CAST_DEFINED_$c_\n";
+                print OUT "#define TRICK_SWIG_CAST_DEFINED_$c_\n";
+                print OUT "\%trick_cast_as($c, $c_)\n";
+                print OUT "#endif\n";
+                print OUT "#endif\n";
+                $class_typemap_printed{$c} = 1;
             }
         }
-        close OUT ;
+        close OUT;
 
-        print "[34mWriting[0m    $out_file\n" if not verbose_build() ;
+        print "[34mWriting[0m    $out_file\n" if not verbose_build();
     }
 
 }
 
 sub usage() {
-    print "$usage\n" ;
-    exit ;
+    print "$usage\n";
+    exit;
 }
 
 ## ================================================================================
@@ -403,67 +422,80 @@ sub usage() {
 ##
 
 sub process_contents($$$$) {
-    my ( $contents_ref , $new_contents_ref , $curr_namespace , $class_names_ref ) = @_ ;
+    my ( $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref )
+      = @_;
 
-    while ( $$contents_ref =~ s/^(.*?)(?:($typedef_struct)|
+    while (
+        $$contents_ref =~ s/^(.*?)(?:($typedef_struct)|
                                     ($typedef_const_struct)|
                                     ($template_def)|
                                     ($namespace_def)|
                                     ($enum_class_def)|
-                                    ($class_def))//sx ) {
-        my ( $non_var ) = $1 ;
-        my ( $typedef_struct_string ) = $2 ;
-        my ( $typedef_const_struct_string ) = $3 ;
-        my ( $template_string ) = $4 ;
-        my ( $namespace_string ) = $5 ;
-        my ( $enum_class_string ) = $6 ;
-        my ( $class_string ) = $7 ;
+                                    ($class_def))//sx
+      )
+    {
+        my ($non_var)                     = $1;
+        my ($typedef_struct_string)       = $2;
+        my ($typedef_const_struct_string) = $3;
+        my ($template_string)             = $4;
+        my ($namespace_string)            = $5;
+        my ($enum_class_string)           = $6;
+        my ($class_string)                = $7;
 
 ## Handle the case of: non_var
-        if ( $non_var ne "" )  {
-            $$new_contents_ref .= $non_var ;
+        if ( $non_var ne "" ) {
+            $$new_contents_ref .= $non_var;
         }
 
 ##
 ## Handle the case of: typedef_struct ==> typedef (struct | union ) <name> '{' ...
 ##
-        if ( $typedef_struct_string ne "" )  {
-            process_typedef_struct($typedef_struct_string , $contents_ref, $new_contents_ref, $curr_namespace, $class_names_ref) ;
+        if ( $typedef_struct_string ne "" ) {
+            process_typedef_struct(
+                $typedef_struct_string, $contents_ref,
+                $new_contents_ref,      $curr_namespace,
+                $class_names_ref
+            );
         }
 ##
 ## Handle the case of: typedef_struct ==> typedef const (struct | union ) <name> '{' ...
 ##
-        if ( $typedef_const_struct_string ne "" )  {
-            process_typedef_const_struct($typedef_const_struct_string , $contents_ref) ;
+        if ( $typedef_const_struct_string ne "" ) {
+            process_typedef_const_struct( $typedef_const_struct_string,
+                $contents_ref );
         }
 ##
 ## Handle the case of: template_def ==> template '<' <template-parameters> '>' class <class-name> ...
 ## This is required so that templated classes do not match the plain class definition.
 ##
-        if ( $template_string ne "" )  {
-            $$new_contents_ref .= $template_string ;
-            process_template( $contents_ref , $new_contents_ref ) ;
+        if ( $template_string ne "" ) {
+            $$new_contents_ref .= $template_string;
+            process_template( $contents_ref, $new_contents_ref );
         }
 ##
 ## Handle the case of: namespace_def ==> namespace <name>
 ##
-        if ( $namespace_string ne "" )  {
-            process_namespace( $namespace_string , $contents_ref , $new_contents_ref , $curr_namespace ,
-                               $class_names_ref ) ;
+        if ( $namespace_string ne "" ) {
+            process_namespace(
+                $namespace_string, $contents_ref, $new_contents_ref,
+                $curr_namespace,   $class_names_ref
+            );
         }
 ##
 ##  Handle the case of: class_def ==> enum class <enum-name> ( '{' | ':' )
 ##
-        if ( $enum_class_string ne "" )  {
-            $$new_contents_ref .= $enum_class_string ;
+        if ( $enum_class_string ne "" ) {
+            $$new_contents_ref .= $enum_class_string;
         }
 
 ##
 ##  Handle the case of: class_def ==> ( class | struct ) <class-name> ( '{' | ':' )
 ##
-        if ( $class_string ne "" )  {
-            process_class( $class_string , $contents_ref , $new_contents_ref , $curr_namespace ,
-                           $class_names_ref ) ;
+        if ( $class_string ne "" ) {
+            process_class(
+                $class_string,   $contents_ref, $new_contents_ref,
+                $curr_namespace, $class_names_ref
+            );
         }
     }
 }
@@ -487,27 +519,30 @@ sub process_contents($$$$) {
 ## (OUT) The SWIG code generated so far.
 ##
 sub process_template($$) {
-    my ( $contents_ref , $new_contents_ref ) = @_ ;
-    my $extracted ;
+    my ( $contents_ref, $new_contents_ref ) = @_;
+    my $extracted;
 
-    # Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper class attribute assingment in input processor
-    # The function call is inserted after the 1st { of the class template so it is placed at the top 
-    $$contents_ref=~s/{\n/{\n\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n/m;
+# Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper class attribute assingment in input processor
+# The function call is inserted after the 1st { of the class template so it is placed at the top
+    $$contents_ref =~
+s/{\n/{\n\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n/m;
     if ( $$contents_ref =~ s/^(\s*;)//s ) {
-        $$new_contents_ref .= $1 ;
-    } else {
+        $$new_contents_ref .= $1;
+    }
+    else {
         # grab all of the text including the opening bracket.
-        $$contents_ref =~ s/^(.*?\s*\{)//s ;
-        $$new_contents_ref .= $1 ;
+        $$contents_ref =~ s/^(.*?\s*\{)//s;
+        $$new_contents_ref .= $1;
 
         # grab the rest of the template
-        ($extracted, $$contents_ref) = extract_bracketed( "{" . $$contents_ref , "{}") ;
+        ( $extracted, $$contents_ref ) =
+          extract_bracketed( "{" . $$contents_ref, "{}" );
 
         # remove added extra opening "brace"
-        $extracted =~ s/^\{// ;
-        $extracted =~ s/const\s+static/static const/g ;
+        $extracted =~ s/^\{//;
+        $extracted =~ s/const\s+static/static const/g;
 
-        $$new_contents_ref .= $extracted ;
+        $$new_contents_ref .= $extracted;
     }
 }
 
@@ -546,26 +581,30 @@ sub process_template($$) {
 ## process_contents()
 ##
 sub process_namespace($$$$$) {
-    my ( $namespace_string , $contents_ref , $new_contents_ref ,
-         $curr_namespace , $class_names_ref ) = @_ ;
-    my $extracted ;
-    my ($namespace_name) ;
+    my (
+        $namespace_string, $contents_ref, $new_contents_ref,
+        $curr_namespace,   $class_names_ref
+    ) = @_;
+    my $extracted;
+    my ($namespace_name);
 
     # Get the name of this namespace and add it to the current namespace
-    $namespace_string =~ /namespace\s+([_A-Za-z]\w*)/sx ;
-    $namespace_name = $curr_namespace . "$1::" ;
+    $namespace_string =~ /namespace\s+([_A-Za-z]\w*)/sx;
+    $namespace_name = $curr_namespace . "$1::";
+
     #print "*** namespace_name = $namespace_name ***\n" ;
 
-    $$new_contents_ref .= $namespace_string ;
+    $$new_contents_ref .= $namespace_string;
 
     # Extract the contents of the namespace
-    ($extracted, $$contents_ref) = extract_bracketed( $$contents_ref , "{}") ;
+    ( $extracted, $$contents_ref ) = extract_bracketed( $$contents_ref, "{}" );
 
     # Process the contents of the namespace
-    process_contents( \$extracted , $new_contents_ref , $namespace_name , $class_names_ref ) ;
+    process_contents( \$extracted, $new_contents_ref, $namespace_name,
+        $class_names_ref );
 
     # Append whatever wasn't matched in process contents to the new file.
-    $$new_contents_ref .= $extracted ;
+    $$new_contents_ref .= $extracted;
 }
 
 ## ================================================================================
@@ -597,161 +636,182 @@ sub process_namespace($$$$$) {
 ## <func-depend name="extract_bracketed">
 
 sub process_class($$$$$) {
-    my ( $class_string , $contents_ref , $new_contents_ref , $curr_namespace ,
-         $class_names_ref ) = @_ ;
+    my (
+        $class_string,   $contents_ref, $new_contents_ref,
+        $curr_namespace, $class_names_ref
+    ) = @_;
 
-    my $extracted ;
-    my ($class_name) ;
-    my @qualified_template_typedefs ;
-    my @unqualified_template_typedefs ;
+    my $extracted;
+    my ($class_name);
+    my @qualified_template_typedefs;
+    my @unqualified_template_typedefs;
 
 ## Extract the class_name from the class_string
-    $class_string =~ /^(?:class|struct)\s+               # keyword class or struct
+    $class_string =~
+      /^(?:class|struct)\s+               # keyword class or struct
                       ([_A-Za-z]\w*)                     # class name
                       \s*[\{\:]$
-                     /sx or die "Internal error" ;
-    $class_name = $1 ;
-    my $my_class_contents = $class_string ;
+                     /sx or die "Internal error";
+    $class_name = $1;
+    my $my_class_contents = $class_string;
 
     if ( $class_string !~ /\{$/ ) {
-        $$contents_ref =~ s/^(.*?\s*\{)//s ;
-        $my_class_contents .= $1 ;
+        $$contents_ref =~ s/^(.*?\s*\{)//s;
+        $my_class_contents .= $1;
     }
 
-    # Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper class attribute assingment in input processor
-    $my_class_contents .= "\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n" ;
+# Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper class attribute assingment in input processor
+    $my_class_contents .=
+"\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    __setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n";
 
-    ($extracted, $$contents_ref) = extract_bracketed( "{" . $$contents_ref , "{}") ;
+    ( $extracted, $$contents_ref ) =
+      extract_bracketed( "{" . $$contents_ref, "{}" );
 
     # remove the trailing semicolon because we may append text to the class.
-    $$contents_ref =~ s/^\s*;//s ;
+    $$contents_ref =~ s/^\s*;//s;
 
     #remove added extra opening "brace"
-    $extracted =~ s/^\{// ;
+    $extracted =~ s/^\{//;
 
     #print "*** extracted = $extracted ***\n" ;
     #print "*** contents = $$contents_ref ***\n" ;
 
     # SWIG doesn't like "const static".  Change it to "static const"
-    $extracted =~ s/const\s+static/static const/g ;
+    $extracted =~ s/const\s+static/static const/g;
 
-    my $isSwigExcludeBlock = 0 ;
+    my $isSwigExcludeBlock = 0;
 
-    # templated variables need to be declared with the SWIG %template directive.
-    # This loop looks for any templated variables and creates the %template lines.
+  # templated variables need to be declared with the SWIG %template directive.
+  # This loop looks for any templated variables and creates the %template lines.
     while ( $extracted =~ s/^(.*?)(?:($template_var_def))//sx ) {
-        my ( $non_var ) = $1 ;
-        my ( $template_var_def_str ) = $2 ;
+        my ($non_var)              = $1;
+        my ($template_var_def_str) = $2;
 
-        if ( $non_var ne "" )  {
+        if ( $non_var ne "" ) {
+
             #print "*** non_var = $non_var ***\n" ;
-            $my_class_contents .= $non_var ;
+            $my_class_contents .= $non_var;
             my $ifndefSwig = $non_var;
-            my $moreNonVar = 1 ;
-            # search for all instances of #ifndef SWIG, #if !defined(SWIG), and #endif prior to template variable
-            # update $isSwigExcludeBlock to the last instance*
-            # exit when no match is found
-            # *  this script does not track preprocessor scope, so any #endif will set $isSwigExcludeBlock to 0
-            #    in other words we don't support SWIGing nested preprocessor if statements, use at your peril
-            while ($moreNonVar == 1) {
-               if ($ifndefSwig =~ s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)// ) {
-                  if($1 ne "" or $2 ne "") {
-                     $isSwigExcludeBlock = 1 ;
-                  }
-                  elsif($3 ne "") {
-                     $isSwigExcludeBlock = 0 ;
-                  }
-               }
-               else {
-                  $moreNonVar = 0 ;
-               }
+            my $moreNonVar = 1;
+
+# search for all instances of #ifndef SWIG, #if !defined(SWIG), and #endif prior to template variable
+# update $isSwigExcludeBlock to the last instance*
+# exit when no match is found
+# *  this script does not track preprocessor scope, so any #endif will set $isSwigExcludeBlock to 0
+#    in other words we don't support SWIGing nested preprocessor if statements, use at your peril
+            while ( $moreNonVar == 1 ) {
+                if ( $ifndefSwig =~
+s/(#\s*ifndef\s*SWIG)|(#\s*if\s*!\s*defined\s*\(\s*SWIG\s*\))|(#\s*endif\s*)//
+                  )
+                {
+                    if ( $1 ne "" or $2 ne "" ) {
+                        $isSwigExcludeBlock = 1;
+                    }
+                    elsif ( $3 ne "" ) {
+                        $isSwigExcludeBlock = 0;
+                    }
+                }
+                else {
+                    $moreNonVar = 0;
+                }
             }
         }
 
-        if ( $template_var_def_str ne "" )  {
+        if ( $template_var_def_str ne "" ) {
+
             # if there is a whiff of const in the template we are punting.
             if ( $template_var_def_str !~ /^const|[<,\s]const\s/ ) {
-                $template_var_def_str =~ /(.*?>)\s*([_A-Za-z]\w*).*?;/s ;
-                my ($template_full_type) = $1 ;
-                my ($var_name) = $2 ;
-                $my_class_contents .= $template_var_def_str ;
+                $template_var_def_str =~ /(.*?>)\s*([_A-Za-z]\w*).*?;/s;
+                my ($template_full_type) = $1;
+                my ($var_name)           = $2;
+                $my_class_contents .= $template_var_def_str;
 
-                $template_full_type =~ /([_A-Za-z][:\w]*)\s*</ ;
-                my ($template_type) = $1 ;
+                $template_full_type =~ /([_A-Za-z][:\w]*)\s*</;
+                my ($template_type) = $1;
+
                 # ignore some STL types and types that involve std::wstring
-                if ( ((  $stls and ! exists $stl_names{$template_type})
-                   or ( !$stls and ! exists $all_stl_names{$template_type} ))
-                   and $template_full_type !~ /(std::)?wstring/ ) {
+                if (
+                    (
+                           ( $stls  and !exists $stl_names{$template_type} )
+                        or ( !$stls and !exists $all_stl_names{$template_type} )
+                    )
+                    and $template_full_type !~ /(std::)?wstring/
+                  )
+                {
 
-                    my ($template_type_no_sp) = $template_full_type ;
-                    $template_type_no_sp =~ s/\s//g ;
+                    my ($template_type_no_sp) = $template_full_type;
+                    $template_type_no_sp =~ s/\s//g;
 
-                    #print "*** template_type_no_sp = $template_type_no_sp ***\n" ;
-                    if ( ! exists $processed_templates{$template_type_no_sp} ) {
+                 #print "*** template_type_no_sp = $template_type_no_sp ***\n" ;
+                    if ( !exists $processed_templates{$template_type_no_sp} ) {
 
-                        my $sanitized_namespace = $curr_namespace =~ s/:/_/gr ;
-                        my $identifier = "${sanitized_namespace}${class_name}_${var_name}" ;
-                        my $trick_swig_template = "TRICK_SWIG_TEMPLATE_$identifier" ;
+                        my $sanitized_namespace = $curr_namespace =~ s/:/_/gr;
+                        my $identifier =
+                          "${sanitized_namespace}${class_name}_${var_name}";
+                        my $trick_swig_template =
+                          "TRICK_SWIG_TEMPLATE_$identifier";
 
                         # Insert template directive immediately before instance
                         # This is required as of SWIG 4
-                        my $typedef = "\n#ifndef $trick_swig_template\n" ;
-                        $typedef   .= "#define $trick_swig_template\n" ;
-                        $typedef   .= "\%template($identifier) $template_full_type;\n" ;
-                        $typedef   .= "#endif\n" ;
+                        my $typedef = "\n#ifndef $trick_swig_template\n";
+                        $typedef .= "#define $trick_swig_template\n";
+                        $typedef .=
+                          "\%template($identifier) $template_full_type;\n";
+                        $typedef .= "#endif\n";
 
-                        # A SWIG %template directive must:
-                        # 1. Appear before each template instantiation
-                        # 2. Be in scope where the instantiation is declared
-                        # 3. Not be enclosed within a different namespace
-                        #
-                        # See https://www.swig.org/Doc4.2/SWIGPlus.html#SWIGPlus_template_scoping
-                        #
-                        # Generally, convert_swig is not smart enough to put all %template
-                        # directives in the right scope because:
-                        # 1. We do not keep track of what scope each type we encounter is
-                        #    declared in.
-                        # 2. We cannot easily add %template directives to already-processed
-                        #    scopes.
-                        #
-                        # As a compromise:
-                        # 1. For an unqualified template instantiation, the template declaration
-                        #    is necessarily in the current or a containing scope. Hope it's in the
-                        #    current namespace and put the %template directive there. This will
-                        #    create invalid SWIG input code for templates declared in a containing
-                        #    namespace and for member templates declared in this class.
-                        # 2. For a qualified template instantiation, the template declaration is
-                        #    in a (possibly nested) scope contained by the current or a containing
-                        #    scope. Assume the instantiation is fully qualified and put it in the
-                        #    global namespace. This will create invalid SWIG code for partially-
-                        #    qualified instantiations.
-                        #
-                        # See https://github.com/nasa/trick/issues/768
+      # A SWIG %template directive must:
+      # 1. Appear before each template instantiation
+      # 2. Be in scope where the instantiation is declared
+      # 3. Not be enclosed within a different namespace
+      #
+      # See https://www.swig.org/Doc4.2/SWIGPlus.html#SWIGPlus_template_scoping
+      #
+      # Generally, convert_swig is not smart enough to put all %template
+      # directives in the right scope because:
+      # 1. We do not keep track of what scope each type we encounter is
+      #    declared in.
+      # 2. We cannot easily add %template directives to already-processed
+      #    scopes.
+      #
+      # As a compromise:
+      # 1. For an unqualified template instantiation, the template declaration
+      #    is necessarily in the current or a containing scope. Hope it's in the
+      #    current namespace and put the %template directive there. This will
+      #    create invalid SWIG input code for templates declared in a containing
+      #    namespace and for member templates declared in this class.
+      # 2. For a qualified template instantiation, the template declaration is
+      #    in a (possibly nested) scope contained by the current or a containing
+      #    scope. Assume the instantiation is fully qualified and put it in the
+      #    global namespace. This will create invalid SWIG code for partially-
+      #    qualified instantiations.
+      #
+      # See https://github.com/nasa/trick/issues/768
 
-                        if ($isSwigExcludeBlock == 0) {
-                            if ($template_full_type =~ /^\w*(::\w+)+</) {
-                                push @qualified_template_typedefs, $typedef ;
+                        if ( $isSwigExcludeBlock == 0 ) {
+                            if ( $template_full_type =~ /^\w*(::\w+)+</ ) {
+                                push @qualified_template_typedefs, $typedef;
                             }
                             else {
-                                push @unqualified_template_typedefs, $typedef ;
+                                push @unqualified_template_typedefs, $typedef;
                             }
                         }
 
-                        $processed_templates{$template_type_no_sp} = 1 ;
+                        $processed_templates{$template_type_no_sp} = 1;
                     }
                 }
             }
         }
     }
+
     #print "*** unprocessed extracted = $extracted ***\n" ;
 
-    push @$class_names_ref , "$curr_namespace$class_name" ;
+    push @$class_names_ref, "$curr_namespace$class_name";
 
     # Write out the %template directives for template instantiations found in
     # this class. Put the directives for unqualified instantiations in the
     # namespace containing this class, just before the class definition.
     foreach (@unqualified_template_typedefs) {
-        $$new_contents_ref .= $_ ;
+        $$new_contents_ref .= $_;
     }
 
     # Assume qualified template instantiations are fully qualified and put
@@ -760,25 +820,26 @@ sub process_class($$$$$) {
     # 2. add the %template directives
     # 3. open all namespaces, restoring the scope
     if (@qualified_template_typedefs) {
-        my @namespaces = split(/::/, $curr_namespace) ;
+        my @namespaces = split( /::/, $curr_namespace );
         $$new_contents_ref .= "}" x @namespaces . "\n";
         foreach (@qualified_template_typedefs) {
-            $$new_contents_ref .= $_ ;
+            $$new_contents_ref .= $_;
         }
         $$new_contents_ref .= "\n";
         foreach (@namespaces) {
-            $$new_contents_ref .= "namespace " . $_ . " { " ;
+            $$new_contents_ref .= "namespace " . $_ . " { ";
         }
     }
 
-    # write the class contents and semicolon to ensure any template declarations below are after the semicolon.
-    $$new_contents_ref .= "\n" . $my_class_contents . $extracted . ";\n" ;
+# write the class contents and semicolon to ensure any template declarations below are after the semicolon.
+    $$new_contents_ref .= "\n" . $my_class_contents . $extracted . ";\n";
 
-    my $c_ = "$curr_namespace$class_name" ;
-    $c_ =~ s/\:/_/g ;
-    # Add a #define line that signals that this class has been processed by swig. Classes excluded in #if 0 blocks will
-    # not have this #define defined.
-    $$new_contents_ref .= "#define TRICK_SWIG_DEFINED_$c_" ;
+    my $c_ = "$curr_namespace$class_name";
+    $c_ =~ s/\:/_/g;
+
+# Add a #define line that signals that this class has been processed by swig. Classes excluded in #if 0 blocks will
+# not have this #define defined.
+    $$new_contents_ref .= "#define TRICK_SWIG_DEFINED_$c_";
 }
 
 ## ================================================================================
@@ -795,7 +856,7 @@ sub process_class($$$$$) {
 ## Parameters
 ##
 ## typedef_struct_string
-## (IN) This is a string of the form: 
+## (IN) This is a string of the form:
 ##     "typedef struct [<name>] {"   OR   "typedef union [<name>] {" </parameter>
 ##
 ## contents_ref
@@ -814,50 +875,58 @@ sub process_class($$$$$) {
 ##
 sub process_typedef_struct($$$$$) {
 
-    my ($typedef_struct_string , $contents_ref, $new_contents_ref , $curr_namespace, $class_names_ref) = @_ ;
+    my (
+        $typedef_struct_string, $contents_ref, $new_contents_ref,
+        $curr_namespace,        $class_names_ref
+    ) = @_;
 
-    my $extracted ;
-    my ($tail , $my_struct_contents, $struct_names, @struct_names) ;
+    my $extracted;
+    my ( $tail, $my_struct_contents, $struct_names, @struct_names );
 
     #print "*** typedef_struct_string = $typedef_struct_string ***\n" ;
 
-    $$new_contents_ref .= $typedef_struct_string ;
+    $$new_contents_ref .= $typedef_struct_string;
 
-    $typedef_struct_string =~ s/((?:typedef\s+)?(struct|union)\s*   # the words typedef struct|union
+    $typedef_struct_string =~
+      s/((?:typedef\s+)?(struct|union)\s*   # the words typedef struct|union
          ([_A-Za-z]\w*)?\s*                                         # optional name
-         {)//sx ;
+         {)//sx;
 
-    ($extracted, $$contents_ref) = extract_bracketed( "{" . $$contents_ref , "{}") ;
+    ( $extracted, $$contents_ref ) =
+      extract_bracketed( "{" . $$contents_ref, "{}" );
+
     #print "*** extracted = $extracted ***\n" ;
 
     #remove added extra opening "brace"
-    $extracted =~ s/{// ;
+    $extracted =~ s/{//;
 
-    $$contents_ref =~ s/^(\s*([\w,\s\*]+)?\s*;)//sx ;
-    $tail = $1 ;
-    $struct_names = $2 ;
+    $$contents_ref =~ s/^(\s*([\w,\s\*]+)?\s*;)//sx;
+    $tail         = $1;
+    $struct_names = $2;
 
-    $struct_names =~ s/\s//g ;
-    @struct_names = split /,/ , $struct_names ;
+    $struct_names =~ s/\s//g;
+    @struct_names = split /,/, $struct_names;
 
-    foreach my $s ( @struct_names ) {
+    foreach my $s (@struct_names) {
         if ( $s !~ /\*/ ) {
-            push @$class_names_ref , "${curr_namespace}${s}" ;
-            # Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper struct attribute assingment in input processor
-            $my_struct_contents .= "\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    if '$s' in globals():\n        $s.__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n" ;
-            # Generate the same define that process_class generates so the #ifdef-guarded
-            # %trick_cast_as() at the bottom of the .i file generates a cast helper
-            # with the fully-qualified type name (e.g. peer::Leek * castAspeer__Leek).
-            my $c_ = "${curr_namespace}${s}" ;
-            $c_ =~ s/\:/_/g ;
-            $my_struct_contents .= "\n#define TRICK_SWIG_DEFINED_$c_" ;
+            push @$class_names_ref, "${curr_namespace}${s}";
+
+# Add _swig_setattr_nondynamic_instance_variable function for raising AttributeError for improper struct attribute assingment in input processor
+            $my_struct_contents .=
+"\n#if SWIG_VERSION > 0x040000\n\%pythoncode \%{\n    if '$s' in globals():\n        $s.__setattr__ = _swig_setattr_nondynamic_instance_variable(object.__setattr__)\n\%}\n#endif\n";
+
+   # Generate the same define that process_class generates so the #ifdef-guarded
+   # %trick_cast_as() at the bottom of the .i file generates a cast helper
+   # with the fully-qualified type name (e.g. peer::Leek * castAspeer__Leek).
+            my $c_ = "${curr_namespace}${s}";
+            $c_ =~ s/\:/_/g;
+            $my_struct_contents .= "\n#define TRICK_SWIG_DEFINED_$c_";
         }
     }
 
-    $$new_contents_ref .= $extracted . $tail . $my_struct_contents ;
+    $$new_contents_ref .= $extracted . $tail . $my_struct_contents;
 
 }
-
 
 ## ================================================================================
 ## process_typedef_const_struct
@@ -871,11 +940,12 @@ sub process_typedef_struct($$$$$) {
 
 sub process_typedef_const_struct($$$$) {
 
-    my ($typedef_const_struct_string , $contents_ref ) = @_ ;
-    my $extracted ;
+    my ( $typedef_const_struct_string, $contents_ref ) = @_;
+    my $extracted;
 
-    ($extracted, $$contents_ref) = extract_bracketed( "{" . $$contents_ref , "{}") ;
-    $$contents_ref =~ s/^(\s*([\w,\s\*]+)?\s*;)//sx ;
+    ( $extracted, $$contents_ref ) =
+      extract_bracketed( "{" . $$contents_ref, "{}" );
+    $$contents_ref =~ s/^(\s*([\w,\s\*]+)?\s*;)//sx;
 
 }
 

--- a/test/SIM_python_namespace/RUN_test/unit_test.py
+++ b/test/SIM_python_namespace/RUN_test/unit_test.py
@@ -15,16 +15,23 @@ def main():
     ball.foo_yummyfood.print_me()
     print
 
+    # global typedef struct (not in a namespace)
+    ball.trick_food.globalFoodItems = trick.alloc_type(1, "GlobalFoodItem")
+    ball.trick_food.globalFoodItems[0].itemName = "Hotdog"
+    ball.trick_food.globalFoodItems[0].price = 3.50
+    TRICK_EXPECT_EQ( str(ball.trick_food.globalFoodItems[0].itemName) , "Hotdog", test_suite , "global typedef struct" )
+    TRICK_EXPECT_EQ( ball.trick_food.globalFoodItems[0].price , 3.50, test_suite , "global typedef struct" )
+
     # struct in a namespace
     ball.foo_yummyfood.foo_food_in_struct = trick.alloc_type(2, "Foo::FooFoodInStruct")
     ball.foo_yummyfood.foo_food_in_struct[0].foodName = "Pizza"
     ball.foo_yummyfood.foo_food_in_struct[0].calories = 100.0
     ball.foo_yummyfood.foo_food_in_struct[1].foodName = "Ice Cream"
     ball.foo_yummyfood.foo_food_in_struct[1].calories = 200.0
-    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct[0].foodName) , "Pizza", test_suite , "struct in a namespace" )
-    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct[0].calories , 100.0, test_suite , "struct in a namespace" )
-    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct[1].foodName) , "Ice Cream", test_suite , "struct in a namespace" )
-    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct[1].calories , 200.0, test_suite , "struct in a namespace" )
+    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct[0].foodName) , "Pizza", test_suite , "typedef struct in a namespace" )
+    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct[0].calories , 100.0, test_suite , "typedef struct in a namespace" )
+    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct[1].foodName) , "Ice Cream", test_suite , "typedef struct in a namespace" )
+    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct[1].calories , 200.0, test_suite , "typedef struct in a namespace" )
 
     # struct in a namespace without typedef
     ball.foo_yummyfood.foo_food_in_struct_no_typedef = trick.alloc_type(2, "Foo::FooFoodInStructNoTypedef")

--- a/test/SIM_python_namespace/RUN_test/unit_test.py
+++ b/test/SIM_python_namespace/RUN_test/unit_test.py
@@ -1,11 +1,13 @@
-
 from trick.unit_test import *
+
 
 def main():
     trick.stop(1.0)
     trick_utest.unit_tests.enable()
-    trick_utest.unit_tests.set_file_name( os.getenv("TRICK_HOME") + "/trick_test/SIM_python_namespace.xml" )
-    trick_utest.unit_tests.set_test_name( "PythonNamespace" )
+    trick_utest.unit_tests.set_file_name(
+        os.getenv("TRICK_HOME") + "/trick_test/SIM_python_namespace.xml"
+    )
+    trick_utest.unit_tests.set_test_name("PythonNamespace")
     test_suite = "python_namespace"
 
     # normal class methods from S_define
@@ -19,8 +21,18 @@ def main():
     ball.trick_food.globalFoodItems = trick.alloc_type(1, "GlobalFoodItem")
     ball.trick_food.globalFoodItems[0].itemName = "Hotdog"
     ball.trick_food.globalFoodItems[0].price = 3.50
-    TRICK_EXPECT_EQ( str(ball.trick_food.globalFoodItems[0].itemName) , "Hotdog", test_suite , "global typedef struct" )
-    TRICK_EXPECT_EQ( ball.trick_food.globalFoodItems[0].price , 3.50, test_suite , "global typedef struct" )
+    TRICK_EXPECT_EQ(
+        str(ball.trick_food.globalFoodItems[0].itemName),
+        "Hotdog",
+        test_suite,
+        "global typedef struct",
+    )
+    TRICK_EXPECT_EQ(
+        ball.trick_food.globalFoodItems[0].price,
+        3.50,
+        test_suite,
+        "global typedef struct",
+    )
 
     # struct in a namespace
     ball.foo_yummyfood.foo_food_in_struct = trick.alloc_type(2, "Foo::FooFoodInStruct")
@@ -28,58 +40,99 @@ def main():
     ball.foo_yummyfood.foo_food_in_struct[0].calories = 100.0
     ball.foo_yummyfood.foo_food_in_struct[1].foodName = "Ice Cream"
     ball.foo_yummyfood.foo_food_in_struct[1].calories = 200.0
-    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct[0].foodName) , "Pizza", test_suite , "typedef struct in a namespace" )
-    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct[0].calories , 100.0, test_suite , "typedef struct in a namespace" )
-    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct[1].foodName) , "Ice Cream", test_suite , "typedef struct in a namespace" )
-    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct[1].calories , 200.0, test_suite , "typedef struct in a namespace" )
+    TRICK_EXPECT_EQ(
+        str(ball.foo_yummyfood.foo_food_in_struct[0].foodName),
+        "Pizza",
+        test_suite,
+        "typedef struct in a namespace",
+    )
+    TRICK_EXPECT_EQ(
+        ball.foo_yummyfood.foo_food_in_struct[0].calories,
+        100.0,
+        test_suite,
+        "typedef struct in a namespace",
+    )
+    TRICK_EXPECT_EQ(
+        str(ball.foo_yummyfood.foo_food_in_struct[1].foodName),
+        "Ice Cream",
+        test_suite,
+        "typedef struct in a namespace",
+    )
+    TRICK_EXPECT_EQ(
+        ball.foo_yummyfood.foo_food_in_struct[1].calories,
+        200.0,
+        test_suite,
+        "typedef struct in a namespace",
+    )
 
     # struct in a namespace without typedef
-    ball.foo_yummyfood.foo_food_in_struct_no_typedef = trick.alloc_type(2, "Foo::FooFoodInStructNoTypedef")
+    ball.foo_yummyfood.foo_food_in_struct_no_typedef = trick.alloc_type(
+        2, "Foo::FooFoodInStructNoTypedef"
+    )
     ball.foo_yummyfood.foo_food_in_struct_no_typedef[0].foodName = "Pizza"
     ball.foo_yummyfood.foo_food_in_struct_no_typedef[0].calories = 100.0
     ball.foo_yummyfood.foo_food_in_struct_no_typedef[1].foodName = "Ice Cream"
     ball.foo_yummyfood.foo_food_in_struct_no_typedef[1].calories = 200.0
-    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct_no_typedef[0].foodName) , "Pizza", test_suite , "struct without typedef in a namespace" )
-    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct_no_typedef[0].calories , 100.0, test_suite , "struct without typedef in a namespace" )
-    TRICK_EXPECT_EQ( str(ball.foo_yummyfood.foo_food_in_struct_no_typedef[1].foodName) , "Ice Cream", test_suite , "struct without typedef in a namespace" )
-    TRICK_EXPECT_EQ( ball.foo_yummyfood.foo_food_in_struct_no_typedef[1].calories , 200.0, test_suite , "struct without typedef in a namespace" )
+    TRICK_EXPECT_EQ(
+        str(ball.foo_yummyfood.foo_food_in_struct_no_typedef[0].foodName),
+        "Pizza",
+        test_suite,
+        "struct without typedef in a namespace",
+    )
+    TRICK_EXPECT_EQ(
+        ball.foo_yummyfood.foo_food_in_struct_no_typedef[0].calories,
+        100.0,
+        test_suite,
+        "struct without typedef in a namespace",
+    )
+    TRICK_EXPECT_EQ(
+        str(ball.foo_yummyfood.foo_food_in_struct_no_typedef[1].foodName),
+        "Ice Cream",
+        test_suite,
+        "struct without typedef in a namespace",
+    )
+    TRICK_EXPECT_EQ(
+        ball.foo_yummyfood.foo_food_in_struct_no_typedef[1].calories,
+        200.0,
+        test_suite,
+        "struct without typedef in a namespace",
+    )
 
     # new class from Foo.Food
     food = trick.Foo.Food()
     food.print_me()
-    TRICK_EXPECT_EQ( food.fast , 0, test_suite , "first level python namespace" )
+    TRICK_EXPECT_EQ(food.fast, 0, test_suite, "first level python namespace")
     food.fast = trick.Foo.Burger
-    TRICK_EXPECT_EQ( food.fast , 2, test_suite , "first level python namespace" )
+    TRICK_EXPECT_EQ(food.fast, 2, test_suite, "first level python namespace")
 
     # new class from Foo.Food.Inner
     foodinner = trick.Foo.Inner.Food()
     foodinner.print_me()
-    TRICK_EXPECT_EQ( foodinner.fast , 1, test_suite , "second level python namespace" )
+    TRICK_EXPECT_EQ(foodinner.fast, 1, test_suite, "second level python namespace")
     foodinner.fast = trick.Foo.Inner.Burger
-    TRICK_EXPECT_EQ( foodinner.fast , 0, test_suite , "second level python namespace" )
+    TRICK_EXPECT_EQ(foodinner.fast, 0, test_suite, "second level python namespace")
 
     # new class from Foo.Food.Inner
     bar = trick.Bar.Food()
     bar.print_me()
-    TRICK_EXPECT_EQ( bar.fast , 2, test_suite , "another first level python namespace" )
+    TRICK_EXPECT_EQ(bar.fast, 2, test_suite, "another first level python namespace")
     bar.fast = trick.Bar.Burger
-    TRICK_EXPECT_EQ( bar.fast , 1, test_suite , "another first level python namespace" )
+    TRICK_EXPECT_EQ(bar.fast, 1, test_suite, "another first level python namespace")
 
     # new class from Foo.Food.Inner
     yummy = trick.Foo.YummyFood()
     yummy.print_me()
-    TRICK_EXPECT_EQ( yummy.yummy , 1, test_suite , "additional file in same namespace" )
+    TRICK_EXPECT_EQ(yummy.yummy, 1, test_suite, "additional file in same namespace")
     yummy.yummy = trick.Foo.Doughnuts
-    TRICK_EXPECT_EQ( yummy.yummy , 2, test_suite , "additional file in same namespace" )
+    TRICK_EXPECT_EQ(yummy.yummy, 2, test_suite, "additional file in same namespace")
 
     # new class from TrickFood
     trickfood = trick.Food()
     trickfood.print_me()
-    TRICK_EXPECT_EQ( trickfood.fast , 2, test_suite , "blank python_module statement" )
+    TRICK_EXPECT_EQ(trickfood.fast, 2, test_suite, "blank python_module statement")
     trickfood.fast = trick.Pizza
-    TRICK_EXPECT_EQ( trickfood.fast , 0, test_suite , "blank python_module statement" )
+    TRICK_EXPECT_EQ(trickfood.fast, 0, test_suite, "blank python_module statement")
+
 
 if __name__ == "__main__":
     main()
-
-

--- a/test/SIM_python_namespace/RUN_test/unit_test.py
+++ b/test/SIM_python_namespace/RUN_test/unit_test.py
@@ -34,7 +34,7 @@ def main():
         "global typedef struct",
     )
 
-    # global same typedef struct (creal64_T) declared in two different headers (SignalA.hh and SignalB.hh) 
+    # global same typedef struct (creal64_T) declared in two different headers (SignalA.hh and SignalB.hh)
     # regression test for duplicate castAs* symbol
     ball.signal_a.value_a_array = trick.alloc_type(1, "creal64_T")
     ball.signal_b.value_b_array = trick.alloc_type(1, "creal64_T")
@@ -42,18 +42,58 @@ def main():
     ball.signal_a.value_a_array[0].im = 2.0
     ball.signal_b.value_b_array[0].re = 3.0
     ball.signal_b.value_b_array[0].im = 4.0
-    TRICK_EXPECT_EQ( ball.signal_a.value_a_array[0].re , 1.0, test_suite , "duplicate typedef struct in two headers" )
-    TRICK_EXPECT_EQ( ball.signal_a.value_a_array[0].im , 2.0, test_suite , "duplicate typedef struct in two headers" )
-    TRICK_EXPECT_EQ( ball.signal_b.value_b_array[0].re , 3.0, test_suite , "duplicate typedef struct in two headers" )
-    TRICK_EXPECT_EQ( ball.signal_b.value_b_array[0].im , 4.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ(
+        ball.signal_a.value_a_array[0].re,
+        1.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
+    TRICK_EXPECT_EQ(
+        ball.signal_a.value_a_array[0].im,
+        2.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
+    TRICK_EXPECT_EQ(
+        ball.signal_b.value_b_array[0].re,
+        3.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
+    TRICK_EXPECT_EQ(
+        ball.signal_b.value_b_array[0].im,
+        4.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
     ball.signal_a.value.re = 1.0
     ball.signal_a.value.im = 2.0
     ball.signal_b.value.re = 3.0
     ball.signal_b.value.im = 4.0
-    TRICK_EXPECT_EQ( ball.signal_a.value.re , 1.0, test_suite , "duplicate typedef struct in two headers" )
-    TRICK_EXPECT_EQ( ball.signal_a.value.im , 2.0, test_suite , "duplicate typedef struct in two headers" )
-    TRICK_EXPECT_EQ( ball.signal_b.value.re , 3.0, test_suite , "duplicate typedef struct in two headers" )
-    TRICK_EXPECT_EQ( ball.signal_b.value.im , 4.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ(
+        ball.signal_a.value.re,
+        1.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
+    TRICK_EXPECT_EQ(
+        ball.signal_a.value.im,
+        2.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
+    TRICK_EXPECT_EQ(
+        ball.signal_b.value.re,
+        3.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
+    TRICK_EXPECT_EQ(
+        ball.signal_b.value.im,
+        4.0,
+        test_suite,
+        "duplicate typedef struct in two headers",
+    )
 
     # struct in a namespace
     ball.foo_yummyfood.foo_food_in_struct = trick.alloc_type(2, "Foo::FooFoodInStruct")

--- a/test/SIM_python_namespace/RUN_test/unit_test.py
+++ b/test/SIM_python_namespace/RUN_test/unit_test.py
@@ -34,6 +34,27 @@ def main():
         "global typedef struct",
     )
 
+    # global same typedef struct (creal64_T) declared in two different headers (SignalA.hh and SignalB.hh) 
+    # regression test for duplicate castAs* symbol
+    ball.signal_a.value_a_array = trick.alloc_type(1, "creal64_T")
+    ball.signal_b.value_b_array = trick.alloc_type(1, "creal64_T")
+    ball.signal_a.value_a_array[0].re = 1.0
+    ball.signal_a.value_a_array[0].im = 2.0
+    ball.signal_b.value_b_array[0].re = 3.0
+    ball.signal_b.value_b_array[0].im = 4.0
+    TRICK_EXPECT_EQ( ball.signal_a.value_a_array[0].re , 1.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ( ball.signal_a.value_a_array[0].im , 2.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ( ball.signal_b.value_b_array[0].re , 3.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ( ball.signal_b.value_b_array[0].im , 4.0, test_suite , "duplicate typedef struct in two headers" )
+    ball.signal_a.value.re = 1.0
+    ball.signal_a.value.im = 2.0
+    ball.signal_b.value.re = 3.0
+    ball.signal_b.value.im = 4.0
+    TRICK_EXPECT_EQ( ball.signal_a.value.re , 1.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ( ball.signal_a.value.im , 2.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ( ball.signal_b.value.re , 3.0, test_suite , "duplicate typedef struct in two headers" )
+    TRICK_EXPECT_EQ( ball.signal_b.value.im , 4.0, test_suite , "duplicate typedef struct in two headers" )
+
     # struct in a namespace
     ball.foo_yummyfood.foo_food_in_struct = trick.alloc_type(2, "Foo::FooFoodInStruct")
     ball.foo_yummyfood.foo_food_in_struct[0].foodName = "Pizza"

--- a/test/SIM_python_namespace/S_define
+++ b/test/SIM_python_namespace/S_define
@@ -10,6 +10,8 @@ PURPOSE:
 ##include "BarFood.hh"
 ##include "FooYummyFood.hh"
 ##include "TrickFood.hh"
+##include "SignalA.hh"
+##include "SignalB.hh"
 
 class SimObj : public Trick::SimObject {
 
@@ -19,6 +21,8 @@ class SimObj : public Trick::SimObject {
         Bar::Food bar_food ;
         Foo::YummyFood foo_yummyfood ;
         Food trick_food;
+        SignalA signal_a;
+        SignalB signal_b;
 
         /** Constructor to add the jobs */
         SimObj() {

--- a/test/SIM_python_namespace/models/SignalA.hh
+++ b/test/SIM_python_namespace/models/SignalA.hh
@@ -1,0 +1,30 @@
+/**
+@file
+
+@verbatim
+PURPOSE: (SignalA directly defines creal64_T - simulates a Simulink-generated header
+          where the same typedef appears verbatim in multiple generated files.)
+@endverbatim
+*******************************************************************************/
+
+#ifndef SIGNALA_HH
+#define SIGNALA_HH
+
+#ifndef CREAL64_T_DEFINED
+#define CREAL64_T_DEFINED
+typedef double real64_T;
+
+typedef struct {
+    real64_T re;
+    real64_T im;
+} creal64_T;
+#endif
+
+class SignalA {
+  public:
+    SignalA() : value() {}
+    creal64_T value;
+    creal64_T *value_a_array;
+};
+
+#endif

--- a/test/SIM_python_namespace/models/SignalA.hh
+++ b/test/SIM_python_namespace/models/SignalA.hh
@@ -14,17 +14,22 @@ PURPOSE: (SignalA directly defines creal64_T - simulates a Simulink-generated he
 #define CREAL64_T_DEFINED
 typedef double real64_T;
 
-typedef struct {
-    real64_T re;
-    real64_T im;
+typedef struct
+{
+        real64_T re;
+        real64_T im;
 } creal64_T;
 #endif
 
-class SignalA {
-  public:
-    SignalA() : value() {}
-    creal64_T value;
-    creal64_T *value_a_array;
+class SignalA
+{
+    public:
+        SignalA()
+            : value()
+        {
+        }
+        creal64_T value;
+        creal64_T* value_a_array;
 };
 
 #endif

--- a/test/SIM_python_namespace/models/SignalB.hh
+++ b/test/SIM_python_namespace/models/SignalB.hh
@@ -1,0 +1,30 @@
+/**
+@file
+
+@verbatim
+PURPOSE: (SignalB directly defines creal64_T - simulates a Simulink-generated header
+          where the same typedef appears verbatim in multiple generated files.)
+@endverbatim
+*******************************************************************************/
+
+#ifndef SIGNALB_HH
+#define SIGNALB_HH
+
+#ifndef CREAL64_T_DEFINED
+#define CREAL64_T_DEFINED
+typedef double real64_T;
+
+typedef struct {
+    real64_T re;
+    real64_T im;
+} creal64_T;
+#endif
+
+class SignalB {
+  public:
+    SignalB() : value() {}
+    creal64_T value;
+    creal64_T *value_b_array;
+};
+
+#endif

--- a/test/SIM_python_namespace/models/SignalB.hh
+++ b/test/SIM_python_namespace/models/SignalB.hh
@@ -14,17 +14,22 @@ PURPOSE: (SignalB directly defines creal64_T - simulates a Simulink-generated he
 #define CREAL64_T_DEFINED
 typedef double real64_T;
 
-typedef struct {
-    real64_T re;
-    real64_T im;
+typedef struct
+{
+        real64_T re;
+        real64_T im;
 } creal64_T;
 #endif
 
-class SignalB {
-  public:
-    SignalB() : value() {}
-    creal64_T value;
-    creal64_T *value_b_array;
+class SignalB
+{
+    public:
+        SignalB()
+            : value()
+        {
+        }
+        creal64_T value;
+        creal64_T* value_b_array;
 };
 
 #endif

--- a/test/SIM_python_namespace/models/TrickFood.hh
+++ b/test/SIM_python_namespace/models/TrickFood.hh
@@ -12,11 +12,10 @@ PYTHON_MODULE: ()
 
 #include <iostream>
 
-
 typedef struct
 {
-    char* itemName;
-    double price;
+        char* itemName;
+        double price;
 } GlobalFoodItem;
 
 enum Fast {
@@ -30,7 +29,7 @@ class Food {
     Food() : fast(Taco) {}
     void print_me() { std::cout << "Food::print_me!" << std::endl; }
     Fast fast;
-    GlobalFoodItem *globalFoodItems;
+    GlobalFoodItem* globalFoodItems;
 };
 
 

--- a/test/SIM_python_namespace/models/TrickFood.hh
+++ b/test/SIM_python_namespace/models/TrickFood.hh
@@ -13,6 +13,11 @@ PYTHON_MODULE: ()
 #include <iostream>
 
 
+typedef struct
+{
+    char* itemName;
+    double price;
+} GlobalFoodItem;
 
 enum Fast {
     Pizza,
@@ -25,6 +30,7 @@ class Food {
     Food() : fast(Taco) {}
     void print_me() { std::cout << "Food::print_me!" << std::endl; }
     Fast fast;
+    GlobalFoodItem *globalFoodItems;
 };
 
 


### PR DESCRIPTION
Fix the linking issue due to duplicate struct/class cast_as generated in .i files (castAs in _py.cpp) if the same typedef declaration in different header files. The linker would see duplicates if different headers share the same tyepdef if with program scope. 
Before PR #2111, cast_as never got generated (for both namespace and global typedef) so no issue but can't call alloc_type other than direct access in the input file.
The fix is to make castAt static so it's in translation unit scope and the linker never sees the duplicates.
