### PR TITLE
Use raw string for regex pattern in python

### DIFF
--- a/share/trick/trickops/TrickWorkflow.py
+++ b/share/trick/trickops/TrickWorkflow.py
@@ -142,7 +142,7 @@ class TrickWorkflow(WorkflowCommon):
         RuntimeError
            If more than one range string found
         """
-        pattern = "\[\d+-\d+\]"
+        pattern = r"\[\d+-\d+\]"
         if (len(re.findall(pattern, string))) > 1:
           msg = ("ERROR: [min-max] pattern found more than once in %s. Only one instance is"
             " supported." % (string))
@@ -1577,4 +1577,3 @@ class SingleRun(Job):
           - self._start_time)
         return 'Average Speed: {0:4.1f} X'.format(
           self._tics.value / self._tics_per_sec.value / elapsed_time)
-

--- a/share/trick/trickops/TrickWorkflow.py
+++ b/share/trick/trickops/TrickWorkflow.py
@@ -7,16 +7,32 @@ Requires: python3 and requirements.txt containing:
   PyYAML         # For reading input yml files
   psutil         # For child process acquisition
 """
-import os, sys, threading, socket, abc, time, re, copy, subprocess, hashlib, inspect
-from TrickWorkflowYamlVerifier import *  # TODO revisit this import - Jordan
 
+import copy
+import hashlib
+import inspect
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+from TrickWorkflowYamlVerifier import *  # TODO revisit this import - Jordan
 from WorkflowCommon import *
-import pprint
+
 # Import Trick natively supported python variable server utilities
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(
-  os.path.abspath(inspect.getsourcefile(lambda:0))), '../pymods')))
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda: 0))),
+            "../pymods",
+        )
+    )
+)
+
 from trick import variable_server
-import pdb
 
 # This global is the result of hours of frustration and debugging. This is only used by doctest
 # but appears to be the only solution to the problem of __file__ not being an absolute path in
@@ -31,7 +47,10 @@ import pdb
 # given for any function that prints, because we make use of color printing extensively in this
 # module via the tprint function, and doctest is not well suited for handling color output.
 #    - Sincerely, a quite ornery Dan Jordan 4/2021
-this_trick = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../..'))
+this_trick = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../..")
+)
+
 
 class TrickWorkflow(WorkflowCommon):
     """
@@ -76,11 +95,14 @@ class TrickWorkflow(WorkflowCommon):
       # Note that runs, comparisons, and analysis management classes and/or jobs also
       # support the report() method
     """
+
     # These are static so Run and Sim classes can access them when needed
     # TODO: It would be nice to consolidate and read this from .yaml_requirements.txt
     # -Jordan 12/2022
-    allowed_phase_range = {'min': -1000, 'max': 1000}
-    all_possible_phases = range(allowed_phase_range['min'], allowed_phase_range['max']+1)
+    allowed_phase_range = {"min": -1000, "max": 1000}
+    all_possible_phases = range(
+        allowed_phase_range["min"], allowed_phase_range["max"] + 1
+    )
 
     def listify_phase(phase=None):
         """
@@ -109,21 +131,28 @@ class TrickWorkflow(WorkflowCommon):
         """
         # Handle type of phase given
         phases = []  # To be populated with all valid phases requested by user
-        if (phase is None):
+        if phase is None:
             phases = list(TrickWorkflow.all_possible_phases)
         elif isinstance(phase, int) and phase in TrickWorkflow.all_possible_phases:
             phases = [phase]
-        elif ( (isinstance(phase, list) or isinstance(phase, range)) and
-          all(isinstance(p, int) for p in phase) and
-          all(p in TrickWorkflow.all_possible_phases for p in phase)):
+        elif (
+            (isinstance(phase, list) or isinstance(phase, range))
+            and all(isinstance(p, int) for p in phase)
+            and all(p in TrickWorkflow.all_possible_phases for p in phase)
+        ):
             phases = list(phase)  # Cast to list to cover range case
         else:
-            msg =("ERROR: Given phase %s in listify_given_phase() must be an int,"
-                  " list of ints, or range() within the bounds [%s, %s]" % (phase,
-                  TrickWorkflow.allowed_phase_range['min'],
-                  TrickWorkflow.allowed_phase_range['max']))
+            msg = (
+                "ERROR: Given phase %s in listify_given_phase() must be an int,"
+                " list of ints, or range() within the bounds [%s, %s]"
+                % (
+                    phase,
+                    TrickWorkflow.allowed_phase_range["min"],
+                    TrickWorkflow.allowed_phase_range["max"],
+                )
+            )
             raise RuntimeError(msg)
-        return(phases)
+        return phases
 
     def _find_range_string(string):
         """
@@ -144,16 +173,20 @@ class TrickWorkflow(WorkflowCommon):
         """
         pattern = r"\[\d+-\d+\]"
         if (len(re.findall(pattern, string))) > 1:
-          msg = ("ERROR: [min-max] pattern found more than once in %s. Only one instance is"
-            " supported." % (string))
-          raise RuntimeError(msg)
+            msg = (
+                "ERROR: [min-max] pattern found more than once in %s. Only one instance is"
+                " supported." % (string)
+            )
+            raise RuntimeError(msg)
         m = re.search(pattern, string)
         if m:
-          return m.group(0)
+            return m.group(0)
         else:
-          return None
+            return None
 
-    def __init__(self, project_top_level, log_dir, trick_dir, config_file, cpus=3, quiet=False):
+    def __init__(
+        self, project_top_level, log_dir, trick_dir, config_file, cpus=3, quiet=False
+    ):
         """
         Initialize this instance.
 
@@ -176,21 +209,25 @@ class TrickWorkflow(WorkflowCommon):
             when true which is useful for running in a CI system where stdin isn't
             available
         """
-        super().__init__(project_top_level=project_top_level, log_dir=log_dir, quiet=quiet)
-        self.config_errors =  []        # Contains errors in setup of management classes
-        self.compare_errors = False     # True if comparison errors were found
-        self.sims = []                  # list of Sim() instances, filled out from config file
+        super().__init__(
+            project_top_level=project_top_level, log_dir=log_dir, quiet=quiet
+        )
+        self.config_errors = []  # Contains errors in setup of management classes
+        self.compare_errors = False  # True if comparison errors were found
+        self.sims = []  # list of Sim() instances, filled out from config file
         self.config_file = config_file  # path to yml config
-        self.cpus = cpus                # Number of CPUs this workflow should use when running
+        self.cpus = cpus  # Number of CPUs this workflow should use when running
         self.yaml_verifier = TrickWorkflowYamlVerifier(self.config_file)
         # If not found in the config file, these defaults are used
         self.trick_dir = trick_dir
         self.trick_host_cpu = self.get_trick_host_cpu()
-        self.env = ''
+        self.env = ""
         self.config = self.yaml_verifier.verify()
-        self.parsing_errors = self.yaml_verifier.parsing_errors  # All errors found during parsing
+        self.parsing_errors = (
+            self.yaml_verifier.parsing_errors
+        )  # All errors found during parsing
         for e in self.parsing_errors:
-            tprint(e, 'DARK_RED')
+            tprint(e, "DARK_RED")
         self._populate_sims()
 
     def _populate_sims(self):
