### PR TITLE
Let user aware when itimer is deactivate because the frame time is less than 10ms.

### DIFF
--- a/trick_source/sim_services/Timer/ITimer.cpp
+++ b/trick_source/sim_services/Timer/ITimer.cpp
@@ -99,8 +99,10 @@ int Trick::ITimer::start(double in_frame_time) {
 
         // check minimum time > 10ms
         if ( frame_sec == 0 && frame_usec < 10000 ) {
-            message_publish(MSG_WARNING, "ITimer: frame time (%g s or %g ms) is less than 10ms minimum; "
-                            "itimer disabled, falling back to clock_spin.\n", in_frame_time, in_frame_time*1000);
+            message_publish(MSG_WARNING,
+                            "ITimer: frame time (%g s or %g ms) is less than 10ms minimum; "
+                            "itimer disabled, falling back to clock_spin.\n",
+                            in_frame_time, in_frame_time * 1000);
             active = false ;
             return(0) ;
         }

--- a/trick_source/sim_services/Timer/ITimer.cpp
+++ b/trick_source/sim_services/Timer/ITimer.cpp
@@ -99,6 +99,8 @@ int Trick::ITimer::start(double in_frame_time) {
 
         // check minimum time > 10ms
         if ( frame_sec == 0 && frame_usec < 10000 ) {
+            message_publish(MSG_WARNING, "ITimer: frame time (%g s or %g ms) is less than 10ms minimum; "
+                            "itimer disabled, falling back to clock_spin.\n", in_frame_time, in_frame_time*1000);
             active = false ;
             return(0) ;
         }

--- a/trick_source/sim_services/Timer/ITimer.cpp
+++ b/trick_source/sim_services/Timer/ITimer.cpp
@@ -99,10 +99,13 @@ int Trick::ITimer::start(double in_frame_time) {
 
         // check minimum time > 10ms
         if ( frame_sec == 0 && frame_usec < 10000 ) {
-            message_publish(MSG_WARNING,
-                            "ITimer: frame time (%g s or %g ms) is less than 10ms minimum; "
-                            "itimer disabled, falling back to clock_spin.\n",
-                            in_frame_time, in_frame_time * 1000);
+            if (active)
+            {
+                message_publish(MSG_WARNING,
+                                "ITimer: frame time (%g s or %g ms) is less than 10ms minimum; "
+                                "itimer deactivated, falling back to clock_spin.\n",
+                                in_frame_time, in_frame_time * 1000);
+            }
             active = false ;
             return(0) ;
         }


### PR DESCRIPTION
Display a msg to notify the user whenever the itimer is changed from active to inactive even it's enabled because the frame time is less than 10ms. 