### PR TITLE
Add support for llvm 23.

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -207,7 +207,11 @@ int main(int argc, char * argv[]) {
 #else
     ci.createDiagnostics();
 #endif
+#if (LIBCLANG_MAJOR >= 23)
+    ci.getDiagnosticOpts().setShowColors(clang::ShowColorsKind::On);
+#else
     ci.getDiagnosticOpts().ShowColors = 1 ;
+#endif
     ci.getDiagnostics().setIgnoreAllWarnings(true) ;
     set_lang_opts(ci);
 
@@ -282,11 +286,17 @@ int main(int argc, char * argv[]) {
     hsd.addSearchDirs(include_dirs, isystem_dirs);
 
     // Add a preprocessor callback to search for TRICK_ICG
+#if (LIBCLANG_MAJOR >= 23)
+    const auto BOU_FALSE_VAL = llvm::cl::boolOrDefault::BOU_FALSE;
+#else
+    const auto BOU_FALSE_VAL = llvm::cl::BOU_FALSE;
+#endif
+
 #if (LIBCLANG_MAJOR > 3) || ((LIBCLANG_MAJOR == 3) && (LIBCLANG_MINOR >= 6))
-    std::unique_ptr<FindTrickICG> ftg(new FindTrickICG(ci, hsd, print_trick_icg != llvm::cl::BOU_FALSE )) ;
+    auto ftg = std::make_unique<FindTrickICG>(ci, hsd, print_trick_icg != BOU_FALSE_VAL);
     pp.addPPCallbacks(std::move(ftg)) ;
 #else
-    FindTrickICG * ftg = new FindTrickICG(ci, hsd, print_trick_icg != llvm::cl::BOU_FALSE ) ;
+    FindTrickICG* ftg = new FindTrickICG(ci, hsd, print_trick_icg != BOU_FALSE_VAL);
     pp.addPPCallbacks(ftg) ;
 #endif
 

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -90,7 +90,7 @@ void set_lang_opts(clang::CompilerInstance & ci) {
     // Activate C++14 parsing
 #if (LIBCLANG_MAJOR >= 6)
     ci.getLangOpts().CPlusPlus14 = true ;
-    ci.getLangOpts().DoubleSquareBracketAttributes = true ;    
+    ci.getLangOpts().DoubleSquareBracketAttributes = true;
 #endif
 
 #if (LIBCLANG_MAJOR >= 6 && LIBCLANG_MAJOR < 10)
@@ -137,9 +137,9 @@ const char * gcc_version = "";
             // https://github.com/nasa/trick/issues/1519
             // Before LLVM 11, the flag was named CPlusPlus2a
             ci.getLangOpts().CPlusPlus2a = true ;
-            #else 
+#else
             ci.getLangOpts().CPlusPlus20 = true ;
-            #endif
+#endif
         } else {
             std::cerr << "Invalid C++ standard version specified:" << standard_version << std::endl;
         }
@@ -170,8 +170,9 @@ int main(int argc, char * argv[]) {
      * Gather all of the command line arguments into lists of include directories, defines, and input files.
      * All other arguments will be ignored.
      *
-     * Filter out -W because of LLVM cl option that has been enabled and cannot be disabled in LLVM 10 when linking libclang-cpp.so.
-     * TODO: Troubleshoot or contact LLVM for a fix.  
+     * Filter out -W because of LLVM cl option that has been enabled and cannot be disabled in LLVM 10 when linking
+     * libclang-cpp.so.
+     * TODO: Troubleshoot or contact LLVM for a fix.
      */
     std::vector<const char *> filtered_args;
     for ( unsigned int ii = 0;  ii < argc ; ii++ ) {
@@ -179,7 +180,7 @@ int main(int argc, char * argv[]) {
             filtered_args.push_back(argv[ii]);
         }
     }
-    
+
     llvm::cl::ParseCommandLineOptions(filtered_args.size(), filtered_args.data());
 
     if (input_file_names.empty()) {
@@ -199,8 +200,8 @@ int main(int argc, char * argv[]) {
     // llvm::IntrusiveRefCntPtr is LLVM's reference counting smart pointer
     // The smart pointer is used to manage objects that require reference counting such as VFS
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = llvm::vfs::getRealFileSystem();
-    // createDiagnostics(llvm::vfs::FileSystem &VFS, 
-    //                   DiagnosticConsumer * 	Client = nullptr, 
+    // createDiagnostics(llvm::vfs::FileSystem &VFS,
+    //                   DiagnosticConsumer * 	Client = nullptr,
     //                   bool 	ShouldOwnClient = true)
     // DiagnosticConsumer is set later in the code to our ICGDiagnosticConsumer and here is nullptr
     ci.createDiagnostics(*vfs); // Create diagnostics for clang 20+


### PR DESCRIPTION
Our LLVM Compatibility CI ran this weekend for the first time against a new LLVM version.[^1]

LLVM 23 is planned to release on August 25, 2026.[^4] 


There were two API changes that need to be gated for llvm 23 support.

1. `ShowColors` was refactored into a protected enum with setters and getters available. https://github.com/llvm/llvm-project/commit/2a215f473fb9ab5e4a2bf8cdc3ebe04a1ec560b0
2. `BOU_FALSE` was refactored into a scoped enum. https://github.com/llvm/llvm-project/commit/bf18f6f43052cb558502e3e6f4db6a7368fe7b61

[^1]: https://github.com/nasa/trick/actions/runs/29670101843
[^4]: https://llvm.org/