### PR TITLE
clang setLangDefaults for clang >= 15

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, char * argv[]) {
 #if (LIBCLANG_MAJOR > 3) || ((LIBCLANG_MAJOR == 3) && (LIBCLANG_MINOR >= 9))
     llvm::Triple trip (to.Triple) ;
 #if (LIBCLANG_MAJOR >= 15)
-    //clang::CompilerInvocation::setLangDefaults(ci.getLangOpts(), clang::Language::CXX, trip, ppo.Includes) ;
+    clang::LangOptions::setLangDefaults(ci.getLangOpts(), clang::Language::CXX, trip, ppo.Includes) ;
 #elif (LIBCLANG_MAJOR >= 12)
     clang::CompilerInvocation::setLangDefaults(ci.getLangOpts(), clang::Language::CXX, trip, ppo.Includes) ;
 #elif (LIBCLANG_MAJOR >= 10)

--- a/trick_source/codegen/Interface_Code_Gen/main.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, char * argv[]) {
 #if (LIBCLANG_MAJOR > 3) || ((LIBCLANG_MAJOR == 3) && (LIBCLANG_MINOR >= 9))
     llvm::Triple trip (to.Triple) ;
 #if (LIBCLANG_MAJOR >= 15)
-    clang::LangOptions::setLangDefaults(ci.getLangOpts(), clang::Language::CXX, trip, ppo.Includes) ;
+    clang::LangOptions::setLangDefaults(ci.getLangOpts(), clang::Language::CXX, trip, ppo.Includes);
 #elif (LIBCLANG_MAJOR >= 12)
     clang::CompilerInvocation::setLangDefaults(ci.getLangOpts(), clang::Language::CXX, trip, ppo.Includes) ;
 #elif (LIBCLANG_MAJOR >= 10)


### PR DESCRIPTION
I currently working on porting a project using trick from ubuntu 20 (clang 9) -> ubuntu 26 (clang 21) and was running into an issue with `//*` comments that worked on the old setup, but failed on the new one.

I found the commented out clang 15+ branch and set it up to preserve the prior clang behavior under the new namespace.