@@ -202,87 +239,127 @@ class TrickWorkflow(WorkflowCommon):
         from self.config so we can create all management classes at the sim and run
         levels without worry.
         """
+
         def cprint(msg, color):
             self.config_errors.append(msg)
             tprint(msg, color)
-        self.env = self.config['globals']['env']
-        all_sim_paths = [] # Keep a list of all paths for uniqueness check
+
+        self.env = self.config["globals"]["env"]
+        all_sim_paths = []  # Keep a list of all paths for uniqueness check
         for s in self.config:
-          if not str(s).startswith('SIM'):  # Ignore everything not starting with SIM
-            continue
-          if (not os.path.exists(os.path.join(self.project_top_level, self.config[s]['path'])) ):
-            cprint("ERROR: %s's 'path' %s not found. Continuing but skipping this entire entry from %s."
-                 % (s, self.config[s]['path'], self.config_file), 'DARK_RED')
-            continue
-          if self.config[s]['path'] in all_sim_paths:
-            cprint("ERROR: %s's 'path' is not unique in %s. Continuing but ignoring this sim."
-                % (s, self.config_file), 'DARK_RED')
-            continue
-          # Add the CPU format string (won't fail if there is no CPU placeholder)
-          self.config[s]['binary'] = self.config[s]['binary'].format(cpu=self.trick_host_cpu)
-          # Add the full path to the build command
-          trick_CP=os.path.join(self.trick_dir, "bin/trick-CP")
-          if self.config[s]['build_args']:
-            trick_CP+=(' ' + self.config[s]['build_args'])
-          thisSim = TrickWorkflow.Sim(name=s, sim_dir=self.config[s]['path'],
-            description=self.config[s]['description'], labels=self.config[s]['labels'],
-            prebuild_cmd=self.env, build_cmd=trick_CP,
-            cpus=self.cpus, size=self.config[s]['size'], phase=self.config[s]['phase'],
-            log_dir=self.log_dir)
-          all_sim_paths.append(self.config[s]['path'])
+            if not str(s).startswith("SIM"):  # Ignore everything not starting with SIM
+                continue
+            if not os.path.exists(
+                os.path.join(self.project_top_level, self.config[s]["path"])
+            ):
+                cprint(
+                    "ERROR: %s's 'path' %s not found. Continuing but skipping this entire entry from %s."
+                    % (s, self.config[s]["path"], self.config_file),
+                    "DARK_RED",
+                )
+                continue
+            if self.config[s]["path"] in all_sim_paths:
+                cprint(
+                    "ERROR: %s's 'path' is not unique in %s. Continuing but ignoring this sim."
+                    % (s, self.config_file),
+                    "DARK_RED",
+                )
+                continue
+            # Add the CPU format string (won't fail if there is no CPU placeholder)
+            self.config[s]["binary"] = self.config[s]["binary"].format(
+                cpu=self.trick_host_cpu
+            )
+            # Add the full path to the build command
+            trick_CP = os.path.join(self.trick_dir, "bin/trick-CP")
+            if self.config[s]["build_args"]:
+                trick_CP += " " + self.config[s]["build_args"]
+            thisSim = TrickWorkflow.Sim(
+                name=s,
+                sim_dir=self.config[s]["path"],
+                description=self.config[s]["description"],
+                labels=self.config[s]["labels"],
+                prebuild_cmd=self.env,
+                build_cmd=trick_CP,
+                cpus=self.cpus,
+                size=self.config[s]["size"],
+                phase=self.config[s]["phase"],
+                log_dir=self.log_dir,
+            )
+            all_sim_paths.append(self.config[s]["path"])
 
-          all_run_paths = []   # Keep a list of all paths for uniqueness check
-          for r in self.config[s]['runs']:
-            just_RUN = r.split()[0]                   # Drop arguments after RUN../...py
-            just_RUN_dir = os.path.dirname(just_RUN)  # Drop path before     RUN../..py
-            # TODO: This check will break generated runs, do we even need to check this at all? - Jordan 2022
-            #if not os.path.exists(os.path.join(self.project_top_level, self.config[s]['path'], just_RUN)):
-            #  cprint("ERROR: %s's 'run' path %s not found. Continuing but skipping this run "
-            #    "from %s." % (s, just_RUN, self.config_file), 'DARK_RED')
-            #  continue
-            if just_RUN_dir in all_run_paths and self.config[s]['parallel_safety'] == 'strict':
-              cprint("ERROR: %s's run directory %s is not unique in %s. With setting "
-                     "parallel_safety: strict, you cannot have the same RUN directory listed "
-                     "more than once per sim. Continuing but skipping this run." %
-                     (s, r, self.config_file), 'DARK_RED')
-              continue
+            all_run_paths = []  # Keep a list of all paths for uniqueness check
+            for r in self.config[s]["runs"]:
+                just_RUN = r.split()[0]  # Drop arguments after RUN../...py
+                just_RUN_dir = os.path.dirname(
+                    just_RUN
+                )  # Drop path before     RUN../..py
+                # TODO: This check will break generated runs, do we even need to check this at all? - Jordan 2022
+                # if not os.path.exists(os.path.join(self.project_top_level, self.config[s]['path'], just_RUN)):
+                #  cprint("ERROR: %s's 'run' path %s not found. Continuing but skipping this run "
+                #    "from %s." % (s, just_RUN, self.config_file), 'DARK_RED')
+                #  continue
+                if (
+                    just_RUN_dir in all_run_paths
+                    and self.config[s]["parallel_safety"] == "strict"
+                ):
+                    cprint(
+                        "ERROR: %s's run directory %s is not unique in %s. With setting "
+                        "parallel_safety: strict, you cannot have the same RUN directory listed "
+                        "more than once per sim. Continuing but skipping this run."
+                        % (s, r, self.config_file),
+                        "DARK_RED",
+                    )
+                    continue
 
-            thisRun = TrickWorkflow.Run(sim_dir=self.config[s]['path'], input_file=r,
-                          binary= self.config[s]['binary'], prerun_cmd=self.env,
-                          returns=self.config[s]['runs'][r]['returns'],
-                          valgrind_flags=self.config[s]['runs'][r]['valgrind'],
-                          phase=self.config[s]['runs'][r]['phase'], log_dir=self.log_dir)
+                thisRun = TrickWorkflow.Run(
+                    sim_dir=self.config[s]["path"],
+                    input_file=r,
+                    binary=self.config[s]["binary"],
+                    prerun_cmd=self.env,
+                    returns=self.config[s]["runs"][r]["returns"],
+                    valgrind_flags=self.config[s]["runs"][r]["valgrind"],
+                    phase=self.config[s]["runs"][r]["phase"],
+                    log_dir=self.log_dir,
+                )
 
-            # The check for list allows all other non-list types in the yaml file,
-            # allowing groups to define their own comparison methodology
-            if isinstance(self.config[s]['runs'][r]['compare'], list):
-              for cmp in self.config[s]['runs'][r]['compare']:
-                lhs, rhs = [ s.strip() for s in cmp.split(' vs.') ]
-                thisRun.add_comparison(test_data=lhs, baseline_data=rhs)
+                # The check for list allows all other non-list types in the yaml file,
+                # allowing groups to define their own comparison methodology
+                if isinstance(self.config[s]["runs"][r]["compare"], list):
+                    for cmp in self.config[s]["runs"][r]["compare"]:
+                        lhs, rhs = [s.strip() for s in cmp.split(" vs.")]
+                        thisRun.add_comparison(test_data=lhs, baseline_data=rhs)
 
-            if self.config[s]['runs'][r]['analyze'] is not None:
-              thisRun.add_analysis(cmd=self.config[s]['runs'][r]['analyze'])
+                if self.config[s]["runs"][r]["analyze"] is not None:
+                    thisRun.add_analysis(cmd=self.config[s]["runs"][r]["analyze"])
 
-            theseRuns = []
-            try:
-              theseRuns = thisRun.multiply()  # If [from-to] notation used, expand runs
-            except RuntimeError as e:
-              msg = ("ERROR: Unable to multiply run %s in sim %s. Ignoring this run. "
-                  "Check for bad [min-max] syntax in run keys in %s and try again.\n  %s"
-                  % (r, s, self.config_file, e) )
-              cprint(msg, 'DARK_RED')
+                theseRuns = []
+                try:
+                    theseRuns = (
+                        thisRun.multiply()
+                    )  # If [from-to] notation used, expand runs
+                except RuntimeError as e:
+                    msg = (
+                        "ERROR: Unable to multiply run %s in sim %s. Ignoring this run. "
+                        "Check for bad [min-max] syntax in run keys in %s and try again.\n  %s"
+                        % (r, s, self.config_file, e)
+                    )
+                    cprint(msg, "DARK_RED")
 
-            for r in theseRuns:
-              thisSim.add_run(r)      # Add Run/Runs to this Sim()
+                for r in theseRuns:
+                    thisSim.add_run(r)  # Add Run/Runs to this Sim()
 
-            all_run_paths.append(just_RUN_dir)  # Keep track of all runs to check parallel safety
+                all_run_paths.append(
+                    just_RUN_dir
+                )  # Keep track of all runs to check parallel safety
 
-          self.sims.append(thisSim)   # Add Sim() to internal list
+            self.sims.append(thisSim)  # Add Sim() to internal list
         if len(self.sims) < 1:  # At minimum, one valid SIM structure must exist
-            msg = ("ERROR: After validating config file, there is insufficient information to continue."
+            msg = (
+                "ERROR: After validating config file, there is insufficient information to continue."
                 " Check the syntax in config file %s and try again."
-                % (self.config_file) )
-            cprint(msg, 'DARK_RED')
+                % (self.config_file)
+            )
+            cprint(msg, "DARK_RED")
             self._cleanup()
             raise RuntimeError(msg)
 
@@ -297,10 +374,10 @@ class TrickWorkflow(WorkflowCommon):
         >>> tw.create_test_suite()
 
         """
