### PR TITLE
Call deleteInstance before deleting oldType

### DIFF
--- a/trick_source/sim_services/DataTypes/src/AllocInfo.cpp
+++ b/trick_source/sim_services/DataTypes/src/AllocInfo.cpp
@@ -215,8 +215,8 @@ void* AllocInfo::resize( size_t newElementCount ) {
         memcpy( newMemoryObject, oldMemoryObject, minByteCount);
     }
 
-    delete oldType;
     oldType->deleteInstance( oldMemoryObject );
+    delete oldType;
     start = newMemoryObject;
     end = (char*)start + newType->getSize();
     ownDataType = newType;


### PR DESCRIPTION
`AllocInfo::resize` destroys `oldType` before invoking `deleteInstance`.

Call `deleteInstance` before deleting `oldType`.
