### PR TITLE
Remove the unsigned char to string literal formatting used for the checkpoint.

### DIFF
--- a/trick_source/sim_services/CheckPointAgent/ClassicCheckPointAgent.cpp
+++ b/trick_source/sim_services/CheckPointAgent/ClassicCheckPointAgent.cpp
@@ -764,11 +764,14 @@ std::string Trick::ClassicCheckPointAgent::
             // attr.index[0].size = 0 (not static array)
             // attr.size = sizeof(char)
             // This prevents anonymous allocations from appearing in subsequent checkpoints
-            if ((attr != NULL) && attr->type == TRICK_CHARACTER && ((curr_dim + 1) == attr->num_index)) {
+            if ((attr != NULL) && attr->type == TRICK_CHARACTER && ((curr_dim + 1) == attr->num_index))
+            {
                 std::stringstream ss;
                 write_quoted_str( ss, (const char*)pointer);
                 reference_string = ss.str();
-            } else {
+            }
+            else
+            {
                 int alloc_elem_size;
                 int alloc_elem_index;
                 int misalignment;

--- a/trick_source/sim_services/CheckPointAgent/ClassicCheckPointAgent.cpp
+++ b/trick_source/sim_services/CheckPointAgent/ClassicCheckPointAgent.cpp
@@ -764,7 +764,7 @@ std::string Trick::ClassicCheckPointAgent::
             // attr.index[0].size = 0 (not static array)
             // attr.size = sizeof(char)
             // This prevents anonymous allocations from appearing in subsequent checkpoints
-            if ((attr != NULL) && (attr->type == TRICK_CHARACTER || attr->type == TRICK_UNSIGNED_CHARACTER) && ((curr_dim + 1) == attr->num_index)) {
+            if ((attr != NULL) && attr->type == TRICK_CHARACTER && ((curr_dim + 1) == attr->num_index)) {
                 std::stringstream ss;
                 write_quoted_str( ss, (const char*)pointer);
                 reference_string = ss.str();

--- a/trick_source/sim_services/MemoryManager/MemoryManager_write_checkpoint.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_write_checkpoint.cpp
@@ -37,8 +37,9 @@ void Trick::MemoryManager::execute_checkpoint( std::ostream& out_s ) {
             // Skip naming individual C-string allocations to eliminate unused declarations
             // Individual char arrays (size=1, num_index=1) represent single strings that are
             // included in char* arrays, so we don't need separate allocations for them
-            if (alloc_info->type == TRICK_CHARACTER &&
-                alloc_info->size == 1 && alloc_info->num_index == 1 && alloc_info->stcl == TRICK_LOCAL) {
+            if (alloc_info->type == TRICK_CHARACTER && alloc_info->size == 1 && alloc_info->num_index == 1
+                && alloc_info->stcl == TRICK_LOCAL)
+            {
                 // Skip naming this individual char array allocation to prevent unused declarations
                 continue;
             }
@@ -83,9 +84,9 @@ void Trick::MemoryManager::execute_checkpoint( std::ostream& out_s ) {
         // Individual char arrays (size=1, num_index=1) represent single strings that are
         // included in char* arrays, so we don't need separate allocations for them.
         // Also, safety check for NULL name before pushing to name stack later.
-        if (!(alloc_info->type == TRICK_CHARACTER &&
-               alloc_info->size == 1 && alloc_info->num_index == 1 && alloc_info->stcl == TRICK_LOCAL) &&
-             alloc_info->name != NULL)
+        if (!(alloc_info->type == TRICK_CHARACTER && alloc_info->size == 1 && alloc_info->num_index == 1
+              && alloc_info->stcl == TRICK_LOCAL)
+            && alloc_info->name != NULL)
         {
             write_var(out_s, alloc_info);
             out_s << std::endl;

--- a/trick_source/sim_services/MemoryManager/MemoryManager_write_checkpoint.cpp
+++ b/trick_source/sim_services/MemoryManager/MemoryManager_write_checkpoint.cpp
@@ -37,7 +37,7 @@ void Trick::MemoryManager::execute_checkpoint( std::ostream& out_s ) {
             // Skip naming individual C-string allocations to eliminate unused declarations
             // Individual char arrays (size=1, num_index=1) represent single strings that are
             // included in char* arrays, so we don't need separate allocations for them
-            if ((alloc_info->type == TRICK_CHARACTER || alloc_info->type == TRICK_UNSIGNED_CHARACTER) && 
+            if (alloc_info->type == TRICK_CHARACTER &&
                 alloc_info->size == 1 && alloc_info->num_index == 1 && alloc_info->stcl == TRICK_LOCAL) {
                 // Skip naming this individual char array allocation to prevent unused declarations
                 continue;
@@ -83,7 +83,7 @@ void Trick::MemoryManager::execute_checkpoint( std::ostream& out_s ) {
         // Individual char arrays (size=1, num_index=1) represent single strings that are
         // included in char* arrays, so we don't need separate allocations for them.
         // Also, safety check for NULL name before pushing to name stack later.
-        if (!((alloc_info->type == TRICK_CHARACTER || alloc_info->type == TRICK_UNSIGNED_CHARACTER) &&
+        if (!(alloc_info->type == TRICK_CHARACTER &&
                alloc_info->size == 1 && alloc_info->num_index == 1 && alloc_info->stcl == TRICK_LOCAL) &&
              alloc_info->name != NULL)
         {


### PR DESCRIPTION
Remove the unsigned char to string literal formatting used for the checkpoint.