-        self.get_jobs(kind='build')
-        self.get_jobs(kind='run')
-        self.get_jobs(kind='analysis')
-        self.get_jobs(kind='valgrind')
+        self.get_jobs(kind="build")
+        self.get_jobs(kind="run")
+        self.get_jobs(kind="analysis")
+        self.get_jobs(kind="valgrind")
 
     def get_trick_host_cpu(self):
         """
@@ -315,12 +392,17 @@ class TrickWorkflow(WorkflowCommon):
         str or None
             TRICK_HOST_CPU or None if it cannot be determined
         """
-        gte_cmd = [os.path.join(self.trick_dir, "bin/trick-gte" ), "TRICK_HOST_CPU"]
-        result = run_subprocess(gte_cmd, m_stdout=subprocess.PIPE, m_stderr=subprocess.PIPE)
+        gte_cmd = [os.path.join(self.trick_dir, "bin/trick-gte"), "TRICK_HOST_CPU"]
+        result = run_subprocess(
+            gte_cmd, m_stdout=subprocess.PIPE, m_stderr=subprocess.PIPE
+        )
         self.trick_host_cpu = result.stdout.strip()
-        if self.trick_host_cpu == None or self.trick_host_cpu == '':
-            tprint("ERROR: Unable to determine TRICK_HOST_CPU, you may encounter problems "
-            "if you continue... ", 'DARK_RED')
+        if self.trick_host_cpu == None or self.trick_host_cpu == "":
+            tprint(
+                "ERROR: Unable to determine TRICK_HOST_CPU, you may encounter problems "
+                "if you continue... ",
+                "DARK_RED",
+            )
             self.trick_host_cpu = None
         return self.trick_host_cpu
 
@@ -350,7 +432,9 @@ class TrickWorkflow(WorkflowCommon):
             If identifier is not a str
         """
         if type(identifier) != str:
-            raise TypeError('get_sim() only accepts a Sim name or Sim path from project top level')
+            raise TypeError(
+                "get_sim() only accepts a Sim name or Sim path from project top level"
+            )
         for sim in self.sims:
             if sim.sim_dir == identifier or sim.name == identifier:
                 return sim
@@ -391,14 +475,15 @@ class TrickWorkflow(WorkflowCommon):
         elif type(labels) == list:
             ls = [str(l) for l in labels]
         else:
-            raise TypeError('get_sims() only accepts a label string or list of label strings')
+            raise TypeError(
+                "get_sims() only accepts a label string or list of label strings"
+            )
         for sim in self.sims:
             if all(l in sim.labels for l in ls):
                 sims_found.append(sim)
         return sims_found
 
-
-    def report(self, indent=''):
+    def report(self, indent=""):
         """
         Recursively report all internal information
         >>> tw = TrickWorkflow(project_top_level=this_trick, log_dir='/tmp/', trick_dir=this_trick, config_file=os.path.join(this_trick,"share/trick/trickops/tests/trick_sims.yml"))
@@ -410,41 +495,90 @@ class TrickWorkflow(WorkflowCommon):
         Print a summary of all jobs executed, and return 'SUCCESS' if all were successful, 'FAILURE'
         if any job was not successful
         """
-        all_builds      = self.get_jobs(kind='build')
-        all_runs        = self.get_jobs(kind='run')
-        all_analysis    = self.get_jobs(kind='analysis')
+        all_builds = self.get_jobs(kind="build")
+        all_runs = self.get_jobs(kind="run")
+        all_analysis = self.get_jobs(kind="analysis")
         all_comparisons = self.get_comparisons()
-        all_valgrind    = self.get_jobs(kind='valgrind')
+        all_valgrind = self.get_jobs(kind="valgrind")
 
-        executed_builds = [ build for build in all_builds if build.get_status() != Job.Status.NOT_STARTED ]
-        executed_runs   = [ run for run in all_runs if run.get_status() != Job.Status.NOT_STARTED ]
-        executed_analysis = [ a for a in all_analysis if a.get_status() != Job.Status.NOT_STARTED ]
-        executed_comparisons  = [ c for c in all_comparisons if c.status  != Job.Status.NOT_STARTED ]
-        executed_valgrind = [ v for v in all_valgrind if v.get_status() != Job.Status.NOT_STARTED ]
+        executed_builds = [
+            build
+            for build in all_builds
+            if build.get_status() != Job.Status.NOT_STARTED
+        ]
+        executed_runs = [
+            run for run in all_runs if run.get_status() != Job.Status.NOT_STARTED
+        ]
+        executed_analysis = [
+            a for a in all_analysis if a.get_status() != Job.Status.NOT_STARTED
+        ]
+        executed_comparisons = [
+            c for c in all_comparisons if c.status != Job.Status.NOT_STARTED
+        ]
+        executed_valgrind = [
+            v for v in all_valgrind if v.get_status() != Job.Status.NOT_STARTED
+        ]
 
-        ok_builds       = [ build for build in executed_builds  if build.get_status() == Job.Status.SUCCESS ]
-        ok_runs         = [ run for run in executed_runs if run.get_status() == Job.Status.SUCCESS ]
-        ok_analysis     = [ a for a in executed_analysis if a.get_status() == Job.Status.SUCCESS ]
-        ok_comparisons  = [ c for c in executed_comparisons if c.status  == Job.Status.SUCCESS ]
-        ok_valgrind     = [ v for v in executed_valgrind if v.get_status() == Job.Status.SUCCESS ]
+        ok_builds = [
+            build
+            for build in executed_builds
+            if build.get_status() == Job.Status.SUCCESS
+        ]
+        ok_runs = [
+            run for run in executed_runs if run.get_status() == Job.Status.SUCCESS
+        ]
+        ok_analysis = [
+            a for a in executed_analysis if a.get_status() == Job.Status.SUCCESS
+        ]
+        ok_comparisons = [
+            c for c in executed_comparisons if c.status == Job.Status.SUCCESS
+        ]
+        ok_valgrind = [
+            v for v in executed_valgrind if v.get_status() == Job.Status.SUCCESS
+        ]
 
-        tprint( "SUMMARY:" )
+        tprint("SUMMARY:")
         if executed_builds:
-          tprint( "  {0} out of {1} builds succeeded".format(len(ok_builds),len(executed_builds)))
+            tprint(
+                "  {0} out of {1} builds succeeded".format(
+                    len(ok_builds), len(executed_builds)
+                )
+            )
         if executed_runs:
-          tprint( "  {0} out of {1} runs succeeded".format(len(ok_runs),len(executed_runs)))
+            tprint(
+                "  {0} out of {1} runs succeeded".format(
+                    len(ok_runs), len(executed_runs)
+                )
+            )
         if executed_analysis:
-          tprint( "  {0} out of {1} analyses succeeded".format(len(ok_analysis),len(executed_analysis)))
+            tprint(
+                "  {0} out of {1} analyses succeeded".format(
+                    len(ok_analysis), len(executed_analysis)
+                )
+            )
         if executed_comparisons:
-          tprint( "  {0} out of {1} comparisons succeeded".format(len(ok_comparisons),len(executed_comparisons)))
+            tprint(
+                "  {0} out of {1} comparisons succeeded".format(
+                    len(ok_comparisons), len(executed_comparisons)
+                )
+            )
         if executed_valgrind:
-          tprint( "  {0} out of {1} valgrind runs succeeded".format(len(ok_valgrind),len(executed_valgrind)))
+            tprint(
+                "  {0} out of {1} valgrind runs succeeded".format(
+                    len(ok_valgrind), len(executed_valgrind)
+                )
+            )
 
-        if (executed_builds == ok_builds and executed_runs == ok_runs and executed_analysis == ok_analysis
-            and executed_comparisons == ok_comparisons and executed_valgrind == ok_valgrind) :
-          return 'SUCCESS'
+        if (
+            executed_builds == ok_builds
+            and executed_runs == ok_runs
+            and executed_analysis == ok_analysis
+            and executed_comparisons == ok_comparisons
+            and executed_valgrind == ok_valgrind
+        ):
+            return "SUCCESS"
         else:
-          return 'FAILURE'
+            return "FAILURE"
 
     def compare(self):
         """
@@ -490,25 +624,27 @@ class TrickWorkflow(WorkflowCommon):
         phases = TrickWorkflow.listify_phase(phase)
 
         jobs = []
-        if kind == 'build' or kind == 'builds':
-            jobs = [ sim.get_build_job() for sim in self.sims if sim.phase in phases ]
-        elif kind == 'run' or kind == 'runs':
-          for sim in self.sims:
-            jobs +=  sim.get_run_jobs(kind='normal', phase=phases)
-        elif kind == 'valgrind' or kind == 'valgrinds':
-          for sim in self.sims:
-            jobs +=  sim.get_run_jobs(kind='valgrind', phase=phases)
-        elif kind == 'analysis' or kind == 'analyses' or kind == 'analyze':
-          for sim in self.sims:
-            jobs +=  sim.get_analysis_jobs(phase=phases)
+        if kind == "build" or kind == "builds":
+            jobs = [sim.get_build_job() for sim in self.sims if sim.phase in phases]
+        elif kind == "run" or kind == "runs":
+            for sim in self.sims:
+                jobs += sim.get_run_jobs(kind="normal", phase=phases)
+        elif kind == "valgrind" or kind == "valgrinds":
+            for sim in self.sims:
+                jobs += sim.get_run_jobs(kind="valgrind", phase=phases)
+        elif kind == "analysis" or kind == "analyses" or kind == "analyze":
+            for sim in self.sims:
+                jobs += sim.get_analysis_jobs(phase=phases)
         else:
-            raise TypeError('get_jobs() only accepts kinds: build, run, valgrind, analysis')
+            raise TypeError(
+                "get_jobs() only accepts kinds: build, run, valgrind, analysis"
+            )
         # If these jobs are of type SingleRun and self.quiet is True, tell the jobs to
         # skip the variable server connection logic
         for job in jobs:
             if self.quiet and isinstance(job, SingleRun):
                 job.set_use_var_server(False)
-        return (jobs)
+        return jobs
 
     def get_comparisons(self):
         """
@@ -524,7 +660,7 @@ class TrickWorkflow(WorkflowCommon):
         list
             List of Comparison objects
         """
-        return ([ c for sim in self.sims for run in sim.runs for c in run.comparisons ])
+        return [c for sim in self.sims for run in sim.runs for c in run.comparisons]
 
     def get_unique_comparison_dirs(self):
         """
@@ -547,11 +683,11 @@ class TrickWorkflow(WorkflowCommon):
         """
         all_cmp_dirnames = []  # list of tuples ( test_dir, baseline_dir )
         for sim in self.sims:
-          for run in sim.runs:
-            for cmp in run.comparisons:
-              all_cmp_dirnames.append(cmp.get_dirnames())
+            for run in sim.runs:
+                for cmp in run.comparisons:
+                    all_cmp_dirnames.append(cmp.get_dirnames())
         # Reduce full list to unique list
-        return(list(set(all_cmp_dirnames)))
+        return list(set(all_cmp_dirnames))
 
     def get_koviz_report_job(self, test_dir, baseline_dir, pres=None):
         """
@@ -580,28 +716,44 @@ class TrickWorkflow(WorkflowCommon):
            (Job() instance for the run directories given or None if error encountered,
             error details or None if successful)
         """
-        if os.system(self.env + ' which koviz > /dev/null 2>&1') != 0:
+        if os.system(self.env + " which koviz > /dev/null 2>&1") != 0:
             msg = "ERROR: koviz is not found in PATH. Returning None in get_koviz_report_job()"
-            tprint (msg, 'DARK_RED')
+            tprint(msg, "DARK_RED")
             return None, msg
         dirs = [test_dir, baseline_dir]
         for dir in dirs:
-           if not os.path.exists(dir):
-            msg = "ERROR: %s not found, Returning None in get_koviz_report_job()" % (dir)
-            tprint(msg, 'DARK_RED')
-            return None, msg
-        cmd = (self.env + " koviz -platform offscreen -a")
+            if not os.path.exists(dir):
+                msg = (
+                    "ERROR: %s not found, Returning None in get_koviz_report_job()"
+                    % (dir)
+                )
+                tprint(msg, "DARK_RED")
+                return None, msg
+        cmd = self.env + " koviz -platform offscreen -a"
         if pres:
-            cmd+= (" -pres %s " % pres )
-        cmd+= (" -pdf %s %s %s" % (os.path.join(self.log_dir,
-            (unixify_string(test_dir)+'_vs_' + unixify_string(baseline_dir)) + '.pdf'),
-            test_dir, baseline_dir) )
-        name='koviz report %s vs. %s' % (test_dir, baseline_dir)
-        return(Job(name=name, command=cmd, log_file=os.path.join(self.log_dir,"."+unixify_string(name)),
-          expected_exit_status=0), None)
+            cmd += " -pres %s " % pres
+        cmd += " -pdf %s %s %s" % (
+            os.path.join(
+                self.log_dir,
+                (unixify_string(test_dir) + "_vs_" + unixify_string(baseline_dir))
+                + ".pdf",
+            ),
+            test_dir,
+            baseline_dir,
+        )
+        name = "koviz report %s vs. %s" % (test_dir, baseline_dir)
+        return (
+            Job(
+                name=name,
+                command=cmd,
+                log_file=os.path.join(self.log_dir, "." + unixify_string(name)),
+                expected_exit_status=0,
+            ),
+            None,
+        )
 
     def get_koviz_report_jobs(self):
-        '''
+        """
         Loop over all runs for all sims and generate a koviz pdf report job for each unique
         run directory comparison found.
 
@@ -618,18 +770,22 @@ class TrickWorkflow(WorkflowCommon):
         -------
         Tuple
             List of 'koviz' commands executed, List of errors
-        '''
+        """
         koviz_jobs = []
         koviz_errors = []
-        all_cmp_dirnames = self.get_unique_comparison_dirs() # List of (test_dir, baseline_dir) tuples
+        all_cmp_dirnames = (
+            self.get_unique_comparison_dirs()
+        )  # List of (test_dir, baseline_dir) tuples
         # Generate koviz reports for the given test_dir, baseline_dir pairs
-        for (test_dir, baseline_dir) in all_cmp_dirnames:
-          if test_dir and baseline_dir:  # Will be None if dir is empty
-            job, error = self.get_koviz_report_job(test_dir, baseline_dir, pres='error')
-            if job:
-              koviz_jobs.append(job)
-            if error:
-              koviz_errors.append(error)
+        for test_dir, baseline_dir in all_cmp_dirnames:
+            if test_dir and baseline_dir:  # Will be None if dir is empty
+                job, error = self.get_koviz_report_job(
+                    test_dir, baseline_dir, pres="error"
+                )
+                if job:
+                    koviz_jobs.append(job)
+                if error:
+                    koviz_errors.append(error)
         return koviz_jobs, koviz_errors
 
     class Sim(object):
@@ -638,8 +794,20 @@ class TrickWorkflow(WorkflowCommon):
         key in the dict read will become a single instance of this management class
         stored in the TrickWorkflow.sims list.
         """
-        def __init__(self, name, sim_dir, description=None, labels=[], prebuild_cmd='',
-                     build_cmd='trick-CP', cpus=3, size=2200000, phase=0, log_dir='/tmp'):
+
+        def __init__(
+            self,
+            name,
+            sim_dir,
+            description=None,
+            labels=[],
+            prebuild_cmd="",
+            build_cmd="trick-CP",
+            cpus=3,
+            size=2200000,
+            phase=0,
+            log_dir="/tmp",
+        ):
             """
             Initialize this instance.
 
@@ -667,22 +835,24 @@ class TrickWorkflow(WorkflowCommon):
              log_dir: str
                 Directory in which log files will be written
             """
-            self.name = name               # Name of sim
-            self.sim_dir = sim_dir         # Path to sim directory wrt to top level of project
-            self.description = description # Description of sim
-            self.labels = labels           # Options list of user-specified labels associated w/ this sim
-            self.prebuild_cmd = prebuild_cmd # Optional string to execute in shell immediately before building
-            self.build_cmd = build_cmd     # Build command for sim
-            self.cpus = cpus               # Number of CPUs to use in build
-            self.size = size               # Estimated size of successful build output in bytes
-            self.phase = phase             # Phase associated with this sim build
-            self.log_dir = log_dir         # Directory for which log file should be written
-            self.build_job = None          # Contains Build Job instance
-            self.runs = []                 # List of normal Run instances
-            self.valgrind_runs = []        # List of valgrind Run instances
-            self.printer = ColorStr()      # Color printer utility
+            self.name = name  # Name of sim
+            self.sim_dir = sim_dir  # Path to sim directory wrt to top level of project
+            self.description = description  # Description of sim
+            self.labels = (
+                labels  # Options list of user-specified labels associated w/ this sim
+            )
+            self.prebuild_cmd = prebuild_cmd  # Optional string to execute in shell immediately before building
+            self.build_cmd = build_cmd  # Build command for sim
+            self.cpus = cpus  # Number of CPUs to use in build
+            self.size = size  # Estimated size of successful build output in bytes
+            self.phase = phase  # Phase associated with this sim build
+            self.log_dir = log_dir  # Directory for which log file should be written
+            self.build_job = None  # Contains Build Job instance
+            self.runs = []  # List of normal Run instances
+            self.valgrind_runs = []  # List of valgrind Run instances
+            self.printer = ColorStr()  # Color printer utility
 
-        def get_build_job( self):
+        def get_build_job(self):
             """
             Create the FileSizeJob(Job) instance if not already created and return it for this Sim
 
@@ -697,15 +867,21 @@ class TrickWorkflow(WorkflowCommon):
             """
 
             if not self.build_job:
-                name = 'Build ' + self.sim_dir
-                self.build_job = FileSizeJob(name=name,
-                    command=("%s cd %s && export MAKEFLAGS=-j%d && %s" %
-                    (self.prebuild_cmd, self.sim_dir, self.cpus, self.build_cmd)),
-                    log_file=os.path.join(self.log_dir, unixify_string(self.sim_dir)+'_build.txt'),
-                    size=self.size )
-            return (self.build_job)
+                name = "Build " + self.sim_dir
+                self.build_job = FileSizeJob(
+                    name=name,
+                    command=(
+                        "%s cd %s && export MAKEFLAGS=-j%d && %s"
+                        % (self.prebuild_cmd, self.sim_dir, self.cpus, self.build_cmd)
+                    ),
+                    log_file=os.path.join(
+                        self.log_dir, unixify_string(self.sim_dir) + "_build.txt"
+                    ),
+                    size=self.size,
+                )
+            return self.build_job
 
-        def get_run_jobs( self, kind='normal', phase=None):
+        def get_run_jobs(self, kind="normal", phase=None):
             """
             Collect all SingleRun() instances and return them for all sims subject to the filtering
             paramters kind and phase
@@ -730,13 +906,15 @@ class TrickWorkflow(WorkflowCommon):
             # Transform given phase into a list
             phases = TrickWorkflow.listify_phase(phase)
             all_jobs = []
-            if (kind == 'valgrind'):
-                all_jobs = [r.get_run_job() for r in self.valgrind_runs if r.phase in phases]
+            if kind == "valgrind":
+                all_jobs = [
+                    r.get_run_job() for r in self.valgrind_runs if r.phase in phases
+                ]
             else:
                 all_jobs = [r.get_run_job() for r in self.runs if r.phase in phases]
-            return (all_jobs)
+            return all_jobs
 
-        def get_analysis_jobs( self, phase=None):
+        def get_analysis_jobs(self, phase=None):
             """
             Collect all Job() instances for all analysis across all sim runs and valgrind runs
 
@@ -757,7 +935,11 @@ class TrickWorkflow(WorkflowCommon):
             """
             # Transform given phase into a list
             phases = TrickWorkflow.listify_phase(phase)
-            return ([r.analysis for r in (self.runs + self.valgrind_runs) if (r.analysis and r.phase in phases) ])
+            return [
+                r.analysis
+                for r in (self.runs + self.valgrind_runs)
+                if (r.analysis and r.phase in phases)
+            ]
 
         def get_run(self, input_file):
             """
@@ -784,11 +966,13 @@ class TrickWorkflow(WorkflowCommon):
                 If input is not a str
             """
             if type(input_file) != str:
-                raise TypeError('get_run() only accepts the unique key representing the entire input to'
-                  ' the sim binary. Ex: "RUN_test/input.py --flags-too"')
+                raise TypeError(
+                    "get_run() only accepts the unique key representing the entire input to"
+                    ' the sim binary. Ex: "RUN_test/input.py --flags-too"'
+                )
             for run in self.runs:
                 if run.input_file == input_file:
-                   return run
+                    return run
             return None
 
         def get_runs(self):
@@ -824,7 +1008,7 @@ class TrickWorkflow(WorkflowCommon):
             """
             return self.phase
 
-        def set_phase( self, phase):
+        def set_phase(self, phase):
             """
             Set the phase member variable. Phase is an integer in the range(TrickWorkflow.allowed_phase_range['min'],
             TrickWorkflow.allowed_phase_range['max']) which can be used to order sim builds when a workflow cannot
@@ -842,15 +1026,24 @@ class TrickWorkflow(WorkflowCommon):
             phase : int
                 phase to change to
             """
-            if (not isinstance(phase, int) or phase < TrickWorkflow.allowed_phase_range['min'] or
-                phase > TrickWorkflow.allowed_phase_range['max']):
-                msg =("ERROR: set_phase() for SIM %s must be an integer between [%s, %s]"
-                      % (self.name, TrickWorkflow.allowed_phase_range['min'], TrickWorkflow.allowed_phase_range['max']))
+            if (
+                not isinstance(phase, int)
+                or phase < TrickWorkflow.allowed_phase_range["min"]
+                or phase > TrickWorkflow.allowed_phase_range["max"]
+            ):
+                msg = (
+                    "ERROR: set_phase() for SIM %s must be an integer between [%s, %s]"
+                    % (
+                        self.name,
+                        TrickWorkflow.allowed_phase_range["min"],
+                        TrickWorkflow.allowed_phase_range["max"],
+                    )
+                )
                 raise RuntimeError(msg)
             else:
                 self.phase = phase
 
-        def add_run( self, run):
+        def add_run(self, run):
             """
             Append a new Run() instance to the internal run lists. Appends to valgrind
             list if run.valgrind_flags is not None, appends to normal run list otherwise
@@ -864,12 +1057,12 @@ class TrickWorkflow(WorkflowCommon):
             run : Run()
                 Instance to add
             """
-            if (run.valgrind_flags):
+            if run.valgrind_flags:
                 self.valgrind_runs.append(run)
             else:
                 self.runs.append(run)
 
-        def pop_run( self, input_file):
+        def pop_run(self, input_file):
             """
             Remove a run by its unique self.input_file value
 
@@ -889,10 +1082,10 @@ class TrickWorkflow(WorkflowCommon):
                 Instance in this sim's runs list matching self.input_file
             """
             for i, run in enumerate(self.runs):
-              if run.input_file == input_file:
-                 return self.runs.pop(i)
+                if run.input_file == input_file:
+                    return self.runs.pop(i)
 
-        def compare( self):
+        def compare(self):
             """
             Run compare() on all runs for this sim
 
@@ -907,7 +1100,7 @@ class TrickWorkflow(WorkflowCommon):
             """
             return any([r.compare() for r in self.runs])
 
-        def report(self, indent=''):
+        def report(self, indent=""):
             """
             Report this sims information verbosely, ignoring members that are None
 
@@ -918,31 +1111,49 @@ class TrickWorkflow(WorkflowCommon):
 
             """
             if self.name:
-              tprint(indent + "Name:                 " + self.name)
+                tprint(indent + "Name:                 " + self.name)
             else:
-              tprint(indent + self.sim_dir)
+                tprint(indent + self.sim_dir)
             if self.description:
-              tprint(indent + "Description:          " + str(self.description))
+                tprint(indent + "Description:          " + str(self.description))
             if self.labels:
-              tprint(indent + "Labels:               " + str(', '.join(self.labels)))
-            tprint(indent + "  Build: %-20s  %-60s  " %(self.build_job._translate_status()
-              if self.build_job else printer.colorstr('NOT RUN', 'DARK_YELLOW'), self.sim_dir))
+                tprint(indent + "Labels:               " + str(", ".join(self.labels)))
+            tprint(
+                indent
+                + "  Build: %-20s  %-60s  "
+                % (
+                    self.build_job._translate_status()
+                    if self.build_job
+                    else printer.colorstr("NOT RUN", "DARK_YELLOW"),
+                    self.sim_dir,
+                )
+            )
             if self.runs:
-              tprint(indent + "  Runs:")
-              for run in self.runs:
-                  run.report(indent=indent+'  ')
+                tprint(indent + "  Runs:")
+                for run in self.runs:
+                    run.report(indent=indent + "  ")
             if self.valgrind_runs:
-              tprint(indent + "  Valgrind Runs:")
-              for run in self.valgrind_runs:
-                  run.report(indent=indent+'  ')
+                tprint(indent + "  Valgrind Runs:")
+                for run in self.valgrind_runs:
+                    run.report(indent=indent + "  ")
 
     class Run(object):
         """
         Management class for run content read from yml config file. Each key in the
         runs: sub-dict will become a single instance of this management class
         """
-        def __init__(self, sim_dir, input_file, binary, prerun_cmd = '', returns=0, valgrind_flags=None,
-                     phase=0, log_dir='/tmp/'):
+
+        def __init__(
+            self,
+            sim_dir,
+            input_file,
+            binary,
+            prerun_cmd="",
+            returns=0,
+            valgrind_flags=None,
+            phase=0,
+            log_dir="/tmp/",
+        ):
             """
             Initialize this instance.
 
@@ -970,23 +1181,23 @@ class TrickWorkflow(WorkflowCommon):
              log_dir : str
                 Directory in which log files will be written
             """
-            self.sim_dir = sim_dir        # Path to sim directory wrt to top level of project for this run
+            self.sim_dir = sim_dir  # Path to sim directory wrt to top level of project for this run
             self.prerun_cmd = prerun_cmd  # Optional string to execute in shell immediately before running (env)
             self.input_file = input_file  # Full RUN.../input.py --any-flags --as-well, relative to sim_dir
-            self.returns = returns        # Expected exit code on success for this run
+            self.returns = returns  # Expected exit code on success for this run
             self.valgrind_flags = valgrind_flags  # If not None, this run is to be run in valgrind w/ these flags
-            self.phase = phase            # Phase associated with this run
-            self.log_dir = log_dir        # Dir where all logged output will go
-            self.just_input = self.input_file.split(' ')[0]  # Strip flags if any
+            self.phase = phase  # Phase associated with this run
+            self.log_dir = log_dir  # Dir where all logged output will go
+            self.just_input = self.input_file.split(" ")[0]  # Strip flags if any
             # Derive Just the "RUN_something" part of run_dir_path
             self.just_run_dir = os.path.dirname(self.just_input)
             # Derive Path to run directory wrt to top level of project
             self.run_dir_path = os.path.join(self.sim_dir, self.just_run_dir)
             # Populated later
-            self.binary = binary     # Name of binary
-            self.run_job = None      # SingleRun Job instance for this run
-            self.comparisons = []    # List of comparison objects associated with this run
-            self.analysis = None     # Job instance of after-run-completes custom analysis
+            self.binary = binary  # Name of binary
+            self.run_job = None  # SingleRun Job instance for this run
+            self.comparisons = []  # List of comparison objects associated with this run
+            self.analysis = None  # Job instance of after-run-completes custom analysis
 
         def add_comparison(self, test_data, baseline_data):
             """
@@ -1002,8 +1213,8 @@ class TrickWorkflow(WorkflowCommon):
             baseline_dir : str
                 path to file containing baseline logged data
             """
-            comparison = TrickWorkflow.Comparison( test_data, baseline_data );
-            self.comparisons.append( comparison )
+            comparison = TrickWorkflow.Comparison(test_data, baseline_data)
+            self.comparisons.append(comparison)
 
         def add_analysis(self, cmd):
             """
@@ -1018,12 +1229,23 @@ class TrickWorkflow(WorkflowCommon):
                 literal string representing command to execute post-run
             """
             if self.analysis:
-                tprint("WARNING: Overwriting analysis definition for %s's %s" % (self.sim_dir,
-                  self.input_file), 'DARK_YELLOW')
-            logfile = (os.path.join(self.log_dir, unixify_string(self.sim_dir))
-                +'_'+ unixify_string(self.input_file) + '_analysis.txt')
-            self.analysis =  Job(name=textwrap.shorten(cmd, width=90), command=self.prerun_cmd + " " +cmd,
-              log_file=logfile, expected_exit_status=0)
+                tprint(
+                    "WARNING: Overwriting analysis definition for %s's %s"
+                    % (self.sim_dir, self.input_file),
+                    "DARK_YELLOW",
+                )
+            logfile = (
+                os.path.join(self.log_dir, unixify_string(self.sim_dir))
+                + "_"
+                + unixify_string(self.input_file)
+                + "_analysis.txt"
+            )
+            self.analysis = Job(
+                name=textwrap.shorten(cmd, width=90),
+                command=self.prerun_cmd + " " + cmd,
+                log_file=logfile,
+                expected_exit_status=0,
+            )
 
         def get_phase(self):
             """
@@ -1036,7 +1258,7 @@ class TrickWorkflow(WorkflowCommon):
             """
             return self.phase
 
-        def set_phase( self, phase):
+        def set_phase(self, phase):
             """
             Set the phase member variable. Phase is an integer in the range(TrickWorkflow.allowed_phase_range['min'],
             TrickWorkflow.allowed_phase_range['max']) which can be used to order sim runs when a workflow cannot
@@ -1057,16 +1279,25 @@ class TrickWorkflow(WorkflowCommon):
             # TODO: This is very similar to Sim.set_phase() in functionality but I didn't want to create
             # a base class just to support this single instance of reducing code duplication
             # -Jordan 12/2022
-            if (not isinstance(phase, int) or phase < TrickWorkflow.allowed_phase_range['min'] or
-                phase > TrickWorkflow.allowed_phase_range['max']):
-                msg =("ERROR: set_phase() for %s/%s must be an integer between [%s, %s]"
-                      % (self.sim_dir, self.input_file, TrickWorkflow.allowed_phase_range['min'],
-                        TrickWorkflow.allowed_phase_range['max']))
+            if (
+                not isinstance(phase, int)
+                or phase < TrickWorkflow.allowed_phase_range["min"]
+                or phase > TrickWorkflow.allowed_phase_range["max"]
+            ):
+                msg = (
+                    "ERROR: set_phase() for %s/%s must be an integer between [%s, %s]"
+                    % (
+                        self.sim_dir,
+                        self.input_file,
+                        TrickWorkflow.allowed_phase_range["min"],
+                        TrickWorkflow.allowed_phase_range["max"],
+                    )
+                )
                 raise RuntimeError(msg)
             else:
                 self.phase = phase
 
-        def compare( self):
+        def compare(self):
             """
             Execute all internal comparisons for this run
 
@@ -1081,7 +1312,7 @@ class TrickWorkflow(WorkflowCommon):
             """
             return any([c.compare() != Job.Status.SUCCESS for c in self.comparisons])
 
-        def report(self, indent=''):
+        def report(self, indent=""):
             """
             Report this run's information verbosely, ignoring members that are None
 
@@ -1091,16 +1322,23 @@ class TrickWorkflow(WorkflowCommon):
                 prepend the report with this custom string
 
             """
-            tprint(indent + "  %-20s       %s"  % (self.run_job._translate_status()
-              if self.run_job else printer.colorstr('NOT RUN', 'DARK_YELLOW'),
-              self.input_file))
+            tprint(
+                indent
+                + "  %-20s       %s"
+                % (
+                    self.run_job._translate_status()
+                    if self.run_job
+                    else printer.colorstr("NOT RUN", "DARK_YELLOW"),
+                    self.input_file,
+                )
+            )
             if self.comparisons:
-              tprint(indent + "    Run Comparisons:")
-              for comparison in self.comparisons:
-                  comparison.report(indent=indent+'      ')
+                tprint(indent + "    Run Comparisons:")
+                for comparison in self.comparisons:
+                    comparison.report(indent=indent + "      ")
             if self.analysis:
-              tprint(indent + "    Run Analysis:")
-              tprint(indent + "      " + self.analysis.report())
+                tprint(indent + "    Run Analysis:")
+                tprint(indent + "      " + self.analysis.report())
 
         def get_run_job(self):
             """
@@ -1115,25 +1353,35 @@ class TrickWorkflow(WorkflowCommon):
                 SingleRun() Job instance for this run
             """
             if not self.run_job:
-                name = 'Run '
+                name = "Run "
 
                 cmd = "%s cd %s && " % (self.prerun_cmd, self.sim_dir)
                 sim_name = os.path.basename(os.path.normpath(self.sim_dir))
                 logfile = os.path.join(self.log_dir, unixify_string(self.sim_dir))
 
                 if self.valgrind_flags:
-                    cmd += ( "valgrind %s --log-file=%s " % (self.valgrind_flags,
-                      (os.path.join(self.log_dir, sim_name) +'_valgrind_'
-                      + unixify_string(self.input_file) + '.valgrind') ))
-                    logfile += '_valgrind'
-                    name += 'Valgrind '
-                logfile += "_" + unixify_string(self.input_file) + '.txt'
-                cmd += (" ./%s %s" % (self.binary, self.input_file))
-                name += self.sim_dir + ' ' + self.input_file
+                    cmd += "valgrind %s --log-file=%s " % (
+                        self.valgrind_flags,
+                        (
+                            os.path.join(self.log_dir, sim_name)
+                            + "_valgrind_"
+                            + unixify_string(self.input_file)
+                            + ".valgrind"
+                        ),
+                    )
+                    logfile += "_valgrind"
+                    name += "Valgrind "
+                logfile += "_" + unixify_string(self.input_file) + ".txt"
+                cmd += " ./%s %s" % (self.binary, self.input_file)
+                name += self.sim_dir + " " + self.input_file
 
-                self.run_job = SingleRun(name=name, command=(cmd),
-                    expected_exit_status=self.returns, log_file=logfile)
-            return (self.run_job)
+                self.run_job = SingleRun(
+                    name=name,
+                    command=(cmd),
+                    expected_exit_status=self.returns,
+                    log_file=logfile,
+                )
+            return self.run_job
 
         def _get_range_list(self, pattern):
             """
@@ -1159,33 +1407,41 @@ class TrickWorkflow(WorkflowCommon):
             RuntimeError
                If pattern is unrecognized or contains errors
             """
-            must_exist = ['[', ']', '-']
+            must_exist = ["[", "]", "-"]
             if any([char not in pattern for char in must_exist]):
-              msg = ("ERROR: Pattern %s doesn't match expected syntax of \"[min-max]\"" % (pattern))
-              raise RuntimeError(msg)
-            min, max = pattern.strip('[').strip(']').split('-')
+                msg = (
+                    'ERROR: Pattern %s doesn\'t match expected syntax of "[min-max]"'
+                    % (pattern)
+                )
+                raise RuntimeError(msg)
+            min, max = pattern.strip("[").strip("]").split("-")
             if len(min) != len(max):
-              msg = ("ERROR: Pattern %s has inconsistent leading zeros." % (pattern))
-              raise RuntimeError(msg)
+                msg = "ERROR: Pattern %s has inconsistent leading zeros." % (pattern)
+                raise RuntimeError(msg)
             leading_zeros = int(len(min))
             try:
-              min = int(min)
+                min = int(min)
             except ValueError as e:
-              msg = ("ERROR: Pattern %s minimum cannot be converted to integer. \n%s" % (pattern, e))
-              raise RuntimeError(msg)
+                msg = (
+                    "ERROR: Pattern %s minimum cannot be converted to integer. \n%s"
+                    % (pattern, e)
+                )
+                raise RuntimeError(msg)
             try:
-              max = int(max)
+                max = int(max)
             except ValueError as e:
-              msg = ("ERROR: Pattern %s maximum cannot be converted to integer. \n%s" % (pattern, e))
-              raise RuntimeError(msg)
+                msg = (
+                    "ERROR: Pattern %s maximum cannot be converted to integer. \n%s"
+                    % (pattern, e)
+                )
+                raise RuntimeError(msg)
             if min >= (max):
-              msg = ("ERROR: Pattern %s minimum must be less than maximum." % pattern)
-              raise RuntimeError(msg)
+                msg = "ERROR: Pattern %s minimum must be less than maximum." % pattern
+                raise RuntimeError(msg)
             range_list = []
-            for num in range(min, max+1):
-              range_list.append(str(num).zfill(leading_zeros))
-            return (list(range_list))
-
+            for num in range(min, max + 1):
+                range_list.append(str(num).zfill(leading_zeros))
+            return list(range_list)
 
         def multiply(self):
             """
@@ -1225,19 +1481,19 @@ class TrickWorkflow(WorkflowCommon):
             """
             rs = TrickWorkflow._find_range_string(self.input_file)
             if rs is None:
-              return [self]
+                return [self]
             else:
-              range_list = self._get_range_list(rs)
-              multiplied_runs = []
-              for i in range_list:
-                # replace the range string notation with the single run equivalent
-                acopy = copy.deepcopy(self)
-                acopy.input_file = self.input_file.replace(rs, i)
-                # Add comparisons back as multiplied set
-                for c in acopy.comparisons:
-                  c.pattern_replace(expecting_pattern=rs, replace_with=i)
-                multiplied_runs.append(acopy)
-              return multiplied_runs
+                range_list = self._get_range_list(rs)
+                multiplied_runs = []
+                for i in range_list:
+                    # replace the range string notation with the single run equivalent
+                    acopy = copy.deepcopy(self)
+                    acopy.input_file = self.input_file.replace(rs, i)
+                    # Add comparisons back as multiplied set
+                    for c in acopy.comparisons:
+                        c.pattern_replace(expecting_pattern=rs, replace_with=i)
+                    multiplied_runs.append(acopy)
+                return multiplied_runs
 
     class Comparison(object):
         """
@@ -1246,6 +1502,7 @@ class TrickWorkflow(WorkflowCommon):
           test_data:     path to file that represents test data (data generated by a run)
           baseline_data: path to file that represents baseline data for a run
         """
+
         def __init__(self, test_data, baseline_data):
             """
             Initialize this instance. Environment variables used within the test data and baseline data paths will be expanded.
@@ -1260,11 +1517,15 @@ class TrickWorkflow(WorkflowCommon):
             baseline_data : str
                 Path to a single baseline logged data file
             """
-            self.test_data = os.path.expandvars(test_data)           # Test data file with respect to project top level
-            self.baseline_data = os.path.expandvars(baseline_data)   # Baseline data file with respect to project top level
-            self.status = Job.Status.NOT_STARTED # Status of comparison
-            self.error = None                    # Error details if found
-            self.missing = []                    # List of Strings with details of missing files if any
+            self.test_data = os.path.expandvars(
+                test_data
+            )  # Test data file with respect to project top level
+            self.baseline_data = os.path.expandvars(
+                baseline_data
+            )  # Baseline data file with respect to project top level
+            self.status = Job.Status.NOT_STARTED  # Status of comparison
+            self.error = None  # Error details if found
+            self.missing = []  # List of Strings with details of missing files if any
 
         def compare(self):
             """
@@ -1280,20 +1541,20 @@ class TrickWorkflow(WorkflowCommon):
                 status of the comparison: Job.Status.SUCCESS on success, Job.Status.FAILED
             """
             for hs in [self.test_data, self.baseline_data]:
-              if not os.path.exists(hs)  :
-                  self.missing.append(hs)
-                  self.status = Job.Status.FAILED
+                if not os.path.exists(hs):
+                    self.missing.append(hs)
+                    self.status = Job.Status.FAILED
             if self.missing:
-                return  self.status
-            td = hashlib.new('md5', usedforsecurity=False)
-            bd = hashlib.new('md5', usedforsecurity=False)
-            td.update(open(self.test_data,'rb').read())
-            bd.update(open(self.baseline_data,'rb').read())
-            if (td.hexdigest() != bd.hexdigest()):
+                return self.status
+            td = hashlib.new("md5", usedforsecurity=False)
+            bd = hashlib.new("md5", usedforsecurity=False)
+            td.update(open(self.test_data, "rb").read())
+            bd.update(open(self.baseline_data, "rb").read())
+            if td.hexdigest() != bd.hexdigest():
                 self.status = Job.Status.FAILED
             else:
                 self.status = Job.Status.SUCCESS
-            return  self.status
+            return self.status
 
         def get_status(self):
             """
@@ -1316,9 +1577,10 @@ class TrickWorkflow(WorkflowCommon):
             Utility function that takes in a status and colors it, for easier reporting
             """
             text, color = {
-                Job.Status.NOT_STARTED: ('NOT RUN', 'DARK_YELLOW'),
-                Job.Status.SUCCESS: ('OK', 'DARK_GREEN'),
-                Job.Status.FAILED: ('FAIL', 'DARK_RED') }[self.get_status()]
+                Job.Status.NOT_STARTED: ("NOT RUN", "DARK_YELLOW"),
+                Job.Status.SUCCESS: ("OK", "DARK_GREEN"),
+                Job.Status.FAILED: ("FAIL", "DARK_RED"),
+            }[self.get_status()]
             return printer.colorstr(text, color)
 
         def get_dirnames(self):
@@ -1340,12 +1602,12 @@ class TrickWorkflow(WorkflowCommon):
             test_dirname = os.path.dirname(self.test_data)
             baseline_dirname = os.path.dirname(self.baseline_data)
             if not os.path.exists(test_dirname):
-              test_dirname = None
+                test_dirname = None
             if not os.path.exists(baseline_dirname):
-              baseline_dirname = None
+                baseline_dirname = None
             return (test_dirname, baseline_dirname)
 
-        def report (self, indent=''):
+        def report(self, indent=""):
             """
             Report this comparison's information verbosely
 
@@ -1355,12 +1617,12 @@ class TrickWorkflow(WorkflowCommon):
                 prepend the report with this custom string
 
             """
-            string = indent + "%-22s %s"  % (self._translate_status(), self.test_data)
+            string = indent + "%-22s %s" % (self._translate_status(), self.test_data)
             if self.test_data in self.missing:
-              string += printer.colorstr(" (missing)", 'DARK_RED')
-            string += " vs. %s"  % (self.baseline_data)
+                string += printer.colorstr(" (missing)", "DARK_RED")
+            string += " vs. %s" % (self.baseline_data)
             if self.baseline_data in self.missing:
-              string += printer.colorstr(" (missing)", 'DARK_RED')
+                string += printer.colorstr(" (missing)", "DARK_RED")
             tprint(string)
 
         def pattern_replace(self, expecting_pattern, replace_with):
@@ -1383,17 +1645,21 @@ class TrickWorkflow(WorkflowCommon):
             """
             rsb = TrickWorkflow._find_range_string(self.baseline_data)
             rst = TrickWorkflow._find_range_string(self.test_data)
-            if rsb is None and rst is None: # If no patterns, do nothing
-              return
+            if rsb is None and rst is None:  # If no patterns, do nothing
+                return
             if (rsb and rsb != expecting_pattern) or (rst and rst != expecting_pattern):
-              msg = ("ERROR: [min-max] pattern from run (%s) must match pattern in run's"
-                " comparisons test (%s) and baseline (%s) sections, if specified."
-                % (expecting_pattern, rst, rsb))
-              raise RuntimeError(msg)
+                msg = (
+                    "ERROR: [min-max] pattern from run (%s) must match pattern in run's"
+                    " comparisons test (%s) and baseline (%s) sections, if specified."
+                    % (expecting_pattern, rst, rsb)
+                )
+                raise RuntimeError(msg)
             if rsb:
-              self.baseline_data = self.baseline_data.replace(expecting_pattern, replace_with)
+                self.baseline_data = self.baseline_data.replace(
+                    expecting_pattern, replace_with
+                )
             if rst:
-              self.test_data     = self.test_data.replace(expecting_pattern, replace_with)
+                self.test_data = self.test_data.replace(expecting_pattern, replace_with)
 
 
 class SingleRun(Job):
@@ -1401,7 +1667,10 @@ class SingleRun(Job):
     A single trick simulation run Job. SingleRun's can optionally connect to the
     trick variable server to get progress bar information.
     """
-    def __init__(self, name, command, log_file, expected_exit_status=0, use_var_server=True):
+
+    def __init__(
+        self, name, command, log_file, expected_exit_status=0, use_var_server=True
+    ):
         """
         Initialize this instance.
 
@@ -1416,18 +1685,22 @@ class SingleRun(Job):
         """
         self._use_var_server = use_var_server
         self._connected = False
-        super().__init__(name=name, command=command, log_file=log_file,
-          expected_exit_status=expected_exit_status)
+        super().__init__(
+            name=name,
+            command=command,
+            log_file=log_file,
+            expected_exit_status=expected_exit_status,
+        )
 
     def set_use_var_server(self, value):
-        if (not isinstance(value, bool)):
-            msg =("ERROR: SingleRun.set_use_var_server() Requires a True/False value")
+        if not isinstance(value, bool):
+            msg = "ERROR: SingleRun.set_use_var_server() Requires a True/False value"
             raise RuntimeError(msg)
         else:
             self._use_var_server = value
 
     def get_use_var_server(self):
-        return (self._use_var_server)
+        return self._use_var_server
 
     def start(self):
         """
@@ -1444,6 +1717,7 @@ class SingleRun(Job):
         # has finished.
         def connect():
             import psutil
+
             while self.get_status() is self.Status.RUNNING:
                 # The base-class start() call will have already populated self._process.pid,
                 # but that pid may be incompatible with the upcoming find_simulation call
@@ -1455,24 +1729,26 @@ class SingleRun(Job):
                 # self._process.pid if not found
                 sim_pid = self._process.pid
                 try:
-                    children = psutil.Process(self._process.pid).children(recursive=True)
+                    children = psutil.Process(self._process.pid).children(
+                        recursive=True
+                    )
                     outerbreak = False
                     for child in children:
                         for i in child.cmdline():
-                            if re.search('.*S_main', i):
+                            if re.search(".*S_main", i):
                                 sim_pid = child.pid
                                 outerbreak = True
                                 break
                         if outerbreak:
                             break
-                except Exception as e:
+                except Exception:
                     sim_pid = self._process.pid
                 # Now connect to the sim_pid
                 try:
                     self._variable_server = variable_server.find_simulation(
-                      pid=sim_pid, timeout=5)
-                    self._variable_server.add_variables(
-                      *self._create_variables())
+                        pid=sim_pid, timeout=5
+                    )
+                    self._variable_server.add_variables(*self._create_variables())
                     self._variable_server.set_period(0.1)
                     self._connected = True
                     return
@@ -1481,11 +1757,11 @@ class SingleRun(Job):
                 # If a SingleRun job terminates before the thread can connect to the
                 # variable server, Trick's variable_server module throws an IOError
                 # with the message: The remote endpoint has closed the connection
-                except IOError as e:
+                except IOError:
                     pass
 
         if self._use_var_server:
-            thread = threading.Thread(target=connect, name='Looking for ' + self.name)
+            thread = threading.Thread(target=connect, name="Looking for " + self.name)
             thread.daemon = True
             thread.start()
 
@@ -1493,29 +1769,29 @@ class SingleRun(Job):
         return super(SingleRun, self).get_status_string_line_count() + 1
 
     def _not_started_string(self):
-        return super(SingleRun, self)._not_started_string() + '\n'
+        return super(SingleRun, self)._not_started_string() + "\n"
 
     def _running_string(self):
         elapsed_time = super(SingleRun, self)._running_string()
 
         if self._connected:
-            return (elapsed_time + self._connected_string() + '\n' +
-              self._connected_bar())
+            return (
+                elapsed_time + self._connected_string() + "\n" + self._connected_bar()
+            )
 
-        return (elapsed_time + '\n' +
-          create_progress_bar(0, 'Connecting'))
+        return elapsed_time + "\n" + create_progress_bar(0, "Connecting")
 
     def _success_string(self):
         text = super(SingleRun, self)._success_string()
         if self._connected:
             text += self._connected_string()
-        return text + '\n' + self._success_progress_bar
+        return text + "\n" + self._success_progress_bar
 
     def _failed_string(self):
         text = super(SingleRun, self)._failed_string()
         if self._connected:
             text += self._connected_string()
-        return text + '\n' + self._failed_progress_bar
+        return text + "\n" + self._failed_progress_bar
 
     def die(self):
         try:
@@ -1531,25 +1807,24 @@ class SingleRun(Job):
             pass
 
     def _create_variables(self):
-        self._tics = variable_server.Variable(
-          'trick_sys.sched.time_tics', type_=float)
+        self._tics = variable_server.Variable("trick_sys.sched.time_tics", type_=float)
         self._tics_per_sec = variable_server.Variable(
-          'trick_sys.sched.time_tic_value', type_=float)
+            "trick_sys.sched.time_tic_value", type_=float
+        )
         self._terminate_time = variable_server.Variable(
-          'trick_sys.sched.terminate_time', type_=float)
+            "trick_sys.sched.terminate_time", type_=float
+        )
         return self._tics, self._tics_per_sec, self._terminate_time
 
     def _connected_string(self):
-        return '      {0}       {1}'.format(
-          self._sim_time(), self._average_speed())
+        return "      {0}       {1}".format(self._sim_time(), self._average_speed())
 
     def _connected_bar(self):
         if self._terminate_time.value <= 0.0:
-          progress =  0.0
+            progress = 0.0
         else:
-          progress = self._tics.value / self._terminate_time.value
-        return create_progress_bar(
-          progress, '{0:.1f}%'.format(100 * progress))
+            progress = self._tics.value / self._terminate_time.value
+        return create_progress_bar(progress, "{0:.1f}%".format(100 * progress))
 
     def _sim_time(self):
         """
@@ -1560,8 +1835,9 @@ class SingleRun(Job):
         str
             A string for displaying sim time.
         """
-        return 'Sim Time: {0:7.1f} sec'.format(
-          self._tics.value / self._tics_per_sec.value)
+        return "Sim Time: {0:7.1f} sec".format(
+            self._tics.value / self._tics_per_sec.value
+        )
 
     def _average_speed(self):
         """
@@ -1573,7 +1849,8 @@ class SingleRun(Job):
             A string for displaying the ratio of sim time to real time.
         """
         elapsed_time = (
-          (self._stop_time if self._stop_time else time.time())
-          - self._start_time)
-        return 'Average Speed: {0:4.1f} X'.format(
-          self._tics.value / self._tics_per_sec.value / elapsed_time)
+            self._stop_time if self._stop_time else time.time()
+        ) - self._start_time
+        return "Average Speed: {0:4.1f} X".format(
+            self._tics.value / self._tics_per_sec.value / elapsed_time
+        )


### PR DESCRIPTION
Fixes a SyntaxWarning: invalid escape sequence in TrickWorkflow.py by using a raw string for the regex pattern.

This change only touches a single line. Ruff format is the other 1073 lines.