### PR TITLE
Preserve the incoming object in attach_units.

### DIFF
--- a/test/SIM_test_ip/RUN_test/unit_test.py
+++ b/test/SIM_test_ip/RUN_test/unit_test.py
@@ -29,6 +29,11 @@ def main():
 
     test_suite = "double"
 
+    position_in = trick.attach_units("in", 6)
+    position_m = trick.attach_units("m", position_in)
+    TRICK_EXPECT_EQ( str(position_in) , "6 in", test_suite , "position_in" )
+    TRICK_EXPECT_EQ( str(position_m) , "0.1524 m" , test_suite , "position_m (converted from position_in)" )
+
     TRICK_EXPECT_EQ( str(test_so.obj.get_double()) , "4732992000", test_suite , "get generic double with precision" )
 
     test_so.obj.d = 2
@@ -36,6 +41,8 @@ def main():
     TRICK_EXPECT_NEAR( test_so.obj.get_d() , 2.0 , 0.000001 , test_suite , "get_d(), no units" )
     trick.trick_test_add_parent( test_suite , "no units" , "910635102")
 
+    # d is declared with units kg and units kg is preserved
+    # attach_units("lb", 2) converts 2 lb to 0.90718474 kg that gets assigned to d
     test_so.obj.d = trick.attach_units("lb" , 2)
     TRICK_EXPECT_NEAR( test_so.obj.d , 0.90718474 , 0.000001 , test_suite , "units convert" )
     TRICK_EXPECT_NEAR( test_so.obj.get_d() , 0.90718474, 0.000001 , test_suite , "get_d(), no units" )

--- a/test/SIM_test_ip/RUN_test/unit_test.py
+++ b/test/SIM_test_ip/RUN_test/unit_test.py
@@ -1,5 +1,5 @@
-
 import math
+
 from trick.unit_test import *
 
 try:
@@ -8,219 +8,587 @@ try:
 except AttributeError:
     useArrayGetters = False
 
+
 def main():
 
     # These are here as a reference for the add_collect syntax... I have changed the code to not use collect
     # An example of removing collect in the input file (original collect added in S_define file)
-    #test_so.obj.state.work.external_force = trick.delete_collect(test_so.obj.state.work.external_force, test_so.obj.force.output.force)
+    # test_so.obj.state.work.external_force = trick.delete_collect(test_so.obj.state.work.external_force, test_so.obj.force.output.force)
     # An example of adding a collect in the input file
-    #test_so.obj.state.work.external_force = trick.add_collect(test_so.obj.state.work.external_force, test_so.obj.force.output.force)
+    # test_so.obj.state.work.external_force = trick.add_collect(test_so.obj.state.work.external_force, test_so.obj.force.output.force)
 
     # An example of turning off a sim_object
-    trick.exec_set_sim_object_onoff("disabled_obj" , False)
+    trick.exec_set_sim_object_onoff("disabled_obj", False)
 
     trick.exec_set_terminate_time(1.0)
 
     trick_utest.unit_tests.enable()
-    trick_utest.unit_tests.set_file_name( os.getenv("TRICK_HOME") + "/trick_test/SIM_test_ip.xml" )
-    trick_utest.unit_tests.set_test_name( "IPtest" )
+    trick_utest.unit_tests.set_file_name(
+        os.getenv("TRICK_HOME") + "/trick_test/SIM_test_ip.xml"
+    )
+    trick_utest.unit_tests.set_test_name("IPtest")
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "double"
 
     position_in = trick.attach_units("in", 6)
     position_m = trick.attach_units("m", position_in)
-    TRICK_EXPECT_EQ( str(position_in) , "6 in", test_suite , "position_in" )
-    TRICK_EXPECT_EQ( str(position_m) , "0.1524 m" , test_suite , "position_m (converted from position_in)" )
+    TRICK_EXPECT_EQ(str(position_in), "6 in", test_suite, "position_in")
+    TRICK_EXPECT_EQ(
+        str(position_m),
+        "0.1524 m",
+        test_suite,
+        "position_m (converted from position_in)",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.get_double()) , "4732992000", test_suite , "get generic double with precision" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_double()),
+        "4732992000",
+        test_suite,
+        "get generic double with precision",
+    )
 
     test_so.obj.d = 2
-    TRICK_EXPECT_NEAR( test_so.obj.d , 2.0 , 0.000001 , test_suite , "no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.get_d() , 2.0 , 0.000001 , test_suite , "get_d(), no units" )
-    trick.trick_test_add_parent( test_suite , "no units" , "910635102")
+    TRICK_EXPECT_NEAR(test_so.obj.d, 2.0, 0.000001, test_suite, "no units")
+    TRICK_EXPECT_NEAR(
+        test_so.obj.get_d(), 2.0, 0.000001, test_suite, "get_d(), no units"
+    )
+    trick.trick_test_add_parent(test_suite, "no units", "910635102")
 
     # d is declared with units kg and units kg is preserved
     # attach_units("lb", 2) converts 2 lb to 0.90718474 kg that gets assigned to d
-    test_so.obj.d = trick.attach_units("lb" , 2)
-    TRICK_EXPECT_NEAR( test_so.obj.d , 0.90718474 , 0.000001 , test_suite , "units convert" )
-    TRICK_EXPECT_NEAR( test_so.obj.get_d() , 0.90718474, 0.000001 , test_suite , "get_d(), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_d()) , "0.90718474 kg", test_suite , "get_d(), units convert" )
+    test_so.obj.d = trick.attach_units("lb", 2)
+    TRICK_EXPECT_NEAR(test_so.obj.d, 0.90718474, 0.000001, test_suite, "units convert")
+    TRICK_EXPECT_NEAR(
+        test_so.obj.get_d(), 0.90718474, 0.000001, test_suite, "get_d(), no units"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_d()), "0.90718474 kg", test_suite, "get_d(), units convert"
+    )
 
-    test_so.obj.da = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_NEAR( test_so.obj.da[0] , 20 , 0.000001 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[1] , 21 , 0.000001 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[2] , 22 , 0.000001 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.da = [20, 21, 22]
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[0], 20, 0.000001, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[1], 21, 0.000001, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[2], 22, 0.000001, test_suite, "1D array, integer value, no units"
+    )
     if useArrayGetters:
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[0] , 20 , 0.000001 , test_suite , "get_da(), 1D array, integer value, no units" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[1] , 21 , 0.000001 , test_suite , "get_da(), 1D array, integer value, no units" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[2] , 22 , 0.000001 , test_suite , "get_da(), 1D array, integer value, no units" )
-        TRICK_EXPECT_EQ( str(test_so.obj.get_da()) , "[20 kg, 21 kg, 22 kg]", test_suite , "get_da(), 1D array, integer value, no units" )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[0],
+            20,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, integer value, no units",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[1],
+            21,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, integer value, no units",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[2],
+            22,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, integer value, no units",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_da()),
+            "[20 kg, 21 kg, 22 kg]",
+            test_suite,
+            "get_da(), 1D array, integer value, no units",
+        )
 
-    test_so.obj.da = [ 30.1 , 31.1 , 32.1 ]
+    test_so.obj.da = [30.1, 31.1, 32.1]
 
-    TRICK_EXPECT_NEAR( test_so.obj.da[0] , 30.1 , 0.000001 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[1] , 31.1 , 0.000001 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[2] , 32.1 , 0.000001 , test_suite , "1D array, float value, no units" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[0], 30.1, 0.000001, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[1], 31.1, 0.000001, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[2], 32.1, 0.000001, test_suite, "1D array, float value, no units"
+    )
     if useArrayGetters:
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[0] , 30.1 , 0.000001 , test_suite , "get_da(), 1D array, float value, no units" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[1] , 31.1 , 0.000001 , test_suite , "get_da(), 1D array, float value, no units" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[2] , 32.1 , 0.000001 , test_suite , "get_da(), 1D array, float value, no units" )
-        TRICK_EXPECT_EQ( str(test_so.obj.get_da()) , "[30.1 kg, 31.1 kg, 32.1 kg]", test_suite , "get_da(), 1D array, float value, no units" )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[0],
+            30.1,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, float value, no units",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[1],
+            31.1,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, float value, no units",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[2],
+            32.1,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, float value, no units",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_da()),
+            "[30.1 kg, 31.1 kg, 32.1 kg]",
+            test_suite,
+            "get_da(), 1D array, float value, no units",
+        )
 
-    test_so.obj.da = 40.1 , 41.1 , 42.1
+    test_so.obj.da = 40.1, 41.1, 42.1
 
-    TRICK_EXPECT_NEAR( test_so.obj.da[0] , 40.1 , 0.000001 , test_suite , "1D array, tuple float value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[1] , 41.1 , 0.000001 , test_suite , "1D array, tuple float value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[2] , 42.1 , 0.000001 , test_suite , "1D array, tuple float value, no units" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[0],
+        40.1,
+        0.000001,
+        test_suite,
+        "1D array, tuple float value, no units",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[1],
+        41.1,
+        0.000001,
+        test_suite,
+        "1D array, tuple float value, no units",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[2],
+        42.1,
+        0.000001,
+        test_suite,
+        "1D array, tuple float value, no units",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[0] , 40.1 , 0.000001 , test_suite , "get_da(), 1D array, tuple float value, no units" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[1] , 41.1 , 0.000001 , test_suite , "get_da(), 1D array, tuple float value, no units" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[2] , 42.1 , 0.000001 , test_suite , "get_da(), 1D array, tuple float value, no units" )
-        TRICK_EXPECT_EQ( str(test_so.obj.get_da()) , "[40.1 kg, 41.1 kg, 42.1 kg]", test_suite , "get_da(), 1D array, tuple float value, no units" )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[0],
+            40.1,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, tuple float value, no units",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[1],
+            41.1,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, tuple float value, no units",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[2],
+            42.1,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, tuple float value, no units",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_da()),
+            "[40.1 kg, 41.1 kg, 42.1 kg]",
+            test_suite,
+            "get_da(), 1D array, tuple float value, no units",
+        )
 
-    test_so.obj.da = trick.attach_units("lb" , [2 , 3 , 4])
-    TRICK_EXPECT_NEAR( test_so.obj.da[0] , 0.90718474 , 0.000001 , test_suite , "1D array, float value, units convert" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[1] , 1.36077711 ,  0.00001  , test_suite , "1D array, float value, units convert" )
-    TRICK_EXPECT_NEAR( test_so.obj.da[2] , 1.81436948 ,  0.00001  , test_suite , "1D array, float value, units convert" )
+    test_so.obj.da = trick.attach_units("lb", [2, 3, 4])
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[0],
+        0.90718474,
+        0.000001,
+        test_suite,
+        "1D array, float value, units convert",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[1],
+        1.36077711,
+        0.00001,
+        test_suite,
+        "1D array, float value, units convert",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.da[2],
+        1.81436948,
+        0.00001,
+        test_suite,
+        "1D array, float value, units convert",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[0] , 0.90718474 , 0.000001 , test_suite , "get_da(), 1D array, float value, units convert" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[1] , 1.36077711 ,  0.00001  , test_suite , "get_da(), 1D array, float value, units convert" )
-        TRICK_EXPECT_NEAR( test_so.obj.get_da()[2] , 1.81436948 ,  0.00001  , test_suite , "get_da(), 1D array, float value, units convert" )
-        TRICK_EXPECT_EQ( str(test_so.obj.get_da()) , "[0.90718474 kg, 1.36077711 kg, 1.81436948 kg]", test_suite , "get_da(), 1D array, float value, units convert" )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[0],
+            0.90718474,
+            0.000001,
+            test_suite,
+            "get_da(), 1D array, float value, units convert",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[1],
+            1.36077711,
+            0.00001,
+            test_suite,
+            "get_da(), 1D array, float value, units convert",
+        )
+        TRICK_EXPECT_NEAR(
+            test_so.obj.get_da()[2],
+            1.81436948,
+            0.00001,
+            test_suite,
+            "get_da(), 1D array, float value, units convert",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_da()),
+            "[0.90718474 kg, 1.36077711 kg, 1.81436948 kg]",
+            test_suite,
+            "get_da(), 1D array, float value, units convert",
+        )
 
     test_so.obj.dp = trick.TMM_declare_var_s("double tname[6]")
-    TRICK_EXPECT_NEAR( test_so.obj.dp[0] , 0 ,  0.00001  , test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_NEAR( test_so.obj.dp[5] , 0 ,  0.00001  , test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_NEAR( test_so.obj.get_dp()[0] , 0 ,  0.00001  , test_suite , "get_dp(), 1D ptr, allocation" )
-    TRICK_EXPECT_NEAR( test_so.obj.get_dp()[5] , 0 ,  0.00001  , test_suite , "get_dp(), 1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]", test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dp()) , "[0, 0, 0, 0, 0, 0]", test_suite , "get_dp(), 1D ptr, allocation" )
+    TRICK_EXPECT_NEAR(test_so.obj.dp[0], 0, 0.00001, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_NEAR(test_so.obj.dp[5], 0, 0.00001, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_NEAR(
+        test_so.obj.get_dp()[0], 0, 0.00001, test_suite, "get_dp(), 1D ptr, allocation"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.get_dp()[5], 0, 0.00001, test_suite, "get_dp(), 1D ptr, allocation"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dp),
+        "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "1D ptr, allocation",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dp()),
+        "[0, 0, 0, 0, 0, 0]",
+        test_suite,
+        "get_dp(), 1D ptr, allocation",
+    )
 
-    test_so.obj.dp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[30 kg, 31 kg, 32 kg, 33 kg]", test_suite , "1D ptr, list assign, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dp()) , "[30, 31, 32, 33]", test_suite , "get_dp(), 1D ptr, list assign, no units" )
+    test_so.obj.dp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dp),
+        "[30 kg, 31 kg, 32 kg, 33 kg]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dp()),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "get_dp(), 1D ptr, list assign, no units",
+    )
 
     test_so.obj.dp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[30 kg, 31 kg, 62 kg, 33 kg]", test_suite , "1D ptr, partial assign, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dp()) , "[30, 31, 62, 33]", test_suite , "get_dp(), 1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dp),
+        "[30 kg, 31 kg, 62 kg, 33 kg]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dp()),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "get_dp(), 1D ptr, partial assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( test_so.obj.dp[-1], 33, test_suite , "negative index integer value" )
-    TRICK_EXPECT_EQ( test_so.obj.dp[-1.0], 33, test_suite , "negative index float value" )
-    TRICK_EXPECT_EQ( test_so.obj.get_dp()[-1], 33, test_suite , "get_dp(), negative index integer value" )
-    TRICK_EXPECT_EQ( test_so.obj.get_dp()[-1.0], 33, test_suite , "get_dp(), negative index float value" )
+    TRICK_EXPECT_EQ(test_so.obj.dp[-1], 33, test_suite, "negative index integer value")
+    TRICK_EXPECT_EQ(test_so.obj.dp[-1.0], 33, test_suite, "negative index float value")
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_dp()[-1],
+        33,
+        test_suite,
+        "get_dp(), negative index integer value",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_dp()[-1.0],
+        33,
+        test_suite,
+        "get_dp(), negative index float value",
+    )
 
     test_so.obj.dp[-1] = 55
     test_so.obj.dp[-2] = 54
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[30 kg, 31 kg, 54 kg, 55 kg]", test_suite , "negative index assignments" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dp()) , "[30, 31, 54, 55]", test_suite , "get_dp(), negative index assignments" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dp),
+        "[30 kg, 31 kg, 54 kg, 55 kg]",
+        test_suite,
+        "negative index assignments",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dp()),
+        "[30, 31, 54, 55]",
+        test_suite,
+        "get_dp(), negative index assignments",
+    )
 
     test_so.obj.dp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dp()) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
-    
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dp()), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
+
     # Mixed tuple/list notation
-    test_so.obj.daa = trick.attach_units( "kg", (( 50 , 51 , 52) , [53, 54, 55]) )
-    TRICK_EXPECT_EQ( str(test_so.obj.daa) , "[[50 kg, 51 kg, 52 kg],[53 kg, 54 kg, 55 kg]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.daa = trick.attach_units("kg", ((50, 51, 52), [53, 54, 55]))
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daa),
+        "[[50 kg, 51 kg, 52 kg],[53 kg, 54 kg, 55 kg]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daa()) , "[[50 kg, 51 kg, 52 kg],[53 kg, 54 kg, 55 kg]]",
-         test_suite , "get_daa(), 2D array, full assign, no units" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daa()),
+            "[[50 kg, 51 kg, 52 kg],[53 kg, 54 kg, 55 kg]]",
+            test_suite,
+            "get_daa(), 2D array, full assign, no units",
+        )
 
-    test_so.obj.daa = trick.attach_units( "kg", [[ 40 , 41 , 42] , [43, 44, 45]] )
-    TRICK_EXPECT_EQ( str(test_so.obj.daa) , "[[40 kg, 41 kg, 42 kg],[43 kg, 44 kg, 45 kg]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.daa = trick.attach_units("kg", [[40, 41, 42], [43, 44, 45]])
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daa),
+        "[[40 kg, 41 kg, 42 kg],[43 kg, 44 kg, 45 kg]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daa()) , "[[40 kg, 41 kg, 42 kg],[43 kg, 44 kg, 45 kg]]",
-         test_suite , "get_daa(), 2D array, full assign, no units" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daa()),
+            "[[40 kg, 41 kg, 42 kg],[43 kg, 44 kg, 45 kg]]",
+            test_suite,
+            "get_daa(), 2D array, full assign, no units",
+        )
 
-    test_so.obj.daa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.daa) , "[[40 kg, 41 kg, 42 kg],[50 kg, 51 kg, 52 kg]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.daa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daa),
+        "[[40 kg, 41 kg, 42 kg],[50 kg, 51 kg, 52 kg]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daa()) , "[[40 kg, 41 kg, 42 kg],[50 kg, 51 kg, 52 kg]]",
-         test_suite , "get_daa(), 2D array, partial assign, no units" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daa()),
+            "[[40 kg, 41 kg, 42 kg],[50 kg, 51 kg, 52 kg]]",
+            test_suite,
+            "get_daa(), 2D array, partial assign, no units",
+        )
 
-    test_so.obj.daa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.daa) , "[[40 kg, 41 kg, 42 kg],[50.1 kg, 51.2 kg, 52.3 kg]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.daa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daa),
+        "[[40 kg, 41 kg, 42 kg],[50.1 kg, 51.2 kg, 52.3 kg]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daa()) , "[[40 kg, 41 kg, 42 kg],[50.1 kg, 51.2 kg, 52.3 kg]]",
-         test_suite , "get_daa(), 2D array, partial assign, no units" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daa()),
+            "[[40 kg, 41 kg, 42 kg],[50.1 kg, 51.2 kg, 52.3 kg]]",
+            test_suite,
+            "get_daa(), 2D array, partial assign, no units",
+        )
 
-    test_so.obj.daa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.daa) , "[[40 kg, 41 kg, 42 kg],[50.1 kg, 60 kg, 52.3 kg]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.daa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daa),
+        "[[40 kg, 41 kg, 42 kg],[50.1 kg, 60 kg, 52.3 kg]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daa()) , "[[40 kg, 41 kg, 42 kg],[50.1 kg, 60 kg, 52.3 kg]]",
-         test_suite , "get_daa(), 2D array, single assign, no units" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daa()),
+            "[[40 kg, 41 kg, 42 kg],[50.1 kg, 60 kg, 52.3 kg]]",
+            test_suite,
+            "get_daa(), 2D array, single assign, no units",
+        )
 
-    test_so.obj.daa[0] = trick.attach_units( "lb",[ 4.0, 5.0, 6.0])
-    TRICK_EXPECT_EQ( str(test_so.obj.daa[0]) , "[1.81436948 kg, 2.26796185 kg, 2.72155422 kg]",
-     test_suite , "2D array, single single row assignment with units conversion" )
-    if useArrayGetters: 
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daa()[0]) , "[1.81436948 kg, 2.26796185 kg, 2.72155422 kg]",
-         test_suite , "get_daa(), 2D array, single single row assignment with units conversion" )
+    test_so.obj.daa[0] = trick.attach_units("lb", [4.0, 5.0, 6.0])
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daa[0]),
+        "[1.81436948 kg, 2.26796185 kg, 2.72155422 kg]",
+        test_suite,
+        "2D array, single single row assignment with units conversion",
+    )
+    if useArrayGetters:
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daa()[0]),
+            "[1.81436948 kg, 2.26796185 kg, 2.72155422 kg]",
+            test_suite,
+            "get_daa(), 2D array, single single row assignment with units conversion",
+        )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.dap) , "[NULL, NULL, NULL, NULL]", test_suite , "2D array of ptr, initial value" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dap_2d()) , "[NULL, NULL, NULL, NULL]", test_suite , "get_dap_2d(), 2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dap_2d()),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "get_dap_2d(), 2D array of ptr, initial value",
+    )
 
-    test_so.obj.dap[0] = trick.TMM_declare_var_1d( "double", 3)
-    test_so.obj.dap[1] = trick.TMM_declare_var_1d( "double", 4)
-    test_so.obj.dap[2] = trick.TMM_declare_var_1d( "double", 5)
-    test_so.obj.dap[3] = trick.TMM_declare_var_1d( "double", 6)
+    test_so.obj.dap[0] = trick.TMM_declare_var_1d("double", 3)
+    test_so.obj.dap[1] = trick.TMM_declare_var_1d("double", 4)
+    test_so.obj.dap[2] = trick.TMM_declare_var_1d("double", 5)
+    test_so.obj.dap[3] = trick.TMM_declare_var_1d("double", 6)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.dap) , "[[0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]]", test_suite , "2D array of ptr, single row access" )
-    TRICK_EXPECT_EQ( str(test_so.obj.dap[0]) , "[0 kg, 0 kg, 0 kg]", test_suite , "2D array of ptr, single row access" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dap_2d()[0]) , "[0 kg, 0 kg, 0 kg]", test_suite , "get_dap_2d(), 2D array of ptr, single row access" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dap_2d_pl_2()) , "[[0 kg, 0 kg, 0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]]", test_suite , "get_dap_2d_pl_2(), 2D array of ptr, starting at 3rd row" )
-    
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dap),
+        "[[0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dap[0]),
+        "[0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dap_2d()[0]),
+        "[0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "get_dap_2d(), 2D array of ptr, single row access",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dap_2d_pl_2()),
+        "[[0 kg, 0 kg, 0 kg, 0 kg, 0 kg], [0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]]",
+        test_suite,
+        "get_dap_2d_pl_2(), 2D array of ptr, starting at 3rd row",
+    )
 
-    test_so.obj.dap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.dap[3]) , "[60 kg, 61 kg, 62 kg, 63 kg]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dap_2d()[3]) , "[60 kg, 61 kg, 62 kg, 63 kg]",
-     test_suite , "get_dap_2d(), 2D array of ptr, single row realloc and assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dap_2d_pl_2()[1]) , "[60 kg, 61 kg, 62 kg, 63 kg]", test_suite , "get_dap_2d_pl_2(), 2D array of ptr, single row realloc and assignment" )
+    test_so.obj.dap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dap[3]),
+        "[60 kg, 61 kg, 62 kg, 63 kg]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dap_2d()[3]),
+        "[60 kg, 61 kg, 62 kg, 63 kg]",
+        test_suite,
+        "get_dap_2d(), 2D array of ptr, single row realloc and assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dap_2d_pl_2()[1]),
+        "[60 kg, 61 kg, 62 kg, 63 kg]",
+        test_suite,
+        "get_dap_2d_pl_2(), 2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.dap[3][1] = 75
     test_so.obj.dap[3][3] = trick.attach_units("lb", float(test_so.obj.dap[3][3]) + 1.0)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.dap[3]) , "[60 kg, 75 kg, 62 kg, 29.02991168 kg]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dap_2d()[3]) , "[60 kg, 75 kg, 62 kg, 29.02991168 kg]",
-     test_suite , "get_dap_2d(), 2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dap[3]),
+        "[60 kg, 75 kg, 62 kg, 29.02991168 kg]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dap_2d()[3]),
+        "[60 kg, 75 kg, 62 kg, 29.02991168 kg]",
+        test_suite,
+        "get_dap_2d(), 2D array of ptr, single item assignment with unit conversion",
+    )
 
     test_so.obj.dpp = trick.TMM_declare_var_s("double *[4]")
-    TRICK_EXPECT_EQ( str(test_so.obj.dpp) , "[NULL, NULL, NULL, NULL]", test_suite , "2D ptr of ptr, initial value" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()) , "[NULL, NULL, NULL, NULL]", test_suite , "get_dpp(), 2D ptr of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dpp()),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "get_dpp(), 2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.dpp[0] = trick.TMM_declare_var_1d( "double", 5)
-    TRICK_EXPECT_EQ( str(test_so.obj.dpp[0]) , "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg]", test_suite , "2D ptr of ptr, allocate 1 row" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()[0]) , "[0, 0, 0, 0, 0]", test_suite , "get_dpp(), 2D ptr of ptr, allocate 1 row" )
+    test_so.obj.dpp[0] = trick.TMM_declare_var_1d("double", 5)
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dpp[0]),
+        "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dpp()[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "get_dpp(), 2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.dpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.dpp[0]) , "[0 kg, 85 kg, 0 kg, 0 kg, 0 kg]",
-     test_suite , "2D ptr of ptr, scalar assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()[0]) , "[0, 85, 0, 0, 0]",
-     test_suite , "get_dpp(), 2D ptr of ptr, scalar assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dpp[0]),
+        "[0 kg, 85 kg, 0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "2D ptr of ptr, scalar assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dpp()[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "get_dpp(), 2D ptr of ptr, scalar assignment",
+    )
 
-    test_so.obj.dpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.dpp[1]) , "[91 kg, 92 kg, 93 kg]",
-     test_suite , "2D ptr of ptr, row assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()[1]) , "[91, 92, 93]",
-     test_suite , "get_dpp(), 2D ptr of ptr, row assignment" )
+    test_so.obj.dpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dpp[1]),
+        "[91 kg, 92 kg, 93 kg]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dpp()[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "get_dpp(), 2D ptr of ptr, row assignment",
+    )
 
-    test_so.obj.dpp[2] = trick.attach_units("lb" , [ 91 , 92 , 93 , 94 , 95])
-    TRICK_EXPECT_NEAR( test_so.obj.dpp[2][0] , 41.276905 , 0.000001 ,
-     test_suite , "2D ptr of ptr, united value" )
-    TRICK_EXPECT_NEAR( test_so.obj.get_dpp()[2][0] , 41.276905 , 0.000001 ,
-     test_suite , "get_dpp(), 2D ptr of ptr, united value" )
+    test_so.obj.dpp[2] = trick.attach_units("lb", [91, 92, 93, 94, 95])
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dpp[2][0],
+        41.276905,
+        0.000001,
+        test_suite,
+        "2D ptr of ptr, united value",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.get_dpp()[2][0],
+        41.276905,
+        0.000001,
+        test_suite,
+        "get_dpp(), 2D ptr of ptr, united value",
+    )
 
     test_so.obj.dpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.dpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()) , "NULL", test_suite , "get_dpp(), 2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dpp()),
+        "NULL",
+        test_suite,
+        "get_dpp(), 2D ptr None (NULL) assignment",
+    )
 
     test_so.obj.daaa[0][0] = [1, 2, 3, 4]
     test_so.obj.daaa[0][1] = [5, 6, 7, 8]
@@ -229,1751 +597,3657 @@ def main():
     test_so.obj.daaa[0][2][2] = 11
     test_so.obj.daaa[0][2][3] = 12
     # 2D assignment fails with error message but does not exit sim. :(
-    #test_so.obj.daaa[1][0] = [[101, 102, 103, 104] , [105, 106, 107, 108] , [109, 110, 111, 112]]
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa[0]) , "[[1 kg, 2 kg, 3 kg, 4 kg],[5 kg, 6 kg, 7 kg, 8 kg],[9 kg, 10 kg, 11 kg, 12 kg]]",
-     test_suite , "3D array, list and scalar assignment" )
+    # test_so.obj.daaa[1][0] = [[101, 102, 103, 104] , [105, 106, 107, 108] , [109, 110, 111, 112]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa[0]),
+        "[[1 kg, 2 kg, 3 kg, 4 kg],[5 kg, 6 kg, 7 kg, 8 kg],[9 kg, 10 kg, 11 kg, 12 kg]]",
+        test_suite,
+        "3D array, list and scalar assignment",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()[0]) , "[[1 kg, 2 kg, 3 kg, 4 kg],[5 kg, 6 kg, 7 kg, 8 kg],[9 kg, 10 kg, 11 kg, 12 kg]]",
-         test_suite , "get_daaa(), 3D array, list and scalar assignment" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()[0]),
+            "[[1 kg, 2 kg, 3 kg, 4 kg],[5 kg, 6 kg, 7 kg, 8 kg],[9 kg, 10 kg, 11 kg, 12 kg]]",
+            test_suite,
+            "get_daaa(), 3D array, list and scalar assignment",
+        )
 
     # 4D assignment array is not supported yet
-    #test_so.obj.daaaa[0][0][0] = [51, 52, 53, 54, 55]
+    # test_so.obj.daaaa[0][0][0] = [51, 52, 53, 54, 55]
 
     # 3D fixed size array tests
-    test_so.obj.daaa = [[[1.1,2.2,3.3,4],[5.1,6.2,7.3,8],[9.1,10.2,11.3,12]],[[13.1,14.2,15.3,16],[17.1,18.2,19.3,20],[21.1,22.2,23.3,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[13.1 kg, 14.2 kg, 15.3 kg, 16 kg],[17.1 kg, 18.2 kg, 19.3 kg, 20 kg],[21.1 kg, 22.2 kg, 23.3 kg, 24 kg]]]",
-     test_suite , "3D fixed size array, full assignment" )
+    test_so.obj.daaa = [
+        [[1.1, 2.2, 3.3, 4], [5.1, 6.2, 7.3, 8], [9.1, 10.2, 11.3, 12]],
+        [[13.1, 14.2, 15.3, 16], [17.1, 18.2, 19.3, 20], [21.1, 22.2, 23.3, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa),
+        "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[13.1 kg, 14.2 kg, 15.3 kg, 16 kg],[17.1 kg, 18.2 kg, 19.3 kg, 20 kg],[21.1 kg, 22.2 kg, 23.3 kg, 24 kg]]]",
+        test_suite,
+        "3D fixed size array, full assignment",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[13.1 kg, 14.2 kg, 15.3 kg, 16 kg],[17.1 kg, 18.2 kg, 19.3 kg, 20 kg],[21.1 kg, 22.2 kg, 23.3 kg, 24 kg]]]",
-         test_suite , "get_daaa(), 3D fixed size array, full assignment" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()),
+            "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[13.1 kg, 14.2 kg, 15.3 kg, 16 kg],[17.1 kg, 18.2 kg, 19.3 kg, 20 kg],[21.1 kg, 22.2 kg, 23.3 kg, 24 kg]]]",
+            test_suite,
+            "get_daaa(), 3D fixed size array, full assignment",
+        )
 
-    test_so.obj.daaa[1] = [[70.1,80.2,90.3,100],[110.1,120.2,130.3,140],[130.1,140.2,150.3,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
-     test_suite , "3D fixed size array, slice assignment (2D)" )
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa[1]) , "[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]",
-     test_suite , "3D fixed size array, slice assignment (2D), single row access" )
+    test_so.obj.daaa[1] = [
+        [70.1, 80.2, 90.3, 100],
+        [110.1, 120.2, 130.3, 140],
+        [130.1, 140.2, 150.3, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa),
+        "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D)",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa[1]),
+        "[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), single row access",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
-         test_suite , "get_daaa(), 3D fixed size array, slice assignment (2D)" )
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()[1]) , "[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]",
-         test_suite , "get_daaa(), 3D fixed size array, slice assignment (2D), single row access" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()),
+            "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
+            test_suite,
+            "get_daaa(), 3D fixed size array, slice assignment (2D)",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()[1]),
+            "[[70.09999999999999 kg, 80.2 kg, 90.3 kg, 100 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]",
+            test_suite,
+            "get_daaa(), 3D fixed size array, slice assignment (2D), single row access",
+        )
 
-    test_so.obj.daaa[1][0] = [700.1,800.2,900.3,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
-     test_suite , "3D fixed size array, slice assignment (1D)" )
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa[1][0]) , "[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg]",
-     test_suite , "3D fixed size array, slice assignment (1D), single row access" )
+    test_so.obj.daaa[1][0] = [700.1, 800.2, 900.3, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa),
+        "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D)",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa[1][0]),
+        "[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), single row access",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
-         test_suite , "get_daaa(), 3D fixed size array, slice assignment (1D)" )
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()[1][0]) , "[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg]",
-         test_suite , "get_daaa(), 3D fixed size array, slice assignment (1D), single row access" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()),
+            "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
+            test_suite,
+            "get_daaa(), 3D fixed size array, slice assignment (1D)",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()[1][0]),
+            "[700.1 kg, 800.2 kg, 900.3 kg, 1000 kg]",
+            test_suite,
+            "get_daaa(), 3D fixed size array, slice assignment (1D), single row access",
+        )
 
     test_so.obj.daaa[1][0][2] = 99
-    TRICK_EXPECT_EQ( str(test_so.obj.daaa) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 99 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
-     test_suite , "3D fixed size array, single value assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.daaa[1][0][2] , 99,
-     test_suite , "3D fixed size array, single value assignment, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.daaa),
+        "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 99 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
+        test_suite,
+        "3D fixed size array, single value assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.daaa[1][0][2],
+        99,
+        test_suite,
+        "3D fixed size array, single value assignment, single value access",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( str(test_so.obj.get_daaa()) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 99 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
-         test_suite , "get_daaa(), 3D fixed size array, single value assignment" )
-        TRICK_EXPECT_EQ( test_so.obj.get_daaa()[1][0][2] , 99,
-         test_suite , "get_daaa(), 3D fixed size array, single value assignment, single value access" )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_daaa()),
+            "[[[1.1 kg, 2.2 kg, 3.3 kg, 4 kg],[5.1 kg, 6.2 kg, 7.3 kg, 8 kg],[9.1 kg, 10.2 kg, 11.3 kg, 12 kg]],[[700.1 kg, 800.2 kg, 99 kg, 1000 kg],[110.1 kg, 120.2 kg, 130.3 kg, 140 kg],[130.1 kg, 140.2 kg, 150.3 kg, 160 kg]]]",
+            test_suite,
+            "get_daaa(), 3D fixed size array, single value assignment",
+        )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_daaa()[1][0][2],
+            99,
+            test_suite,
+            "get_daaa(), 3D fixed size array, single value assignment, single value access",
+        )
 
     # 3D dynamic array tests
-    test_so.obj.dppp = [[[1.1, 2.2, 3.3, 4.4],[5.5, 6.6, 7.7, 8.8]],[[9.9, 10.1, 11.2, 12.3],[13.4, 14.5, 15.6, 16.7]],[[17.8,18.9,19.0,20.1],[21.2,22.3,23.4,24.5]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.dppp) , "[[[1.1 kg, 2.2 kg, 3.3 kg, 4.4 kg], [5.5 kg, 6.6 kg, 7.7 kg, 8.800000000000001 kg]], [[9.9 kg, 10.1 kg, 11.2 kg, 12.3 kg], [13.4 kg, 14.5 kg, 15.6 kg, 16.7 kg]], [[17.8 kg, 18.9 kg, 19 kg, 20.1 kg], [21.2 kg, 22.3 kg, 23.4 kg, 24.5 kg]]]",
-     test_suite , "3D dynamic array, full assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.dppp[0]) , "[[1.1 kg, 2.2 kg, 3.3 kg, 4.4 kg], [5.5 kg, 6.6 kg, 7.7 kg, 8.800000000000001 kg]]",
-     test_suite , "3D dynamic array, full assignment, single row access" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()) , "[[[1.1, 2.2, 3.3, 4.4], [5.5, 6.6, 7.7, 8.800000000000001]], [[9.9, 10.1, 11.2, 12.3], [13.4, 14.5, 15.6, 16.7]], [[17.8, 18.9, 19, 20.1], [21.2, 22.3, 23.4, 24.5]]]",
-     test_suite , "get_dppp(), 3D dynamic array, full assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()[0]) , "[[1.1, 2.2, 3.3, 4.4], [5.5, 6.6, 7.7, 8.800000000000001]]",
-     test_suite , "get_dppp(), 3D dynamic array, full assignment, single row access" )
+    test_so.obj.dppp = [
+        [[1.1, 2.2, 3.3, 4.4], [5.5, 6.6, 7.7, 8.8]],
+        [[9.9, 10.1, 11.2, 12.3], [13.4, 14.5, 15.6, 16.7]],
+        [[17.8, 18.9, 19.0, 20.1], [21.2, 22.3, 23.4, 24.5]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dppp),
+        "[[[1.1 kg, 2.2 kg, 3.3 kg, 4.4 kg], [5.5 kg, 6.6 kg, 7.7 kg, 8.800000000000001 kg]], [[9.9 kg, 10.1 kg, 11.2 kg, 12.3 kg], [13.4 kg, 14.5 kg, 15.6 kg, 16.7 kg]], [[17.8 kg, 18.9 kg, 19 kg, 20.1 kg], [21.2 kg, 22.3 kg, 23.4 kg, 24.5 kg]]]",
+        test_suite,
+        "3D dynamic array, full assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dppp[0]),
+        "[[1.1 kg, 2.2 kg, 3.3 kg, 4.4 kg], [5.5 kg, 6.6 kg, 7.7 kg, 8.800000000000001 kg]]",
+        test_suite,
+        "3D dynamic array, full assignment, single row access",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dppp()),
+        "[[[1.1, 2.2, 3.3, 4.4], [5.5, 6.6, 7.7, 8.800000000000001]], [[9.9, 10.1, 11.2, 12.3], [13.4, 14.5, 15.6, 16.7]], [[17.8, 18.9, 19, 20.1], [21.2, 22.3, 23.4, 24.5]]]",
+        test_suite,
+        "get_dppp(), 3D dynamic array, full assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dppp()[0]),
+        "[[1.1, 2.2, 3.3, 4.4], [5.5, 6.6, 7.7, 8.800000000000001]]",
+        test_suite,
+        "get_dppp(), 3D dynamic array, full assignment, single row access",
+    )
 
-    test_so.obj.dppp[1] = [[70.5, 80.6, 90.7, 100.8],[110.9, 120.1, 130.2, 140.3]]
-    TRICK_EXPECT_EQ( str(test_so.obj.dppp[1]) , "[[70.5 kg, 80.59999999999999 kg, 90.7 kg, 100.8 kg], [110.9 kg, 120.1 kg, 130.2 kg, 140.3 kg]]",
-     test_suite , "3D dynamic array, slice assignment (2D), single row access" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()[1]) , "[[70.5, 80.59999999999999, 90.7, 100.8], [110.9, 120.1, 130.2, 140.3]]",
-     test_suite , "get_dppp(), 3D dynamic array, slice assignment (2D), single row access" )
+    test_so.obj.dppp[1] = [[70.5, 80.6, 90.7, 100.8], [110.9, 120.1, 130.2, 140.3]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dppp[1]),
+        "[[70.5 kg, 80.59999999999999 kg, 90.7 kg, 100.8 kg], [110.9 kg, 120.1 kg, 130.2 kg, 140.3 kg]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), single row access",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dppp()[1]),
+        "[[70.5, 80.59999999999999, 90.7, 100.8], [110.9, 120.1, 130.2, 140.3]]",
+        test_suite,
+        "get_dppp(), 3D dynamic array, slice assignment (2D), single row access",
+    )
 
     test_so.obj.dppp[1][0] = [700.1, 800.2, 900.3, 1000.4]
-    TRICK_EXPECT_EQ( str(test_so.obj.dppp[1][0]) , "[700.1 kg, 800.2 kg, 900.3 kg, 1000.4 kg]",
-     test_suite , "3D dynamic array, slice assignment (1D), single row access" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()[1][0]) , "[700.1, 800.2, 900.3, 1000.4]",
-     test_suite , "get_dppp(), 3D dynamic array, slice assignment (1D), single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dppp[1][0]),
+        "[700.1 kg, 800.2 kg, 900.3 kg, 1000.4 kg]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), single row access",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dppp()[1][0]),
+        "[700.1, 800.2, 900.3, 1000.4]",
+        test_suite,
+        "get_dppp(), 3D dynamic array, slice assignment (1D), single row access",
+    )
 
     test_so.obj.dppp[1][0][2] = 99.99
-    TRICK_EXPECT_NEAR( test_so.obj.dppp[1][0][2] , 99.99 , 0.00001 ,
-     test_suite , "3D dynamic array, single value assignment, single value access" )
-    TRICK_EXPECT_NEAR( test_so.obj.get_dppp()[1][0][2] , 99.99 , 0.00001 ,
-     test_suite , "get_dppp(), 3D dynamic array, single value assignment, single value access" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dppp[1][0][2],
+        99.99,
+        0.00001,
+        test_suite,
+        "3D dynamic array, single value assignment, single value access",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.get_dppp()[1][0][2],
+        99.99,
+        0.00001,
+        test_suite,
+        "get_dppp(), 3D dynamic array, single value assignment, single value access",
+    )
 
     test_so.obj.dppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.dppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()) , "NULL", test_suite , "get_dppp(), 3D dynamic array None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_dppp()),
+        "NULL",
+        test_suite,
+        "get_dppp(), 3D dynamic array None (NULL) assignment",
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "float"
 
     test_so.obj.f = 2
-    TRICK_EXPECT_NEAR( test_so.obj.f , 2.0 , 0.000001 , test_suite , "no units" )
-    trick.trick_test_add_parent( test_suite , "no units" , "1532242077")
+    TRICK_EXPECT_NEAR(test_so.obj.f, 2.0, 0.000001, test_suite, "no units")
+    trick.trick_test_add_parent(test_suite, "no units", "1532242077")
 
-    test_so.obj.f = trick.attach_units("lb" , 2)
-    TRICK_EXPECT_NEAR( test_so.obj.f , 0.907185 , 0.000001 , test_suite , "units convert" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_f()) , "0.90718472 kg", test_suite , "get_f(), with units" )
+    test_so.obj.f = trick.attach_units("lb", 2)
+    TRICK_EXPECT_NEAR(test_so.obj.f, 0.907185, 0.000001, test_suite, "units convert")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_f()), "0.90718472 kg", test_suite, "get_f(), with units"
+    )
 
-    test_so.obj.fa = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_NEAR( test_so.obj.fa[0] , 20 , 0.000001 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.fa[1] , 21 , 0.000001 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.fa[2] , 22 , 0.000001 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.fa = [20, 21, 22]
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[0], 20, 0.000001, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[1], 21, 0.000001, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[2], 22, 0.000001, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.fa = [ 30.1 , 31.1 , 32.1 ]
+    test_so.obj.fa = [30.1, 31.1, 32.1]
 
-    TRICK_EXPECT_NEAR( test_so.obj.fa[0] , 30.1 , 0.0001 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.fa[1] , 31.1 , 0.0001 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.fa[2] , 32.1 , 0.0001 , test_suite , "1D array, float value, no units" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[0], 30.1, 0.0001, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[1], 31.1, 0.0001, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[2], 32.1, 0.0001, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.fa = trick.attach_units("lb" , [2 , 3 , 4])
-    TRICK_EXPECT_NEAR( test_so.obj.fa[0] , 0.907185 , 0.000001 , test_suite , "1D array, float value, units convert" )
-    TRICK_EXPECT_NEAR( test_so.obj.fa[1] , 1.36078 ,  0.00001  , test_suite , "1D array, float value, units convert" )
-    TRICK_EXPECT_NEAR( test_so.obj.fa[2] , 1.81437 ,  0.00001  , test_suite , "1D array, float value, units convert" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_fa_flat()) , "[0.90718472 kg, 1.3607771 kg, 1.8143694 kg]", test_suite , "get_fa_flat(), no units" )
+    test_so.obj.fa = trick.attach_units("lb", [2, 3, 4])
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[0],
+        0.907185,
+        0.000001,
+        test_suite,
+        "1D array, float value, units convert",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[1],
+        1.36078,
+        0.00001,
+        test_suite,
+        "1D array, float value, units convert",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fa[2],
+        1.81437,
+        0.00001,
+        test_suite,
+        "1D array, float value, units convert",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_fa_flat()),
+        "[0.90718472 kg, 1.3607771 kg, 1.8143694 kg]",
+        test_suite,
+        "get_fa_flat(), no units",
+    )
 
-    test_so.obj.fp = trick.alloc_type( 6 , "float")
-    TRICK_EXPECT_NEAR( test_so.obj.fp[0] , 0 ,  0.00001  , test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_NEAR( test_so.obj.fp[5] , 0 ,  0.00001  , test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.fp) , "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]", test_suite , "1D ptr, allocation" )
+    test_so.obj.fp = trick.alloc_type(6, "float")
+    TRICK_EXPECT_NEAR(test_so.obj.fp[0], 0, 0.00001, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_NEAR(test_so.obj.fp[5], 0, 0.00001, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fp),
+        "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "1D ptr, allocation",
+    )
 
-    test_so.obj.fp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.fp) , "[30 kg, 31 kg, 32 kg, 33 kg]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.fp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fp),
+        "[30 kg, 31 kg, 32 kg, 33 kg]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.fp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.fp) , "[30 kg, 31 kg, 62 kg, 33 kg]", test_suite , "1D ptr, partial assign, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_fp()) , "[30, 31, 62, 33]", test_suite , "get_fp(), 1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fp),
+        "[30 kg, 31 kg, 62 kg, 33 kg]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_fp()),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "get_fp(), 1D ptr, partial assign, no units",
+    )
 
     test_so.obj.fp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.fp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.faa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.faa) , "[[40 kg, 41 kg, 42 kg],[43 kg, 44 kg, 45 kg]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.faa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faa),
+        "[[40 kg, 41 kg, 42 kg],[43 kg, 44 kg, 45 kg]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.faa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.faa) , "[[40 kg, 41 kg, 42 kg],[50 kg, 51 kg, 52 kg]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.faa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faa),
+        "[[40 kg, 41 kg, 42 kg],[50 kg, 51 kg, 52 kg]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.faa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.faa) , "[[40 kg, 41 kg, 42 kg],[50.099998 kg, 51.200001 kg, 52.299999 kg]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.faa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faa),
+        "[[40 kg, 41 kg, 42 kg],[50.099998 kg, 51.200001 kg, 52.299999 kg]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.faa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.faa) , "[[40 kg, 41 kg, 42 kg],[50.099998 kg, 60 kg, 52.299999 kg]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.faa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faa),
+        "[[40 kg, 41 kg, 42 kg],[50.099998 kg, 60 kg, 52.299999 kg]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.fap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.fap[0] = trick.alloc_type( 3 , "float")
-    test_so.obj.fap[1] = trick.alloc_type( 4 , "float")
-    test_so.obj.fap[2] = trick.alloc_type( 5 , "float")
-    test_so.obj.fap[3] = trick.alloc_type( 6 , "float")
-    TRICK_EXPECT_EQ( str(test_so.obj.fap[0]) , "[0 kg, 0 kg, 0 kg]",
-     test_suite , "2D array of ptr, single row access" )
+    test_so.obj.fap[0] = trick.alloc_type(3, "float")
+    test_so.obj.fap[1] = trick.alloc_type(4, "float")
+    test_so.obj.fap[2] = trick.alloc_type(5, "float")
+    test_so.obj.fap[3] = trick.alloc_type(6, "float")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fap[0]),
+        "[0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.fap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.fap[3]) , "[60 kg, 61 kg, 62 kg, 63 kg]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.fap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fap[3]),
+        "[60 kg, 61 kg, 62 kg, 63 kg]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.fap[3][1] = 75
     test_so.obj.fap[3][3] = trick.attach_units("lb", float(test_so.obj.fap[3][3]) + 1.0)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.fap[3]) , "[60 kg, 75 kg, 62 kg, 29.029911 kg]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fap[3]),
+        "[60 kg, 75 kg, 62 kg, 29.029911 kg]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.fpp = trick.alloc_type( 4 , "float *")
-    TRICK_EXPECT_EQ( str(test_so.obj.fpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.fpp = trick.alloc_type(4, "float *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.fpp[0] = trick.alloc_type( 5 , "float")
-    TRICK_EXPECT_EQ( str(test_so.obj.fpp[0]) , "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.fpp[0] = trick.alloc_type(5, "float")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fpp[0]),
+        "[0 kg, 0 kg, 0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.fpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.fpp[0]) , "[0 kg, 85 kg, 0 kg, 0 kg, 0 kg]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fpp[0]),
+        "[0 kg, 85 kg, 0 kg, 0 kg, 0 kg]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.fpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.fpp[1]) , "[91 kg, 92 kg, 93 kg]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.fpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fpp[1]),
+        "[91 kg, 92 kg, 93 kg]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.fpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.fpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     test_so.obj.f_rad = 2.0
-    TRICK_EXPECT_NEAR( test_so.obj.f_rad , 2.0 , 0.000001 , test_suite , "no units" )
+    TRICK_EXPECT_NEAR(test_so.obj.f_rad, 2.0, 0.000001, test_suite, "no units")
 
-    test_so.obj.f_rad = trick.attach_units("degree" , 45.0)
-    TRICK_EXPECT_NEAR( test_so.obj.f_rad , 0.785398 , 0.000001 , test_suite , "unit conv" )
+    test_so.obj.f_rad = trick.attach_units("degree", 45.0)
+    TRICK_EXPECT_NEAR(test_so.obj.f_rad, 0.785398, 0.000001, test_suite, "unit conv")
 
     test_so.obj.d_deg = test_so.obj.f_rad
-    TRICK_EXPECT_NEAR( test_so.obj.d_deg , 45.0 , 0.00001 , test_suite , "value to value assign with conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.d_deg,
+        45.0,
+        0.00001,
+        test_suite,
+        "value to value assign with conversion",
+    )
 
     # 3D fixed size array tests
-    test_so.obj.faaa = [[[1.1,2.2,3.3,4],[5.1,6.2,7.3,8],[9.1,10.2,11.3,12]],[[13.1,14.2,15.3,16],[17.1,18.2,19.3,20],[21.1,22.2,23.3,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.faaa) , "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[13.1, 14.2, 15.3, 16],[17.1, 18.200001, 19.299999, 20],[21.1, 22.200001, 23.299999, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.faaa = [
+        [[1.1, 2.2, 3.3, 4], [5.1, 6.2, 7.3, 8], [9.1, 10.2, 11.3, 12]],
+        [[13.1, 14.2, 15.3, 16], [17.1, 18.2, 19.3, 20], [21.1, 22.2, 23.3, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faaa),
+        "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[13.1, 14.2, 15.3, 16],[17.1, 18.200001, 19.299999, 20],[21.1, 22.200001, 23.299999, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.faaa[1] = [[70.5,80.6,90.7,100.8],[110.9,120.1,130.2,140.3],[130.4,140.5,150.6,160.7]]
-    TRICK_EXPECT_EQ( str(test_so.obj.faaa) , "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[70.5, 80.599998, 90.699997, 100.8],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.faaa[1]) , "[[70.5, 80.599998, 90.699997, 100.8],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.faaa[1] = [
+        [70.5, 80.6, 90.7, 100.8],
+        [110.9, 120.1, 130.2, 140.3],
+        [130.4, 140.5, 150.6, 160.7],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faaa),
+        "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[70.5, 80.599998, 90.699997, 100.8],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faaa[1]),
+        "[[70.5, 80.599998, 90.699997, 100.8],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.faaa[1][0] = [700.1,800.2,900.3,1000.4]
-    TRICK_EXPECT_EQ( str(test_so.obj.faaa) , "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[700.09998, 800.20001, 900.29999, 1000.4],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.faaa[1][0]) , "[700.09998, 800.20001, 900.29999, 1000.4]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.faaa[1][0] = [700.1, 800.2, 900.3, 1000.4]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faaa),
+        "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[700.09998, 800.20001, 900.29999, 1000.4],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faaa[1][0]),
+        "[700.09998, 800.20001, 900.29999, 1000.4]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.faaa[1][0][2] = 99.99
-    TRICK_EXPECT_EQ( str(test_so.obj.faaa) , "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[700.09998, 800.20001, 99.989998, 1000.4],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]]",
-     test_suite , "3D fixed size array, single value assignment, no units" )
-    TRICK_EXPECT_NEAR( test_so.obj.faaa[1][0][2] , 99.99 , 0.00001 ,
-     test_suite , "3D fixed size array, single value assignment, no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.faaa),
+        "[[[1.1, 2.2, 3.3, 4],[5.0999999, 6.1999998, 7.3000002, 8],[9.1000004, 10.2, 11.3, 12]],[[700.09998, 800.20001, 99.989998, 1000.4],[110.9, 120.1, 130.2, 140.3],[130.39999, 140.5, 150.60001, 160.7]]]",
+        test_suite,
+        "3D fixed size array, single value assignment, no units",
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.faaa[1][0][2],
+        99.99,
+        0.00001,
+        test_suite,
+        "3D fixed size array, single value assignment, no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.fppp = [[[1.1, 2.2, 3.3, 4.4],[5.5, 6.6, 7.7, 8.8]],[[9.9, 10.1, 11.2, 12.3],[13.4, 14.5, 15.6, 16.7]],[[17.8,18.9,19.0,20.1],[21.2,22.3,23.4,24.5]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.fppp) , "[[[1.1, 2.2, 3.3, 4.4000001], [5.5, 6.5999999, 7.6999998, 8.8000002]], [[9.8999996, 10.1, 11.2, 12.3], [13.4, 14.5, 15.6, 16.700001]], [[17.799999, 18.9, 19, 20.1], [21.200001, 22.299999, 23.4, 24.5]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.fppp[0]) , "[[1.1, 2.2, 3.3, 4.4000001], [5.5, 6.5999999, 7.6999998, 8.8000002]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.fppp = [
+        [[1.1, 2.2, 3.3, 4.4], [5.5, 6.6, 7.7, 8.8]],
+        [[9.9, 10.1, 11.2, 12.3], [13.4, 14.5, 15.6, 16.7]],
+        [[17.8, 18.9, 19.0, 20.1], [21.2, 22.3, 23.4, 24.5]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fppp),
+        "[[[1.1, 2.2, 3.3, 4.4000001], [5.5, 6.5999999, 7.6999998, 8.8000002]], [[9.8999996, 10.1, 11.2, 12.3], [13.4, 14.5, 15.6, 16.700001]], [[17.799999, 18.9, 19, 20.1], [21.200001, 22.299999, 23.4, 24.5]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fppp[0]),
+        "[[1.1, 2.2, 3.3, 4.4000001], [5.5, 6.5999999, 7.6999998, 8.8000002]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.fppp[1] = [[70.5, 80.6, 90.7, 100.8],[110.9, 120.1, 130.2, 140.3]]
-    TRICK_EXPECT_EQ( str(test_so.obj.fppp[1]) , "[[70.5, 80.599998, 90.699997, 100.8], [110.9, 120.1, 130.2, 140.3]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.fppp[1] = [[70.5, 80.6, 90.7, 100.8], [110.9, 120.1, 130.2, 140.3]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fppp[1]),
+        "[[70.5, 80.599998, 90.699997, 100.8], [110.9, 120.1, 130.2, 140.3]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.fppp[1][0] = [700.1, 800.2, 900.3, 1000.4]
-    TRICK_EXPECT_EQ( str(test_so.obj.fppp[1][0]) , "[700.09998, 800.20001, 900.29999, 1000.4]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fppp[1][0]),
+        "[700.09998, 800.20001, 900.29999, 1000.4]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.fppp[1][0][2] = 99.99
-    TRICK_EXPECT_NEAR( test_so.obj.fppp[1][0][2] , 99.99 , 0.00001 ,
-     test_suite , "3D dynamic array, single value assignment, no units, single value access" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.fppp[1][0][2],
+        99.99,
+        0.00001,
+        test_suite,
+        "3D dynamic array, single value assignment, no units, single value access",
+    )
 
     test_so.obj.fppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.fppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.fppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "char"
 
-    test_so.obj.c = 'g'
-    TRICK_EXPECT_EQ( str(test_so.obj.c) , "103", test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "2896569040")
+    test_so.obj.c = "g"
+    TRICK_EXPECT_EQ(str(test_so.obj.c), "103", test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "2896569040")
 
     test_so.obj.c = 123
-    TRICK_EXPECT_EQ( str(test_so.obj.c) , "123", test_suite , "assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_c()) , "123", test_suite , "get_c(), assignment" )
+    TRICK_EXPECT_EQ(str(test_so.obj.c), "123", test_suite, "assignment")
+    TRICK_EXPECT_EQ(str(test_so.obj.get_c()), "123", test_suite, "get_c(), assignment")
 
     test_so.obj.ca = "Trick is great"
-    TRICK_EXPECT_EQ( str(test_so.obj.ca) , "Trick is great", test_suite , "arrray assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ca), "Trick is great", test_suite, "arrray assignment"
+    )
 
     test_so.obj.ca = [65, 66, 67, 68, 69]
-    TRICK_EXPECT_EQ( str(test_so.obj.ca) , "ABCDE", test_suite , "arrray assignment" )
+    TRICK_EXPECT_EQ(str(test_so.obj.ca), "ABCDE", test_suite, "arrray assignment")
 
     test_so.obj.ca = [65.1, 66.2, 67.3, 68.4, 69.6]
-    TRICK_EXPECT_EQ( str(test_so.obj.ca) , "ABCDE", test_suite , "arrray assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.ca[3] , 68 , test_suite , "arrray assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_ca_flat()) , "ABCDE", test_suite , "get_ca_flat(), arrray assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_ca_flat()[3] , 68 , test_suite , "get_ca_flat(), arrray assignment" )
+    TRICK_EXPECT_EQ(str(test_so.obj.ca), "ABCDE", test_suite, "arrray assignment")
+    TRICK_EXPECT_EQ(test_so.obj.ca[3], 68, test_suite, "arrray assignment")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_ca_flat()),
+        "ABCDE",
+        test_suite,
+        "get_ca_flat(), arrray assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_ca_flat()[3], 68, test_suite, "get_ca_flat(), arrray assignment"
+    )
 
-    test_so.obj.cp = trick.alloc_type( 6 , "char")
-    TRICK_EXPECT_EQ( test_so.obj.cp[0] , 0 , test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.cp[5] , 0 , test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.cp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.cp = trick.alloc_type(6, "char")
+    TRICK_EXPECT_EQ(test_so.obj.cp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.cp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.cp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.cp) , "[30, 31, ' ', '!']", test_suite , "float 1D ptr, list assign, no units" )
+    test_so.obj.cp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cp),
+        "[30, 31, ' ', '!']",
+        test_suite,
+        "float 1D ptr, list assign, no units",
+    )
 
     test_so.obj.cp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.cp) , "[30, 31, '>', '!']", test_suite , "float 1D ptr, partial assign, no units" )
-
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cp),
+        "[30, 31, '>', '!']",
+        test_suite,
+        "float 1D ptr, partial assign, no units",
+    )
 
     test_so.obj.cp = "testing"
-    TRICK_EXPECT_EQ( str(test_so.obj.cp) , "testing", test_suite , "ptr assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_cp()) , "testing", test_suite , "get_cp(), ptr assignment" )    
+    TRICK_EXPECT_EQ(str(test_so.obj.cp), "testing", test_suite, "ptr assignment")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_cp()), "testing", test_suite, "get_cp(), ptr assignment"
+    )
 
     test_so.obj.cp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.cp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.caa = [ "abcdefg" , "hijklmn" ]
-    TRICK_EXPECT_EQ( str(test_so.obj.caa) , "[\"abcdefg\",\"hijklmn\",[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]", test_suite , "2D array string assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.caa[1]) , "hijklmn", test_suite , "2D array item access" )
-    TRICK_EXPECT_EQ( test_so.obj.caa[1][4] , 108, test_suite , "2D array single char access" )
+    test_so.obj.caa = ["abcdefg", "hijklmn"]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.caa),
+        '["abcdefg","hijklmn",[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]',
+        test_suite,
+        "2D array string assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.caa[1]), "hijklmn", test_suite, "2D array item access"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.caa[1][4], 108, test_suite, "2D array single char access"
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.cap) , """[NULL, NULL, NULL, NULL]""", test_suite , "2D array of ptr initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cap),
+        """[NULL, NULL, NULL, NULL]""",
+        test_suite,
+        "2D array of ptr initial value",
+    )
 
     test_so.obj.cap[0] = "cap0"
     test_so.obj.cap[1] = "cap1"
     test_so.obj.cap[2] = "cap2"
     test_so.obj.cap[3] = "cap3"
-    TRICK_EXPECT_EQ( str(test_so.obj.cap) , "[\"cap0\", \"cap1\", \"cap2\", \"cap3\"]", test_suite , "2D array of ptr single item assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.cap[0]) , "cap0", test_suite , "2D array of ptr single item assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cap),
+        '["cap0", "cap1", "cap2", "cap3"]',
+        test_suite,
+        "2D array of ptr single item assignment",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cap[0]),
+        "cap0",
+        test_suite,
+        "2D array of ptr single item assignment",
+    )
 
-    TRICK_EXPECT_EQ( test_so.obj.cap[3][2] , 112 , test_suite , "2D array of ptr single item assignment" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.cap[3][2], 112, test_suite, "2D array of ptr single item assignment"
+    )
 
-    test_so.obj.cpp = trick.alloc_type( 4 , "char *")
-    TRICK_EXPECT_EQ( str(test_so.obj.cpp) , """[NULL, NULL, NULL, NULL]""", test_suite , "2D ptr of ptr initial value" )
+    test_so.obj.cpp = trick.alloc_type(4, "char *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cpp),
+        """[NULL, NULL, NULL, NULL]""",
+        test_suite,
+        "2D ptr of ptr initial value",
+    )
 
     test_so.obj.cpp[0] = "cpp_string_0"
     test_so.obj.cpp[1] = "cpp_string_1"
     test_so.obj.cpp[2] = "cpp_string_2"
     test_so.obj.cpp[3] = "cpp_string_3"
-    TRICK_EXPECT_EQ( str(test_so.obj.cpp[2]) , "cpp_string_2", test_suite , "2D ptr of ptr single string access" )
-    TRICK_EXPECT_EQ( test_so.obj.cpp[2][3] , 95 , test_suite , "2D ptr of ptr single character access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cpp[2]),
+        "cpp_string_2",
+        test_suite,
+        "2D ptr of ptr single string access",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.cpp[2][3], 95, test_suite, "2D ptr of ptr single character access"
+    )
 
     test_so.obj.cpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.cpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.cpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "unsigned char"
 
     test_so.obj.uc = 95
-    TRICK_EXPECT_EQ( test_so.obj.uc , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "219444977")
+    TRICK_EXPECT_EQ(test_so.obj.uc, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "219444977")
 
     test_so.obj.uc += 1
-    TRICK_EXPECT_EQ( test_so.obj.uc , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.uc, 96, test_suite, "increment")
 
     test_so.obj.uc = test_so.obj.uc + 1
-    TRICK_EXPECT_EQ( test_so.obj.uc , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.uc, 97, test_suite, "increment")
 
     test_so.obj.uc = 1 + test_so.obj.uc
-    TRICK_EXPECT_EQ( test_so.obj.uc , 98 , test_suite , "increment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_uc() , 98 , test_suite , "get_uc(), increment" )
+    TRICK_EXPECT_EQ(test_so.obj.uc, 98, test_suite, "increment")
+    TRICK_EXPECT_EQ(test_so.obj.get_uc(), 98, test_suite, "get_uc(), increment")
 
-    test_so.obj.uca = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.uca[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uca[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uca[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.uca = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.uca[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uca[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uca[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.uca = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.uca[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uca[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uca[2] , 32 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.get_uca_flat()[0] , 30 , test_suite , "get_uca_flat(), 1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.get_uca_flat()[1] , 31 , test_suite , "get_uca_flat(), 1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.get_uca_flat()[2] , 32 , test_suite , "get_uca_flat(), 1D array, float value, no units" )
+    test_so.obj.uca = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.uca[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uca[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uca[2], 32, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_uca_flat()[0],
+        30,
+        test_suite,
+        "get_uca_flat(), 1D array, float value, no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_uca_flat()[1],
+        31,
+        test_suite,
+        "get_uca_flat(), 1D array, float value, no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_uca_flat()[2],
+        32,
+        test_suite,
+        "get_uca_flat(), 1D array, float value, no units",
+    )
 
-    test_so.obj.ucp = trick.alloc_type( 6 , "unsigned char")
-    TRICK_EXPECT_EQ( test_so.obj.ucp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.ucp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ucp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.ucp = trick.alloc_type(6, "unsigned char")
+    TRICK_EXPECT_EQ(test_so.obj.ucp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.ucp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.ucp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ucp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.ucp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.ucp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.ucp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_ucp()) , "[30, 31, 62, 33]", test_suite , "get_ucp(), 1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_ucp()),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "get_ucp(), 1D ptr, partial assign, no units",
+    )
 
     test_so.obj.ucp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ucp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.ucaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ucaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.ucaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.ucaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.ucaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.ucaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.ucaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ucaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.ucaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.ucaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.ucaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.ucaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ucap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.ucap[0] = trick.alloc_type( 3 , "unsigned char")
-    test_so.obj.ucap[1] = trick.alloc_type( 4 , "unsigned char")
-    test_so.obj.ucap[2] = trick.alloc_type( 5 , "unsigned char")
-    test_so.obj.ucap[3] = trick.alloc_type( 6 , "unsigned char")
+    test_so.obj.ucap[0] = trick.alloc_type(3, "unsigned char")
+    test_so.obj.ucap[1] = trick.alloc_type(4, "unsigned char")
+    test_so.obj.ucap[2] = trick.alloc_type(5, "unsigned char")
+    test_so.obj.ucap[3] = trick.alloc_type(6, "unsigned char")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ucap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.ucap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ucap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.ucap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.ucap[3][1] = 75
     test_so.obj.ucap[3][3] = trick.attach_units("--", int(test_so.obj.ucap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ucap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.ucpp = trick.alloc_type( 4 , "unsigned char *")
-    TRICK_EXPECT_EQ( str(test_so.obj.ucpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.ucpp = trick.alloc_type(4, "unsigned char *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.ucpp[0] = trick.alloc_type( 5 , "unsigned char")
-    TRICK_EXPECT_EQ( str(test_so.obj.ucpp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.ucpp[0] = trick.alloc_type(5, "unsigned char")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucpp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.ucpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.ucpp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucpp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.ucpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ucpp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.ucpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucpp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.ucpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ucpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ucpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "short"
 
     test_so.obj.s = 95
-    TRICK_EXPECT_EQ( test_so.obj.s , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "2880907803")
+    TRICK_EXPECT_EQ(test_so.obj.s, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "2880907803")
 
     test_so.obj.s += 1
-    TRICK_EXPECT_EQ( test_so.obj.s , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.s, 96, test_suite, "increment")
 
     test_so.obj.s = test_so.obj.s + 1
-    TRICK_EXPECT_EQ( test_so.obj.s , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.s, 97, test_suite, "increment")
 
     test_so.obj.s = 1 + test_so.obj.s
-    TRICK_EXPECT_EQ( test_so.obj.s , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.s, 98, test_suite, "increment")
 
-    test_so.obj.sa = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.sa[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.sa[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.sa[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.sa = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.sa[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.sa[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.sa[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.sa = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.sa[0] , 30 , test_suite , "short 1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.sa[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.sa[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.sa = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.sa[0], 30, test_suite, "short 1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.sa[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.sa[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.sp = trick.alloc_type( 6 , "short")
-    TRICK_EXPECT_EQ( test_so.obj.sp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.sp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.sp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.sp = trick.alloc_type(6, "short")
+    TRICK_EXPECT_EQ(test_so.obj.sp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.sp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.sp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.sp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.sp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.sp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.sp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.sp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.sp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.saa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.saa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.saa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.saa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.saa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.saa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.saa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.saa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.saa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.saa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.saa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.saa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.sap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.sap[0] = trick.alloc_type( 3 , "short")
-    test_so.obj.sap[1] = trick.alloc_type( 4 , "short")
-    test_so.obj.sap[2] = trick.alloc_type( 5 , "short")
-    test_so.obj.sap[3] = trick.alloc_type( 6 , "short")
+    test_so.obj.sap[0] = trick.alloc_type(3, "short")
+    test_so.obj.sap[1] = trick.alloc_type(4, "short")
+    test_so.obj.sap[2] = trick.alloc_type(5, "short")
+    test_so.obj.sap[3] = trick.alloc_type(6, "short")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.sap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.sap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.sap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.sap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.sap[3][1] = 75
     test_so.obj.sap[3][3] = trick.attach_units("--", int(test_so.obj.sap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.sap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.spp = trick.alloc_type( 4 , "short *")
-    TRICK_EXPECT_EQ( str(test_so.obj.spp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.spp = trick.alloc_type(4, "short *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.spp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.spp[0] = trick.alloc_type( 5 , "short")
-    TRICK_EXPECT_EQ( str(test_so.obj.spp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.spp[0] = trick.alloc_type(5, "short")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.spp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.spp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.spp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.spp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.spp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.spp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.spp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.spp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.spp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.spp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.spp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.saaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.saaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.saaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.saaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.saaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.saaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.saaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.saaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.saaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.saaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.saaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.saaa[1][0][2] = 32000
-    TRICK_EXPECT_EQ( str(test_so.obj.saaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 32000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large short value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.saaa[1][0][2] , 32000 ,
-     test_suite , "3D fixed size array, single value assignment (large short value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.saaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 32000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large short value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.saaa[1][0][2],
+        32000,
+        test_suite,
+        "3D fixed size array, single value assignment (large short value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.sppp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.sppp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.sppp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.sppp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sppp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sppp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.sppp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.sppp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.sppp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sppp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.sppp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.sppp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sppp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.sppp[1][0][2] = -32000
-    TRICK_EXPECT_EQ( test_so.obj.sppp[1][0][2] , -32000 ,
-     test_suite , "3D dynamic array, single value assignment (large negative short value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.sppp[1][0][2],
+        -32000,
+        test_suite,
+        "3D dynamic array, single value assignment (large negative short value), no units, single value access",
+    )
 
     test_so.obj.sppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.sppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.sppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "unsigned short"
 
     test_so.obj.us = 95
-    TRICK_EXPECT_EQ( test_so.obj.us , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "217750348")
+    TRICK_EXPECT_EQ(test_so.obj.us, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "217750348")
 
     test_so.obj.us += 1
-    TRICK_EXPECT_EQ( test_so.obj.us , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.us, 96, test_suite, "increment")
 
     test_so.obj.us = test_so.obj.us + 1
-    TRICK_EXPECT_EQ( test_so.obj.us , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.us, 97, test_suite, "increment")
 
     test_so.obj.us = 1 + test_so.obj.us
-    TRICK_EXPECT_EQ( test_so.obj.us , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.us, 98, test_suite, "increment")
 
-    test_so.obj.usa = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.usa[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.usa[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.usa[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.usa = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.usa[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.usa[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.usa[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.usa = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.usa[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.usa[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.usa[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.usa = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.usa[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.usa[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.usa[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.usp = trick.alloc_type( 6 , "unsigned short")
-    TRICK_EXPECT_EQ( test_so.obj.usp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.usp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.usp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.usp = trick.alloc_type(6, "unsigned short")
+    TRICK_EXPECT_EQ(test_so.obj.usp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.usp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.usp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.usp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.usp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.usp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.usp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.usp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.usp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.usaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.usaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.usaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.usaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.usaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.usaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.usaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.usaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.usaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.usaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.usaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.usaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.usap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.usap[0] = trick.alloc_type( 3 , "unsigned short")
-    test_so.obj.usap[1] = trick.alloc_type( 4 , "unsigned short")
-    test_so.obj.usap[2] = trick.alloc_type( 5 , "unsigned short")
-    test_so.obj.usap[3] = trick.alloc_type( 6 , "unsigned short")
+    test_so.obj.usap[0] = trick.alloc_type(3, "unsigned short")
+    test_so.obj.usap[1] = trick.alloc_type(4, "unsigned short")
+    test_so.obj.usap[2] = trick.alloc_type(5, "unsigned short")
+    test_so.obj.usap[3] = trick.alloc_type(6, "unsigned short")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.usap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.usap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.usap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.usap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.usap[3][1] = 75
     test_so.obj.usap[3][3] = trick.attach_units("--", int(test_so.obj.usap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.usap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.uspp = trick.alloc_type( 4 , "unsigned short *")
-    TRICK_EXPECT_EQ( str(test_so.obj.uspp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.uspp = trick.alloc_type(4, "unsigned short *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uspp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.uspp[0] = trick.alloc_type( 5 , "unsigned short")
-    TRICK_EXPECT_EQ( str(test_so.obj.uspp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.uspp[0] = trick.alloc_type(5, "unsigned short")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uspp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.uspp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.uspp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uspp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.uspp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.uspp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.uspp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uspp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.uspp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.uspp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uspp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.usaaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.usaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.usaaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.usaaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.usaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.usaaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.usaaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.usaaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.usaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.usaaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.usaaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.usaaa[1][0][2] = 65000
-    TRICK_EXPECT_EQ( str(test_so.obj.usaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 65000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large unsigned short value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.usaaa[1][0][2] , 65000 ,
-     test_suite , "3D fixed size array, single value assignment (large unsigned short value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 65000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned short value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.usaaa[1][0][2],
+        65000,
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned short value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.usppp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.usppp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.usppp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.usppp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usppp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usppp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.usppp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.usppp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.usppp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usppp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.usppp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.usppp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usppp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.usppp[1][0][2] = 60000
-    TRICK_EXPECT_EQ( test_so.obj.usppp[1][0][2] , 60000 ,
-     test_suite , "3D dynamic array, single value assignment (large unsigned short value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.usppp[1][0][2],
+        60000,
+        test_suite,
+        "3D dynamic array, single value assignment (large unsigned short value), no units, single value access",
+    )
 
     test_so.obj.usppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.usppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.usppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "enum"
 
     test_so.obj.e = trick.THIRD
-    TRICK_EXPECT_EQ( test_so.obj.e , trick.THIRD , test_suite , "scalar, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.get_e() , trick.THIRD , test_suite , "get_e(), scalar, integer value, no units" )
-    trick.trick_test_add_parent( test_suite , "scalar, integer value, no units" , "3331066868")
+    TRICK_EXPECT_EQ(
+        test_so.obj.e, trick.THIRD, test_suite, "scalar, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_e(),
+        trick.THIRD,
+        test_suite,
+        "get_e(), scalar, integer value, no units",
+    )
+    trick.trick_test_add_parent(
+        test_suite, "scalar, integer value, no units", "3331066868"
+    )
 
-    test_so.obj.ea = [ trick.THIRD , trick.SECOND , trick.FIRST ]
-    TRICK_EXPECT_EQ( test_so.obj.ea[0] , trick.THIRD , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ea[1] , trick.SECOND , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ea[2] , trick.FIRST , test_suite , "1D array, integer value, no units" )
+    test_so.obj.ea = [trick.THIRD, trick.SECOND, trick.FIRST]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ea[0], trick.THIRD, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ea[1], trick.SECOND, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ea[2], trick.FIRST, test_suite, "1D array, integer value, no units"
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( test_so.obj.get_ea()[0] , trick.THIRD , test_suite , "get_ea(), 1D array, integer value, no units" )
-        TRICK_EXPECT_EQ( test_so.obj.get_ea()[1] , trick.SECOND , test_suite , "get_ea(), 1D array, integer value, no units" )
-        TRICK_EXPECT_EQ( test_so.obj.get_ea()[2] , trick.FIRST , test_suite , "get_ea(), 1D array, integer value, no units" )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_ea()[0],
+            trick.THIRD,
+            test_suite,
+            "get_ea(), 1D array, integer value, no units",
+        )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_ea()[1],
+            trick.SECOND,
+            test_suite,
+            "get_ea(), 1D array, integer value, no units",
+        )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_ea()[2],
+            trick.FIRST,
+            test_suite,
+            "get_ea(), 1D array, integer value, no units",
+        )
 
     test_so.obj.ea[1] = trick.THIRD
     test_so.obj.ea[2] = trick.SECOND
-    TRICK_EXPECT_EQ( test_so.obj.ea[1] , trick.THIRD , test_suite , "1D array single value assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.ea[2] , trick.SECOND , test_suite , "1D array single value assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_ea_flat()[1] , trick.THIRD , test_suite , "get_ea_flat(), 1D array single value assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_ea_flat()[2] , trick.SECOND , test_suite , "get_ea_flat(), 1D array single value assignment" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ea[1], trick.THIRD, test_suite, "1D array single value assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ea[2], trick.SECOND, test_suite, "1D array single value assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_ea_flat()[1],
+        trick.THIRD,
+        test_suite,
+        "get_ea_flat(), 1D array single value assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_ea_flat()[2],
+        trick.SECOND,
+        test_suite,
+        "get_ea_flat(), 1D array single value assignment",
+    )
 
-    test_so.obj.ep = trick.alloc_type( 6 , "MY_ENUM")
-    TRICK_EXPECT_EQ( test_so.obj.ep[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.ep[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ep) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.ep = trick.alloc_type(6, "MY_ENUM")
+    TRICK_EXPECT_EQ(test_so.obj.ep[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.ep[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ep), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.ep = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ep) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.ep = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ep),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.ep[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.ep) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_ep()) , "[30, 31, 62, 33]", test_suite , "get_ep(), 1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ep),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_ep()),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "get_ep(), 1D ptr, partial assign, no units",
+    )
 
     test_so.obj.ep = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ep) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ep), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.eaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.eaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.eaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.eaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.eaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.eaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.eaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.eaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.eaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.eaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.eaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.eaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.eap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.eap[0] = trick.alloc_type( 3 , "MY_ENUM")
-    test_so.obj.eap[1] = trick.alloc_type( 4 , "MY_ENUM")
-    test_so.obj.eap[2] = trick.alloc_type( 5 , "MY_ENUM")
-    test_so.obj.eap[3] = trick.alloc_type( 6 , "MY_ENUM")
+    test_so.obj.eap[0] = trick.alloc_type(3, "MY_ENUM")
+    test_so.obj.eap[1] = trick.alloc_type(4, "MY_ENUM")
+    test_so.obj.eap[2] = trick.alloc_type(5, "MY_ENUM")
+    test_so.obj.eap[3] = trick.alloc_type(6, "MY_ENUM")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.eap[0]) , "[0, 0, 0]", test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.eap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.eap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.eap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.eap[3][1] = 75
     test_so.obj.eap[3][3] = trick.attach_units("--", int(test_so.obj.eap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.eap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.eap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.epp = trick.alloc_type( 4 , "MY_ENUM *")
-    TRICK_EXPECT_EQ( str(test_so.obj.epp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "int 2D ptr of ptr, initial value" )
+    test_so.obj.epp = trick.alloc_type(4, "MY_ENUM *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.epp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "int 2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.epp[0] = trick.alloc_type( 5 , "MY_ENUM")
-    TRICK_EXPECT_EQ( str(test_so.obj.epp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.epp[0] = trick.alloc_type(5, "MY_ENUM")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.epp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.epp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.epp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.epp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.epp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.epp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.epp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.epp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.epp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.epp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.epp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "int"
 
     test_so.obj.i = 95
-    TRICK_EXPECT_EQ( test_so.obj.i , 95 , test_suite , "assignment" )
-    #print "test_so.obj.i = " , test_so.obj.i
-    trick.trick_test_add_parent( test_suite , "assignment" , "3074788233")
+    TRICK_EXPECT_EQ(test_so.obj.i, 95, test_suite, "assignment")
+    # print "test_so.obj.i = " , test_so.obj.i
+    trick.trick_test_add_parent(test_suite, "assignment", "3074788233")
 
     test_so.obj.i += 1
-    TRICK_EXPECT_EQ( test_so.obj.i , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 96, test_suite, "increment")
 
     test_so.obj.i = test_so.obj.i + 1
-    TRICK_EXPECT_EQ( test_so.obj.i , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 97, test_suite, "increment")
 
     test_so.obj.i = 1 + test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 98 , test_suite , "increment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_i() , 98 , test_suite , "get_i(), increment" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 98, test_suite, "increment")
+    TRICK_EXPECT_EQ(test_so.obj.get_i(), 98, test_suite, "get_i(), increment")
 
-    test_so.obj.ia = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.ia[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ia[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ia[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.ia = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ia[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ia[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ia[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.ia = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.ia[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ia[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ia[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.ia = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ia[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ia[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ia[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.ia = trick.attach_units("--" , [60, 70])
-    TRICK_EXPECT_EQ( test_so.obj.ia[0] , 60 , test_suite , "1D array, -- units" )
-    TRICK_EXPECT_EQ( test_so.obj.ia[1] , 70 , test_suite , "1D array, -- units" )
-    TRICK_EXPECT_EQ( test_so.obj.get_ia_flat()[0] , 60 , test_suite , "get_ia_flat(), 1D array, -- units" )
-    TRICK_EXPECT_EQ( test_so.obj.get_ia_flat()[1] , 70 , test_suite , "get_ia_flat(), 1D array, -- units" )
+    test_so.obj.ia = trick.attach_units("--", [60, 70])
+    TRICK_EXPECT_EQ(test_so.obj.ia[0], 60, test_suite, "1D array, -- units")
+    TRICK_EXPECT_EQ(test_so.obj.ia[1], 70, test_suite, "1D array, -- units")
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_ia_flat()[0],
+        60,
+        test_suite,
+        "get_ia_flat(), 1D array, -- units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_ia_flat()[1],
+        70,
+        test_suite,
+        "get_ia_flat(), 1D array, -- units",
+    )
 
-    test_so.obj.ip = trick.alloc_type( 6 , "int")
-    TRICK_EXPECT_EQ( test_so.obj.ip[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.ip[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ip) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.ip = trick.alloc_type(6, "int")
+    TRICK_EXPECT_EQ(test_so.obj.ip[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.ip[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.ip = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.ip = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.ip[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.ip) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
-    test_so.obj.ip = trick.attach_units("--" , [60, 70])
-    TRICK_EXPECT_EQ( str(test_so.obj.ip) , "[60, 70]", test_suite , "1D ptr, assign list -- unit-ed values" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_ip()) , "[60, 70]", test_suite , "get_ip(), 1D ptr, assign list -- unit-ed values" )
+    test_so.obj.ip = trick.attach_units("--", [60, 70])
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[60, 70]",
+        test_suite,
+        "1D ptr, assign list -- unit-ed values",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_ip()),
+        "[60, 70]",
+        test_suite,
+        "get_ip(), 1D ptr, assign list -- unit-ed values",
+    )
 
     test_so.obj.ip = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ip) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.iaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.iaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.iaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.iaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.iaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.iaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.iaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.iaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.iaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.iaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.iaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.iaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.iap) , "[NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iap),
+        "[NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.iap[0] = trick.alloc_type( 3 , "int")
-    test_so.obj.iap[1] = trick.alloc_type( 4 , "int")
-    test_so.obj.iap[2] = trick.alloc_type( 5 , "int")
-    test_so.obj.iap[3] = trick.alloc_type( 6 , "int")
-    TRICK_EXPECT_EQ( str(test_so.obj.iap[0]) , "[0, 0, 0]", test_suite , "2D array of ptr, single row access" )
+    test_so.obj.iap[0] = trick.alloc_type(3, "int")
+    test_so.obj.iap[1] = trick.alloc_type(4, "int")
+    test_so.obj.iap[2] = trick.alloc_type(5, "int")
+    test_so.obj.iap[3] = trick.alloc_type(6, "int")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.iap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.iap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.iap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.iap[3][1] = 75
     test_so.obj.iap[3][3] = trick.attach_units("--", int(test_so.obj.iap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.iap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.ipp = trick.alloc_type( 4 , "int *")
-    TRICK_EXPECT_EQ( str(test_so.obj.ipp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.ipp = trick.alloc_type(4, "int *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ipp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.ipp[0] = trick.alloc_type( 5 , "int")
-    TRICK_EXPECT_EQ( str(test_so.obj.ipp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.ipp[0] = trick.alloc_type(5, "int")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ipp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.ipp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.ipp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ipp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.ipp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ipp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.ipp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ipp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.ipp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ipp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ipp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.iaaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.iaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.iaaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.iaaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.iaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.iaaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.iaaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.iaaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.iaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.iaaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.iaaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.iaaa[1][0][2] = 99
-    TRICK_EXPECT_EQ( str(test_so.obj.iaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 99, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.iaaa[1][0][2] , 99 ,
-     test_suite , "3D fixed size array, single value assignment, no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 99, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.iaaa[1][0][2],
+        99,
+        test_suite,
+        "3D fixed size array, single value assignment, no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.ippp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ippp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ippp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.ippp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ippp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ippp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.ippp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ippp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.ippp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ippp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.ippp[1][0] = [700, 800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.ippp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    test_so.obj.ippp[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ippp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.ippp[1][0][2] = 99
-    TRICK_EXPECT_EQ( test_so.obj.ippp[1][0][2] , 99 ,
-     test_suite , "3D dynamic array, single value assignment, no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ippp[1][0][2],
+        99,
+        test_suite,
+        "3D dynamic array, single value assignment, no units, single value access",
+    )
 
     test_so.obj.ippp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ippp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ippp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "unsigned int"
 
     test_so.obj.ui = 95
-    TRICK_EXPECT_EQ( test_so.obj.ui , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "1873736978")
+    TRICK_EXPECT_EQ(test_so.obj.ui, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "1873736978")
 
     test_so.obj.ui += 1
-    TRICK_EXPECT_EQ( test_so.obj.ui , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ui, 96, test_suite, "increment")
 
     test_so.obj.ui = test_so.obj.ui + 1
-    TRICK_EXPECT_EQ( test_so.obj.ui , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ui, 97, test_suite, "increment")
 
     test_so.obj.ui = 1 + test_so.obj.ui
-    TRICK_EXPECT_EQ( test_so.obj.ui , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ui, 98, test_suite, "increment")
 
-    test_so.obj.uia = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.uia[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uia[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uia[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.uia = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.uia[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uia[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uia[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.uia = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.uia[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uia[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uia[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.uia = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.uia[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uia[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uia[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.uip = trick.alloc_type( 6 , "unsigned int")
-    TRICK_EXPECT_EQ( test_so.obj.uip[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.uip[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.uip) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.uip = trick.alloc_type(6, "unsigned int")
+    TRICK_EXPECT_EQ(test_so.obj.uip[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.uip[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uip), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.uip = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.uip) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.uip = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uip),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.uip[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.uip) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uip),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.uip = None
-    TRICK_EXPECT_EQ( str(test_so.obj.uip) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uip), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.uiaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.uiaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.uiaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.uiaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.uiaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.uiaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.uiaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.uiaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.uiap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.uiap[0] = trick.alloc_type( 3 , "unsigned int")
-    test_so.obj.uiap[1] = trick.alloc_type( 4 , "unsigned int")
-    test_so.obj.uiap[2] = trick.alloc_type( 5 , "unsigned int")
-    test_so.obj.uiap[3] = trick.alloc_type( 6 , "unsigned int")
+    test_so.obj.uiap[0] = trick.alloc_type(3, "unsigned int")
+    test_so.obj.uiap[1] = trick.alloc_type(4, "unsigned int")
+    test_so.obj.uiap[2] = trick.alloc_type(5, "unsigned int")
+    test_so.obj.uiap[3] = trick.alloc_type(6, "unsigned int")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.uiap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.uiap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.uiap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.uiap[3][1] = 75
     test_so.obj.uiap[3][3] = trick.attach_units("--", int(test_so.obj.uiap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.uiap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.uipp = trick.alloc_type( 4 , "unsigned int *")
-    TRICK_EXPECT_EQ( str(test_so.obj.uipp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.uipp = trick.alloc_type(4, "unsigned int *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uipp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.uipp[0] = trick.alloc_type( 5 , "unsigned int")
-    TRICK_EXPECT_EQ( str(test_so.obj.uipp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.uipp[0] = trick.alloc_type(5, "unsigned int")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uipp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.uipp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.uipp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uipp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.uipp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.uipp[1]) , "[91, 92, 93]", test_suite , "unsigned int 2D ptr of ptr, row assignment" )
+    test_so.obj.uipp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uipp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "unsigned int 2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.uipp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.uipp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uipp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.uiaaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.uiaaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.uiaaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.uiaaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.uiaaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.uiaaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.uiaaa[1][0][2] = 4000000000
-    TRICK_EXPECT_EQ( str(test_so.obj.uiaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 4000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large unsigned value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.uiaaa[1][0][2] , 4000000000 ,
-     test_suite , "3D fixed size array, single value assignment (large unsigned value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uiaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 4000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uiaaa[1][0][2],
+        4000000000,
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.uippp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.uippp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.uippp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.uippp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uippp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uippp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.uippp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.uippp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.uippp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uippp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.uippp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.uippp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uippp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.uippp[1][0][2] = 3500000000
-    TRICK_EXPECT_EQ( test_so.obj.uippp[1][0][2] , 3500000000 ,
-     test_suite , "3D dynamic array, single value assignment (large unsigned value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.uippp[1][0][2],
+        3500000000,
+        test_suite,
+        "3D dynamic array, single value assignment (large unsigned value), no units, single value access",
+    )
 
     test_so.obj.uippp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.uippp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.uippp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "long"
 
     test_so.obj.l = 95
-    TRICK_EXPECT_EQ( test_so.obj.l , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "3338288463")
+    TRICK_EXPECT_EQ(test_so.obj.l, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "3338288463")
 
     test_so.obj.l += 1
-    TRICK_EXPECT_EQ( test_so.obj.l , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.l, 96, test_suite, "increment")
 
     test_so.obj.l = test_so.obj.l + 1
-    TRICK_EXPECT_EQ( test_so.obj.l , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.l, 97, test_suite, "increment")
 
     test_so.obj.l = 1 + test_so.obj.l
-    TRICK_EXPECT_EQ( test_so.obj.l , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.l, 98, test_suite, "increment")
 
-    test_so.obj.la = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.la[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.la[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.la[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.la = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.la[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.la[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.la[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.la = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.la[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.la[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.la[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.la = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.la[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.la[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.la[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.lp = trick.alloc_type( 6 , "long")
-    TRICK_EXPECT_EQ( test_so.obj.lp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.lp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.lp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.lp = trick.alloc_type(6, "long")
+    TRICK_EXPECT_EQ(test_so.obj.lp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.lp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.lp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.lp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.lp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.lp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.lp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.lp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.lp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.laa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.laa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.laa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.laa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.laa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.laa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.laa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.laa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.laa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.laa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.laa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.laa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.lap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.lap[0] = trick.alloc_type( 3 , "long")
-    test_so.obj.lap[1] = trick.alloc_type( 4 , "long")
-    test_so.obj.lap[2] = trick.alloc_type( 5 , "long")
-    test_so.obj.lap[3] = trick.alloc_type( 6 , "long")
+    test_so.obj.lap[0] = trick.alloc_type(3, "long")
+    test_so.obj.lap[1] = trick.alloc_type(4, "long")
+    test_so.obj.lap[2] = trick.alloc_type(5, "long")
+    test_so.obj.lap[3] = trick.alloc_type(6, "long")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.lap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.lap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.lap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.lap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.lap[3][1] = 75
     test_so.obj.lap[3][3] = trick.attach_units("--", int(test_so.obj.lap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.lap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.lpp = trick.alloc_type( 4 , "long *")
-    TRICK_EXPECT_EQ( str(test_so.obj.lpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.lpp = trick.alloc_type(4, "long *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.lpp[0] = trick.alloc_type( 5 , "long")
-    TRICK_EXPECT_EQ( str(test_so.obj.lpp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.lpp[0] = trick.alloc_type(5, "long")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lpp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.lpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.lpp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lpp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.lpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.lpp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.lpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lpp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.lpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.lpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.laaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.laaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.laaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.laaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.laaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.laaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.laaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.laaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.laaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.laaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.laaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.laaa[1][0][2] = 9000000000
-    TRICK_EXPECT_EQ( str(test_so.obj.laaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 9000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large long value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.laaa[1][0][2] , 9000000000 ,
-     test_suite , "3D fixed size array, single value assignment (large long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.laaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 9000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large long value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.laaa[1][0][2],
+        9000000000,
+        test_suite,
+        "3D fixed size array, single value assignment (large long value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.lppp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.lppp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.lppp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.lppp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lppp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lppp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.lppp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.lppp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.lppp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lppp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.lppp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.lppp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lppp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.lppp[1][0][2] = -5000000000
-    TRICK_EXPECT_EQ( test_so.obj.lppp[1][0][2] , -5000000000 ,
-     test_suite , "3D dynamic array, single value assignment (large negative long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.lppp[1][0][2],
+        -5000000000,
+        test_suite,
+        "3D dynamic array, single value assignment (large negative long value), no units, single value access",
+    )
 
     test_so.obj.lppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.lppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.lppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "unsigned long"
 
     test_so.obj.ul = 95
-    TRICK_EXPECT_EQ( test_so.obj.ul , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "2844151852")
+    TRICK_EXPECT_EQ(test_so.obj.ul, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "2844151852")
 
     test_so.obj.ul += 1
-    TRICK_EXPECT_EQ( test_so.obj.ul , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ul, 96, test_suite, "increment")
 
     test_so.obj.ul = test_so.obj.ul + 1
-    TRICK_EXPECT_EQ( test_so.obj.ul , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ul, 97, test_suite, "increment")
 
     test_so.obj.ul = 1 + test_so.obj.ul
-    TRICK_EXPECT_EQ( test_so.obj.ul , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ul, 98, test_suite, "increment")
 
-    test_so.obj.ula = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.ula[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ula[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ula[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.ula = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ula[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ula[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ula[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.ula = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.ula[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ula[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ula[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.ula = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ula[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ula[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ula[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.ulp = trick.alloc_type( 6 , "unsigned long")
-    TRICK_EXPECT_EQ( test_so.obj.ulp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.ulp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ulp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.ulp = trick.alloc_type(6, "unsigned long")
+    TRICK_EXPECT_EQ(test_so.obj.ulp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.ulp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.ulp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.ulp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.ulp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.ulp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.ulp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ulp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.ulaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.ulaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.ulaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.ulaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.ulaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.ulaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.ulaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.ulaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ulap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.ulap[0] = trick.alloc_type( 3 , "unsigned long")
-    test_so.obj.ulap[1] = trick.alloc_type( 4 , "unsigned long")
-    test_so.obj.ulap[2] = trick.alloc_type( 5 , "unsigned long")
-    test_so.obj.ulap[3] = trick.alloc_type( 6 , "unsigned long")
+    test_so.obj.ulap[0] = trick.alloc_type(3, "unsigned long")
+    test_so.obj.ulap[1] = trick.alloc_type(4, "unsigned long")
+    test_so.obj.ulap[2] = trick.alloc_type(5, "unsigned long")
+    test_so.obj.ulap[3] = trick.alloc_type(6, "unsigned long")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ulap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.ulap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.ulap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.ulap[3][1] = 75
     test_so.obj.ulap[3][3] = trick.attach_units("--", int(test_so.obj.ulap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ulap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.ulpp = trick.alloc_type( 4 , "unsigned long *")
-    TRICK_EXPECT_EQ( str(test_so.obj.ulpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.ulpp = trick.alloc_type(4, "unsigned long *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.ulpp[0] = trick.alloc_type( 5 , "unsigned long")
-    TRICK_EXPECT_EQ( str(test_so.obj.ulpp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.ulpp[0] = trick.alloc_type(5, "unsigned long")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulpp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.ulpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.ulpp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulpp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.ulpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulpp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.ulpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulpp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.ulpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ulpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.ulaaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.ulaaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.ulaaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.ulaaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.ulaaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.ulaaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.ulaaa[1][0][2] = 15000000000
-    TRICK_EXPECT_EQ( str(test_so.obj.ulaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 15000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large unsigned long value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ulaaa[1][0][2] , 15000000000 ,
-     test_suite , "3D fixed size array, single value assignment (large unsigned long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 15000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned long value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulaaa[1][0][2],
+        15000000000,
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned long value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.ulppp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulppp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ulppp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.ulppp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulppp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulppp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.ulppp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulppp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.ulppp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulppp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.ulppp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.ulppp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulppp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.ulppp[1][0][2] = 12000000000
-    TRICK_EXPECT_EQ( test_so.obj.ulppp[1][0][2] , 12000000000 ,
-     test_suite , "3D dynamic array, single value assignment (large unsigned long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulppp[1][0][2],
+        12000000000,
+        test_suite,
+        "3D dynamic array, single value assignment (large unsigned long value), no units, single value access",
+    )
 
     test_so.obj.ulppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ulppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ulppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "long long"
 
     test_so.obj.ll = 95
-    TRICK_EXPECT_EQ( test_so.obj.ll , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "2165977787")
+    TRICK_EXPECT_EQ(test_so.obj.ll, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "2165977787")
 
     test_so.obj.ll += 1
-    TRICK_EXPECT_EQ( test_so.obj.ll , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ll, 96, test_suite, "increment")
 
     test_so.obj.ll = test_so.obj.ll + 1
-    TRICK_EXPECT_EQ( test_so.obj.ll , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ll, 97, test_suite, "increment")
 
     test_so.obj.ll = 1 + test_so.obj.ll
-    TRICK_EXPECT_EQ( test_so.obj.ll , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ll, 98, test_suite, "increment")
 
-    test_so.obj.lla = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.lla[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.lla[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.lla[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.lla = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.lla[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.lla[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.lla[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.lla = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.lla[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.lla[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.lla[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.lla = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.lla[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.lla[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.lla[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.llp = trick.alloc_type( 6 , "long long")
-    TRICK_EXPECT_EQ( test_so.obj.llp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.llp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.llp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.llp = trick.alloc_type(6, "long long")
+    TRICK_EXPECT_EQ(test_so.obj.llp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.llp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.llp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.llp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.llp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.llp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.llp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.llp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.llp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.llaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.llaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.llaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.llaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.llaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.llaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.llaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.llaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.llaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.llaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.llaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.llaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.llap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.llap[0] = trick.alloc_type( 3 , "long long")
-    test_so.obj.llap[1] = trick.alloc_type( 4 , "long long")
-    test_so.obj.llap[2] = trick.alloc_type( 5 , "long long")
-    test_so.obj.llap[3] = trick.alloc_type( 6 , "long long")
+    test_so.obj.llap[0] = trick.alloc_type(3, "long long")
+    test_so.obj.llap[1] = trick.alloc_type(4, "long long")
+    test_so.obj.llap[2] = trick.alloc_type(5, "long long")
+    test_so.obj.llap[3] = trick.alloc_type(6, "long long")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.llap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.llap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.llap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.llap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.llap[3][1] = 75
     test_so.obj.llap[3][3] = trick.attach_units("--", int(test_so.obj.llap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.llap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.llpp = trick.alloc_type( 4 , "long long *")
-    TRICK_EXPECT_EQ( str(test_so.obj.llpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.llpp = trick.alloc_type(4, "long long *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.llpp[0] = trick.alloc_type( 5 , "long long")
-    TRICK_EXPECT_EQ( str(test_so.obj.llpp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.llpp[0] = trick.alloc_type(5, "long long")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llpp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.llpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.llpp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llpp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.llpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.llpp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.llpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llpp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.llpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.llpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.llaaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.llaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.llaaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.llaaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.llaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.llaaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.llaaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.llaaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.llaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.llaaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.llaaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.llaaa[1][0][2] = 5000000000000000000
-    TRICK_EXPECT_EQ( str(test_so.obj.llaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 5000000000000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large long long value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.llaaa[1][0][2] , 5000000000000000000 ,
-     test_suite , "3D fixed size array, single value assignment (large long long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 5000000000000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large long long value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.llaaa[1][0][2],
+        5000000000000000000,
+        test_suite,
+        "3D fixed size array, single value assignment (large long long value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.llppp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.llppp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.llppp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.llppp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llppp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llppp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.llppp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.llppp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.llppp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llppp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.llppp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.llppp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llppp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.llppp[1][0][2] = -9223372036854775808
-    TRICK_EXPECT_EQ( test_so.obj.llppp[1][0][2] , -9223372036854775808 ,
-     test_suite , "3D dynamic array, single value assignment (min long long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.llppp[1][0][2],
+        -9223372036854775808,
+        test_suite,
+        "3D dynamic array, single value assignment (min long long value), no units, single value access",
+    )
 
     test_so.obj.llppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.llppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.llppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "unsigned long long"
 
     test_so.obj.ull = 95
-    TRICK_EXPECT_EQ( test_so.obj.ull , 95 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "3783821020")	
+    TRICK_EXPECT_EQ(test_so.obj.ull, 95, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "3783821020")
 
     test_so.obj.ull += 1
-    TRICK_EXPECT_EQ( test_so.obj.ull , 96 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ull, 96, test_suite, "increment")
 
     test_so.obj.ull = test_so.obj.ull + 1
-    TRICK_EXPECT_EQ( test_so.obj.ull , 97 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ull, 97, test_suite, "increment")
 
     test_so.obj.ull = 1 + test_so.obj.ull
-    TRICK_EXPECT_EQ( test_so.obj.ull , 98 , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.ull, 98, test_suite, "increment")
 
-    test_so.obj.ulla = [ 20 , 21 , 22 ]
-    TRICK_EXPECT_EQ( test_so.obj.ulla[0] , 20 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ulla[1] , 21 , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ulla[2] , 22 , test_suite , "1D array, integer value, no units" )
+    test_so.obj.ulla = [20, 21, 22]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulla[0], 20, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulla[1], 21, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulla[2], 22, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.ulla = [ 30.1 , 31.1 , 32.1 ]
-    TRICK_EXPECT_EQ( test_so.obj.ulla[0] , 30 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ulla[1] , 31 , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ulla[2] , 32 , test_suite , "1D array, float value, no units" )
+    test_so.obj.ulla = [30.1, 31.1, 32.1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulla[0], 30, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulla[1], 31, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ulla[2], 32, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.ullp = trick.alloc_type( 6 , "unsigned long long")
-    TRICK_EXPECT_EQ( test_so.obj.ullp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.ullp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ullp) , "[0, 0, 0, 0, 0, 0]", test_suite , "1D ptr, allocation" )
+    test_so.obj.ullp = trick.alloc_type(6, "unsigned long long")
+    TRICK_EXPECT_EQ(test_so.obj.ullp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.ullp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullp), "[0, 0, 0, 0, 0, 0]", test_suite, "1D ptr, allocation"
+    )
 
-    test_so.obj.ullp = [ 30 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullp) , "[30, 31, 32, 33]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.ullp = [30, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullp),
+        "[30, 31, 32, 33]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.ullp[2] = 62
-    TRICK_EXPECT_EQ( str(test_so.obj.ullp) , "[30, 31, 62, 33]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullp),
+        "[30, 31, 62, 33]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.ullp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ullp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.ullaa = [[ 40 , 41 , 42] , [43, 44, 45]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaa) , "[[40, 41, 42],[43, 44, 45]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.ullaa = [[40, 41, 42], [43, 44, 45]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaa),
+        "[[40, 41, 42],[43, 44, 45]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.ullaa[1] = [ 50 , 51 , 52]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.ullaa[1] = [50, 51, 52]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.ullaa[1] = [ 50.1 , 51.2 , 52.3 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaa) , "[[40, 41, 42],[50, 51, 52]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.ullaa[1] = [50.1, 51.2, 52.3]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaa),
+        "[[40, 41, 42],[50, 51, 52]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
-    test_so.obj.ullaa[1][1] =  60
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaa) , "[[40, 41, 42],[50, 60, 52]]",
-     test_suite , "2D array, single assign, no units" )
+    test_so.obj.ullaa[1][1] = 60
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaa),
+        "[[40, 41, 42],[50, 60, 52]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ullap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.ullap[0] = trick.alloc_type( 3 , "unsigned long long")
-    test_so.obj.ullap[1] = trick.alloc_type( 4 , "unsigned long long")
-    test_so.obj.ullap[2] = trick.alloc_type( 5 , "unsigned long long")
-    test_so.obj.ullap[3] = trick.alloc_type( 6 , "unsigned long long")
+    test_so.obj.ullap[0] = trick.alloc_type(3, "unsigned long long")
+    test_so.obj.ullap[1] = trick.alloc_type(4, "unsigned long long")
+    test_so.obj.ullap[2] = trick.alloc_type(5, "unsigned long long")
+    test_so.obj.ullap[3] = trick.alloc_type(6, "unsigned long long")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ullap[0]) , "[0, 0, 0]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullap[0]),
+        "[0, 0, 0]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.ullap[3] = [ 60 , 61 , 62, 63 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullap[3]) , "[60, 61, 62, 63]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.ullap[3] = [60, 61, 62, 63]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullap[3]),
+        "[60, 61, 62, 63]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.ullap[3][1] = 75
     test_so.obj.ullap[3][3] = trick.attach_units("--", int(test_so.obj.ullap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.ullap[3]) , "[60, 75, 62, 64]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullap[3]),
+        "[60, 75, 62, 64]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.ullpp = trick.alloc_type( 4 , "unsigned long long *")
-    TRICK_EXPECT_EQ( str(test_so.obj.ullpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.ullpp = trick.alloc_type(4, "unsigned long long *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.ullpp[0] = trick.alloc_type( 5 , "unsigned long long")
-    TRICK_EXPECT_EQ( str(test_so.obj.ullpp[0]) , "[0, 0, 0, 0, 0]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.ullpp[0] = trick.alloc_type(5, "unsigned long long")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullpp[0]),
+        "[0, 0, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.ullpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.ullpp[0]) , "[0, 85, 0, 0, 0]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullpp[0]),
+        "[0, 85, 0, 0, 0]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.ullpp[1] = [ 91 , 92 , 93 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullpp[1]) , "[91, 92, 93]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.ullpp[1] = [91, 92, 93]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullpp[1]),
+        "[91, 92, 93]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.ullpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ullpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.ullaaa = [[[1,2,3,4],[5,6,7,8],[9,10,11,12]],[[13,14,15,16],[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.ullaaa = [
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+        [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[13, 14, 15, 16],[17, 18, 19, 20],[21, 22, 23, 24]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.ullaaa[1] = [[70,80,90,100],[110,120,130,140],[130,140,150,160]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaaa[1]) , "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.ullaaa[1] = [
+        [70, 80, 90, 100],
+        [110, 120, 130, 140],
+        [130, 140, 150, 160],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaaa[1]),
+        "[[70, 80, 90, 100],[110, 120, 130, 140],[130, 140, 150, 160]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.ullaaa[1][0] = [700,800,900,1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaaa[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.ullaaa[1][0] = [700, 800, 900, 1000]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 900, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaaa[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.ullaaa[1][0][2] = 50000000000
-    TRICK_EXPECT_EQ( str(test_so.obj.ullaaa) , "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 50000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
-     test_suite , "3D fixed size array, single value assignment (large unsigned long long value), no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ullaaa[1][0][2] , 50000000000,
-     test_suite , "3D fixed size array, single value assignment (large unsigned long long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullaaa),
+        "[[[1, 2, 3, 4],[5, 6, 7, 8],[9, 10, 11, 12]],[[700, 800, 50000000000, 1000],[110, 120, 130, 140],[130, 140, 150, 160]]]",
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned long long value), no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ullaaa[1][0][2],
+        50000000000,
+        test_suite,
+        "3D fixed size array, single value assignment (large unsigned long long value), no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.ullppp = [[[1, 2, 3, 4],[5, 6, 7, 8]],[[9, 10, 11, 12],[13, 14, 15,16]],[[17,18,19,20],[21,22,23,24]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullppp) , "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ullppp[0]) , "[[1, 2, 3, 4], [5, 6, 7, 8]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.ullppp = [
+        [[1, 2, 3, 4], [5, 6, 7, 8]],
+        [[9, 10, 11, 12], [13, 14, 15, 16]],
+        [[17, 18, 19, 20], [21, 22, 23, 24]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullppp),
+        "[[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]], [[17, 18, 19, 20], [21, 22, 23, 24]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullppp[0]),
+        "[[1, 2, 3, 4], [5, 6, 7, 8]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.ullppp[1] = [[70, 80, 90, 100],[110, 120, 130, 140]]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullppp[1]) , "[[70, 80, 90, 100], [110, 120, 130, 140]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.ullppp[1] = [[70, 80, 90, 100], [110, 120, 130, 140]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullppp[1]),
+        "[[70, 80, 90, 100], [110, 120, 130, 140]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.ullppp[1][0] = [700, 800, 900, 1000]
-    TRICK_EXPECT_EQ( str(test_so.obj.ullppp[1][0]) , "[700, 800, 900, 1000]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullppp[1][0]),
+        "[700, 800, 900, 1000]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.ullppp[1][0][2] = 15000000000
-    TRICK_EXPECT_EQ( test_so.obj.ullppp[1][0][2] , 15000000000 ,
-     test_suite , "3D dynamic array, single value assignment (large unsigned long long value), no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ullppp[1][0][2],
+        15000000000,
+        test_suite,
+        "3D dynamic array, single value assignment (large unsigned long long value), no units, single value access",
+    )
 
     test_so.obj.ullppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.ullppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ullppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "bool"
 
     test_so.obj.b = True
-    TRICK_EXPECT_EQ( test_so.obj.b , True , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "4134211307")
+    TRICK_EXPECT_EQ(test_so.obj.b, True, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "4134211307")
 
     test_so.obj.b += 1
-    TRICK_EXPECT_EQ( test_so.obj.b , True , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.b, True, test_suite, "increment")
 
     test_so.obj.b = test_so.obj.b + 1
-    TRICK_EXPECT_EQ( test_so.obj.b , True , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.b, True, test_suite, "increment")
 
     test_so.obj.ull = 1 + test_so.obj.ull
-    TRICK_EXPECT_EQ( test_so.obj.b , True , test_suite , "increment" )
+    TRICK_EXPECT_EQ(test_so.obj.b, True, test_suite, "increment")
 
-    test_so.obj.ba = [ False , True , True ]
-    TRICK_EXPECT_EQ( test_so.obj.ba[0] , False , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ba[1] , True , test_suite , "1D array, integer value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ba[2] , True , test_suite , "1D array, integer value, no units" )
+    test_so.obj.ba = [False, True, True]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ba[0], False, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ba[1], True, test_suite, "1D array, integer value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ba[2], True, test_suite, "1D array, integer value, no units"
+    )
 
-    test_so.obj.ba = [ 2.2 , 1.1 , 0 ]
-    TRICK_EXPECT_EQ( test_so.obj.ba[0] , True , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ba[1] , True , test_suite , "1D array, float value, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.ba[2] , False , test_suite , "1D array, float value, no units" )
+    test_so.obj.ba = [2.2, 1.1, 0]
+    TRICK_EXPECT_EQ(
+        test_so.obj.ba[0], True, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ba[1], True, test_suite, "1D array, float value, no units"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ba[2], False, test_suite, "1D array, float value, no units"
+    )
 
-    test_so.obj.bp = trick.alloc_type( 6 , "bool" )
-    TRICK_EXPECT_EQ( test_so.obj.bp[0] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( test_so.obj.bp[5] , 0 ,  test_suite , "1D ptr, allocation" )
-    TRICK_EXPECT_EQ( str(test_so.obj.bp) , "[False, False, False, False, False, False]", test_suite , "1D ptr, allocation" )
+    test_so.obj.bp = trick.alloc_type(6, "bool")
+    TRICK_EXPECT_EQ(test_so.obj.bp[0], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(test_so.obj.bp[5], 0, test_suite, "1D ptr, allocation")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bp),
+        "[False, False, False, False, False, False]",
+        test_suite,
+        "1D ptr, allocation",
+    )
 
-    test_so.obj.bp = [ 0 , 31 , 32 , 33 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.bp) , "[False, True, True, True]", test_suite , "1D ptr, list assign, no units" )
+    test_so.obj.bp = [0, 31, 32, 33]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bp),
+        "[False, True, True, True]",
+        test_suite,
+        "1D ptr, list assign, no units",
+    )
 
     test_so.obj.bp[2] = 0
-    TRICK_EXPECT_EQ( str(test_so.obj.bp) , "[False, True, False, True]", test_suite , "1D ptr, partial assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bp),
+        "[False, True, False, True]",
+        test_suite,
+        "1D ptr, partial assign, no units",
+    )
 
     test_so.obj.bp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.bp) , "NULL", test_suite , "1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bp), "NULL", test_suite, "1D ptr None (NULL) assignment"
+    )
 
-    test_so.obj.baa = [[ 0 , 1 , 2] , [3, 4, 0]]
-    TRICK_EXPECT_EQ( str(test_so.obj.baa) , "[[False, True, True],[True, True, False]]",
-     test_suite , "2D array, full assign, no units" )
+    test_so.obj.baa = [[0, 1, 2], [3, 4, 0]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baa),
+        "[[False, True, True],[True, True, False]]",
+        test_suite,
+        "2D array, full assign, no units",
+    )
 
-    test_so.obj.baa[1] = [ False , False , True]
-    TRICK_EXPECT_EQ( str(test_so.obj.baa) , "[[False, True, True],[False, False, True]]",
-     test_suite , "2D array, partial assign, no units" )
+    test_so.obj.baa[1] = [False, False, True]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baa),
+        "[[False, True, True],[False, False, True]]",
+        test_suite,
+        "2D array, partial assign, no units",
+    )
 
     test_so.obj.baa[1][1] = True
-    TRICK_EXPECT_EQ( str(test_so.obj.baa) , "[[False, True, True],[False, True, True]]",
-     test_suite , "2D array, single assign, no units" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baa),
+        "[[False, True, True],[False, True, True]]",
+        test_suite,
+        "2D array, single assign, no units",
+    )
 
-    TRICK_EXPECT_EQ( str(test_so.obj.bap) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D array of ptr, initial value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bap),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D array of ptr, initial value",
+    )
 
-    test_so.obj.bap[0] = trick.alloc_type( 3 , "bool")
-    test_so.obj.bap[1] = trick.alloc_type( 4 , "bool")
-    test_so.obj.bap[2] = trick.alloc_type( 5 , "bool")
-    test_so.obj.bap[3] = trick.alloc_type( 6 , "bool")
+    test_so.obj.bap[0] = trick.alloc_type(3, "bool")
+    test_so.obj.bap[1] = trick.alloc_type(4, "bool")
+    test_so.obj.bap[2] = trick.alloc_type(5, "bool")
+    test_so.obj.bap[3] = trick.alloc_type(6, "bool")
 
-    TRICK_EXPECT_EQ( str(test_so.obj.bap[0]) , "[False, False, False]",
-     test_suite , "2D array of ptr, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bap[0]),
+        "[False, False, False]",
+        test_suite,
+        "2D array of ptr, single row access",
+    )
 
-    test_so.obj.bap[3] = [ True , False , True, False ]
-    TRICK_EXPECT_EQ( str(test_so.obj.bap[3]) , "[True, False, True, False]",
-     test_suite , "2D array of ptr, single row realloc and assignment" )
+    test_so.obj.bap[3] = [True, False, True, False]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bap[3]),
+        "[True, False, True, False]",
+        test_suite,
+        "2D array of ptr, single row realloc and assignment",
+    )
 
     test_so.obj.bap[3][1] = 75
     test_so.obj.bap[3][3] = trick.attach_units("--", int(test_so.obj.bap[3][3]) + 1)
 
-    TRICK_EXPECT_EQ( str(test_so.obj.bap[3]) , "[True, True, True, True]",
-     test_suite , "2D array of ptr, single item assignment with unit conversion" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bap[3]),
+        "[True, True, True, True]",
+        test_suite,
+        "2D array of ptr, single item assignment with unit conversion",
+    )
 
-    test_so.obj.bpp = trick.alloc_type( 4 , "bool *")
-    TRICK_EXPECT_EQ( str(test_so.obj.bpp) , "[NULL, NULL, NULL, NULL]",
-     test_suite , "2D ptr of ptr, initial value" )
+    test_so.obj.bpp = trick.alloc_type(4, "bool *")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bpp),
+        "[NULL, NULL, NULL, NULL]",
+        test_suite,
+        "2D ptr of ptr, initial value",
+    )
 
-    test_so.obj.bpp[0] = trick.alloc_type( 5 , "bool")
-    TRICK_EXPECT_EQ( str(test_so.obj.bpp[0]) , "[False, False, False, False, False]", test_suite , "2D ptr of ptr, allocate 1 row" )
+    test_so.obj.bpp[0] = trick.alloc_type(5, "bool")
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bpp[0]),
+        "[False, False, False, False, False]",
+        test_suite,
+        "2D ptr of ptr, allocate 1 row",
+    )
 
     test_so.obj.bpp[0][1] = 85
-    TRICK_EXPECT_EQ( str(test_so.obj.bpp[0]) , "[False, True, False, False, False]", test_suite , "2D ptr of ptr, assign 1 value" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bpp[0]),
+        "[False, True, False, False, False]",
+        test_suite,
+        "2D ptr of ptr, assign 1 value",
+    )
 
-    test_so.obj.bpp[1] = [ True , False , True ]
-    TRICK_EXPECT_EQ( str(test_so.obj.bpp[1]) , "[True, False, True]", test_suite , "2D ptr of ptr, row assignment" )
+    test_so.obj.bpp[1] = [True, False, True]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bpp[1]),
+        "[True, False, True]",
+        test_suite,
+        "2D ptr of ptr, row assignment",
+    )
 
     test_so.obj.bpp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.bpp) , "NULL", test_suite , "2D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bpp), "NULL", test_suite, "2D ptr None (NULL) assignment"
+    )
 
     # 3D fixed size array tests
-    test_so.obj.baaa = [[[True,False,True,False],[False,True,False,True],[True,True,False,False]],[[False,False,True,True],[True,False,True,False],[False,True,False,True]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.baaa) , "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[False, False, True, True],[True, False, True, False],[False, True, False, True]]]",
-     test_suite , "3D fixed size array, full assignment, no units" )
+    test_so.obj.baaa = [
+        [
+            [True, False, True, False],
+            [False, True, False, True],
+            [True, True, False, False],
+        ],
+        [
+            [False, False, True, True],
+            [True, False, True, False],
+            [False, True, False, True],
+        ],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baaa),
+        "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[False, False, True, True],[True, False, True, False],[False, True, False, True]]]",
+        test_suite,
+        "3D fixed size array, full assignment, no units",
+    )
 
-    test_so.obj.baaa[1] = [[True,True,True,True],[False,False,False,False],[True,False,True,False]]
-    TRICK_EXPECT_EQ( str(test_so.obj.baaa) , "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[True, True, True, True],[False, False, False, False],[True, False, True, False]]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.baaa[1]) , "[[True, True, True, True],[False, False, False, False],[True, False, True, False]]",
-     test_suite , "3D fixed size array, slice assignment (2D), no units, single row access" )
+    test_so.obj.baaa[1] = [
+        [True, True, True, True],
+        [False, False, False, False],
+        [True, False, True, False],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baaa),
+        "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[True, True, True, True],[False, False, False, False],[True, False, True, False]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baaa[1]),
+        "[[True, True, True, True],[False, False, False, False],[True, False, True, False]]",
+        test_suite,
+        "3D fixed size array, slice assignment (2D), no units, single row access",
+    )
 
-    test_so.obj.baaa[1][0] = [False,True,False,True]
-    TRICK_EXPECT_EQ( str(test_so.obj.baaa) , "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[False, True, False, True],[False, False, False, False],[True, False, True, False]]]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.baaa[1][0]) , "[False, True, False, True]",
-     test_suite , "3D fixed size array, slice assignment (1D), no units, single row access" )
+    test_so.obj.baaa[1][0] = [False, True, False, True]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baaa),
+        "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[False, True, False, True],[False, False, False, False],[True, False, True, False]]]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baaa[1][0]),
+        "[False, True, False, True]",
+        test_suite,
+        "3D fixed size array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.baaa[1][0][2] = True
-    TRICK_EXPECT_EQ( str(test_so.obj.baaa) , "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[False, True, True, True],[False, False, False, False],[True, False, True, False]]]",
-     test_suite , "3D fixed size array, single value assignment, no units" )
-    TRICK_EXPECT_EQ( test_so.obj.baaa[1][0][2] , True ,
-     test_suite , "3D fixed size array, single value assignment, no units, single value access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.baaa),
+        "[[[True, False, True, False],[False, True, False, True],[True, True, False, False]],[[False, True, True, True],[False, False, False, False],[True, False, True, False]]]",
+        test_suite,
+        "3D fixed size array, single value assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.baaa[1][0][2],
+        True,
+        test_suite,
+        "3D fixed size array, single value assignment, no units, single value access",
+    )
 
     # 3D dynamic array tests
-    test_so.obj.bppp = [[[True, False, True, False],[False, True, False, True]],[[True, True, False, False],[False, False, True, True]],[[True,False,True,False],[False,True,False,True]]]
-    TRICK_EXPECT_EQ( str(test_so.obj.bppp) , "[[[True, False, True, False], [False, True, False, True]], [[True, True, False, False], [False, False, True, True]], [[True, False, True, False], [False, True, False, True]]]",
-     test_suite , "3D dynamic array, full assignment, no units" )
-    TRICK_EXPECT_EQ( str(test_so.obj.bppp[0]) , "[[True, False, True, False], [False, True, False, True]]",
-     test_suite , "3D dynamic array, full assignment, no units, single row access" )
+    test_so.obj.bppp = [
+        [[True, False, True, False], [False, True, False, True]],
+        [[True, True, False, False], [False, False, True, True]],
+        [[True, False, True, False], [False, True, False, True]],
+    ]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bppp),
+        "[[[True, False, True, False], [False, True, False, True]], [[True, True, False, False], [False, False, True, True]], [[True, False, True, False], [False, True, False, True]]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bppp[0]),
+        "[[True, False, True, False], [False, True, False, True]]",
+        test_suite,
+        "3D dynamic array, full assignment, no units, single row access",
+    )
 
-    test_so.obj.bppp[1] = [[True, True, True, True],[False, False, False, False]]
-    TRICK_EXPECT_EQ( str(test_so.obj.bppp[1]) , "[[True, True, True, True], [False, False, False, False]]",
-     test_suite , "3D dynamic array, slice assignment (2D), no units, single row access" )
+    test_so.obj.bppp[1] = [[True, True, True, True], [False, False, False, False]]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bppp[1]),
+        "[[True, True, True, True], [False, False, False, False]]",
+        test_suite,
+        "3D dynamic array, slice assignment (2D), no units, single row access",
+    )
 
     test_so.obj.bppp[1][0] = [False, True, False, True]
-    TRICK_EXPECT_EQ( str(test_so.obj.bppp[1][0]) , "[False, True, False, True]",
-     test_suite , "3D dynamic array, slice assignment (1D), no units, single row access" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bppp[1][0]),
+        "[False, True, False, True]",
+        test_suite,
+        "3D dynamic array, slice assignment (1D), no units, single row access",
+    )
 
     test_so.obj.bppp[1][0][2] = True
-    TRICK_EXPECT_EQ( test_so.obj.bppp[1][0][2] , True ,
-     test_suite , "3D dynamic array, single value assignment, no units, single value access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.bppp[1][0][2],
+        True,
+        test_suite,
+        "3D dynamic array, single value assignment, no units, single value access",
+    )
 
     test_so.obj.bppp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.bppp) , "NULL", test_suite , "3D dynamic array None (NULL) assignment" )
-######################################################################################################################
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.bppp),
+        "NULL",
+        test_suite,
+        "3D dynamic array None (NULL) assignment",
+    )
+    ######################################################################################################################
 
     test_suite = "structure"
 
@@ -1981,538 +4255,674 @@ def main():
     test_so.obj.cana[0].jj = 350
     test_so.obj.cana[1].ii = 260
     test_so.obj.cana[1].jj = 360
-    TRICK_EXPECT_EQ( test_so.obj.cana[0].ii , 250 , test_suite , "1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.cana[0].jj , 350 , test_suite , "1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.cana[1].ii , 260 , test_suite , "1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.cana[1].jj , 360 , test_suite , "1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.get_cana_flat()[0].ii , 250 , test_suite , "get_cana_flat(), 1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.get_cana_flat()[0].jj , 350 , test_suite , "get_cana_flat(), 1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.get_cana_flat()[1].ii , 260 , test_suite , "get_cana_flat(), 1D array access" )
-    TRICK_EXPECT_EQ( test_so.obj.get_cana_flat()[1].jj , 360 , test_suite , "get_cana_flat(), 1D array access" )
+    TRICK_EXPECT_EQ(test_so.obj.cana[0].ii, 250, test_suite, "1D array access")
+    TRICK_EXPECT_EQ(test_so.obj.cana[0].jj, 350, test_suite, "1D array access")
+    TRICK_EXPECT_EQ(test_so.obj.cana[1].ii, 260, test_suite, "1D array access")
+    TRICK_EXPECT_EQ(test_so.obj.cana[1].jj, 360, test_suite, "1D array access")
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_cana_flat()[0].ii,
+        250,
+        test_suite,
+        "get_cana_flat(), 1D array access",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_cana_flat()[0].jj,
+        350,
+        test_suite,
+        "get_cana_flat(), 1D array access",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_cana_flat()[1].ii,
+        260,
+        test_suite,
+        "get_cana_flat(), 1D array access",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_cana_flat()[1].jj,
+        360,
+        test_suite,
+        "get_cana_flat(), 1D array access",
+    )
     if useArrayGetters:
-        TRICK_EXPECT_EQ( test_so.obj.get_cana()[0].ii , 250 , test_suite , "get_cana(), 1D array access" )
-        TRICK_EXPECT_EQ( test_so.obj.get_cana()[0].jj , 350 , test_suite , "get_cana(), 1D array access" )
-        TRICK_EXPECT_EQ( test_so.obj.get_cana()[1].ii , 260 , test_suite , "get_cana(), 1D array access" )
-        TRICK_EXPECT_EQ( test_so.obj.get_cana()[1].jj , 360 , test_suite , "get_cana(), 1D array access" )
-    trick.trick_test_add_parent( test_suite , "1D array access" , "2797105872")
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_cana()[0].ii, 250, test_suite, "get_cana(), 1D array access"
+        )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_cana()[0].jj, 350, test_suite, "get_cana(), 1D array access"
+        )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_cana()[1].ii, 260, test_suite, "get_cana(), 1D array access"
+        )
+        TRICK_EXPECT_EQ(
+            test_so.obj.get_cana()[1].jj, 360, test_suite, "get_cana(), 1D array access"
+        )
+    trick.trick_test_add_parent(test_suite, "1D array access", "2797105872")
 
     test_so.obj.can.ii = 150
     test_so.obj.can.jj = 160
     test_so.obj.can2 = test_so.obj.can
-    TRICK_EXPECT_EQ( test_so.obj.can2.ii , 150 , test_suite , "copy" )
-    TRICK_EXPECT_EQ( test_so.obj.can2.jj , 160 , test_suite , "copy" )
-    TRICK_EXPECT_EQ( test_so.obj.get_can2().ii , 150 , test_suite , "get_can2(), copy" )
-    TRICK_EXPECT_EQ( test_so.obj.get_can2().jj , 160 , test_suite , "get_can2(), copy" )
+    TRICK_EXPECT_EQ(test_so.obj.can2.ii, 150, test_suite, "copy")
+    TRICK_EXPECT_EQ(test_so.obj.can2.jj, 160, test_suite, "copy")
+    TRICK_EXPECT_EQ(test_so.obj.get_can2().ii, 150, test_suite, "get_can2(), copy")
+    TRICK_EXPECT_EQ(test_so.obj.get_can2().jj, 160, test_suite, "get_can2(), copy")
 
-    #test_so.obj.cana[3] = test_so.obj.can
+    # test_so.obj.cana[3] = test_so.obj.can
 
     test_so.obj.canp = test_so.obj.can
-    TRICK_EXPECT_EQ( test_so.obj.canp.ii , 150 , test_suite , "pointer assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.canp.jj , 160 , test_suite , "pointer assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp().ii , 150 , test_suite , "get_canp(), pointer assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp().jj , 160 , test_suite , "get_canp(), pointer assignment" )
+    TRICK_EXPECT_EQ(test_so.obj.canp.ii, 150, test_suite, "pointer assignment")
+    TRICK_EXPECT_EQ(test_so.obj.canp.jj, 160, test_suite, "pointer assignment")
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp().ii, 150, test_suite, "get_canp(), pointer assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp().jj, 160, test_suite, "get_canp(), pointer assignment"
+    )
 
     test_so.obj.canp = test_so.obj.cana[1]
-    TRICK_EXPECT_EQ( test_so.obj.canp.ii , 260 , test_suite , "pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.canp.jj , 360 , test_suite , "pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp().ii , 260 , test_suite , "get_canp(), pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp().jj , 360 , test_suite , "get_canp(), pointer to array element assignment" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.canp.ii, 260, test_suite, "pointer to array element assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.canp.jj, 360, test_suite, "pointer to array element assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp().ii,
+        260,
+        test_suite,
+        "get_canp(), pointer to array element assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp().jj,
+        360,
+        test_suite,
+        "get_canp(), pointer to array element assignment",
+    )
 
-    test_so.obj.canp = trick.alloc_type( 2 , "CanCopy" )
+    test_so.obj.canp = trick.alloc_type(2, "CanCopy")
     test_so.obj.canp[0].ii = 400
     test_so.obj.canp[0].jj = 500
     test_so.obj.canp[1].ii = 600
     test_so.obj.canp[1].jj = 700
-    TRICK_EXPECT_EQ( test_so.obj.canp[0].ii , 400 , test_suite , "pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.canp[0].jj , 500 , test_suite , "pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.canp[1].ii , 600 , test_suite , "pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.canp[1].jj , 700 , test_suite , "pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp()[0].ii , 400 , test_suite , "get_canp(), pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp()[0].jj , 500 , test_suite , "get_canp(), pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp()[1].ii , 600 , test_suite , "get_canp(), pointer to array element assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.get_canp()[1].jj , 700 , test_suite , "get_canp(), pointer to array element assignment" )
-    #print test_so.obj.canp[0]
-    #print test_so.obj.canp[1]
+    TRICK_EXPECT_EQ(
+        test_so.obj.canp[0].ii, 400, test_suite, "pointer to array element assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.canp[0].jj, 500, test_suite, "pointer to array element assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.canp[1].ii, 600, test_suite, "pointer to array element assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.canp[1].jj, 700, test_suite, "pointer to array element assignment"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp()[0].ii,
+        400,
+        test_suite,
+        "get_canp(), pointer to array element assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp()[0].jj,
+        500,
+        test_suite,
+        "get_canp(), pointer to array element assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp()[1].ii,
+        600,
+        test_suite,
+        "get_canp(), pointer to array element assignment",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.get_canp()[1].jj,
+        700,
+        test_suite,
+        "get_canp(), pointer to array element assignment",
+    )
+    # print test_so.obj.canp[0]
+    # print test_so.obj.canp[1]
 
     test_so.obj.canp = None
-    TRICK_EXPECT_EQ( str(test_so.obj.canp) , "None", test_suite , "1D ptr None (NULL) assignment" )
-    TRICK_EXPECT_EQ( str(test_so.obj.get_canp()) , "None", test_suite , "get_canp(), 1D ptr None (NULL) assignment" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.canp), "None", test_suite, "1D ptr None (NULL) assignment"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.get_canp()),
+        "None",
+        test_suite,
+        "get_canp(), 1D ptr None (NULL) assignment",
+    )
 
     # silently ignored! need to figure out how to flag this
-    #test_so.obj.cannot = test_so.obj.cannot2
+    # test_so.obj.cannot = test_so.obj.cannot2
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "string"
 
     test_so.obj.str = "hello"
-    TRICK_EXPECT_EQ( test_so.obj.str , "hello" , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "165635378")
+    TRICK_EXPECT_EQ(test_so.obj.str, "hello", test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "165635378")
 
-    #TODO: make a std::string typemap to allow assignment of string from char *
-    #test_so.obj.str = test_so.obj.cap[1]
-    #TRICK_EXPECT_EQ( test_so.obj.str , "cap1" , "IPtest" , "string assignment from char *" )
-    #print "test_so.obj.str = " , test_so.obj.str
+    # TODO: make a std::string typemap to allow assignment of string from char *
+    # test_so.obj.str = test_so.obj.cap[1]
+    # TRICK_EXPECT_EQ( test_so.obj.str , "cap1" , "IPtest" , "string assignment from char *" )
+    # print "test_so.obj.str = " , test_so.obj.str
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "bitfield"
 
     test_so.obj.bit_0 = 7
-    TRICK_EXPECT_EQ( test_so.obj.bit_0 , 7 , test_suite , "assignment" )
-    trick.trick_test_add_parent( test_suite , "assignment" , "1649805110")
+    TRICK_EXPECT_EQ(test_so.obj.bit_0, 7, test_suite, "assignment")
+    trick.trick_test_add_parent(test_suite, "assignment", "1649805110")
 
     test_so.obj.bit_1 = 17
-    TRICK_EXPECT_EQ( test_so.obj.bit_1 , -15 , test_suite , "assignment with overflow" )
+    TRICK_EXPECT_EQ(test_so.obj.bit_1, -15, test_suite, "assignment with overflow")
 
     test_so.obj.boolbit_0 = True
-    TRICK_EXPECT_EQ( test_so.obj.boolbit_0 , True , test_suite , "bool assignment" )
+    TRICK_EXPECT_EQ(test_so.obj.boolbit_0, True, test_suite, "bool assignment")
 
     test_so.obj.boolbit_1 = 2
-    TRICK_EXPECT_EQ( test_so.obj.boolbit_1 , True , test_suite , "bool assignment with overflow" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.boolbit_1, True, test_suite, "bool assignment with overflow"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "union"
 
     test_so.obj.ut.i = 20
-    TRICK_EXPECT_EQ( str(test_so.obj.ut.i) , "20", test_suite , "test 1" )
-    trick.trick_test_add_parent( test_suite , "test 1" , "3095148896")
+    TRICK_EXPECT_EQ(str(test_so.obj.ut.i), "20", test_suite, "test 1")
+    trick.trick_test_add_parent(test_suite, "test 1", "3095148896")
 
     test_so.obj.ut2.i = 30
-    TRICK_EXPECT_EQ( str(test_so.obj.ut2.i) , "30", test_suite , "test 2" )
-    trick.trick_test_add_parent( test_suite , "test 2" , "3095148896")
+    TRICK_EXPECT_EQ(str(test_so.obj.ut2.i), "30", test_suite, "test 2")
+    trick.trick_test_add_parent(test_suite, "test 2", "3095148896")
 
-######################################################################################################################
+    ######################################################################################################################
 
     # swig_int from swig_double
     test_suite = "swig_int"
 
     test_so.obj.dlbm = 50
     test_so.obj.ilbm = test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test_so.obj.ilbm , 50, test_suite , "assignment from swig_double" )
-    trick.trick_test_add_parent( test_suite , "assignment from swig_double" , "2901141151")
+    TRICK_EXPECT_EQ(test_so.obj.ilbm, 50, test_suite, "assignment from swig_double")
+    trick.trick_test_add_parent(test_suite, "assignment from swig_double", "2901141151")
 
     # addition
 
     test_so.obj.ilbm = 50
     test_so.obj.ikg = test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 22, test_suite , "units conversion" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 22, test_suite, "units conversion")
 
     test_so.obj.ikg = test_so.obj.ilbm + 20
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "addition with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "addition with integer")
 
     test_so.obj.ikg = test_so.obj.ilbm + 20.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 32, test_suite , "addition with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 32, test_suite, "addition with float")
 
     test_so.obj.ikg = test_so.obj.ilbm + test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 45, test_suite , "addition with swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 45, test_suite, "addition with swig_int")
 
     test_so.obj.ikg = 50
     test_so.obj.ikg = test_so.obj.ilbm + test_so.obj.ikg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 72, test_suite , "addition with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 72, test_suite, "addition with swig_int and unit conversion"
+    )
 
     test_so.obj.dlbm = 10
     test_so.obj.ikg = test_so.obj.ilbm + test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 27, test_suite , "addition with swig_double" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 27, test_suite, "addition with swig_double")
 
     test_so.obj.dkg = 10
     test_so.obj.ikg = test_so.obj.ilbm + test_so.obj.dkg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 32, test_suite , "addition with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 32, test_suite, "addition with swig_double and unit conversion"
+    )
 
     # subtraction
 
     test_so.obj.ikg = test_so.obj.ilbm - 20
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 13, test_suite , "subtraction with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 13, test_suite, "subtraction with integer")
 
     test_so.obj.ikg = test_so.obj.ilbm - 20.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 13, test_suite , "subtraction with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 13, test_suite, "subtraction with float")
 
     test_so.obj.ikg = test_so.obj.ilbm - test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 0, test_suite , "subtraction with swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 0, test_suite, "subtraction with swig_int")
 
     test_so.obj.ikg = 10
     test_so.obj.ikg = test_so.obj.ilbm - test_so.obj.ikg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 12, test_suite , "subtraction with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 12, test_suite, "subtraction with swig_int and unit conversion"
+    )
 
     test_so.obj.dlbm = 10
     test_so.obj.ikg = test_so.obj.ilbm - test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 18, test_suite , "subtraction with swig_double" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 18, test_suite, "subtraction with swig_double")
 
     test_so.obj.dkg = 10
     test_so.obj.ikg = test_so.obj.ilbm - test_so.obj.dkg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 12, test_suite , "subtraction with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg,
+        12,
+        test_suite,
+        "subtraction with swig_double and unit conversion",
+    )
 
     # multiplication
 
     test_so.obj.ilbm = 50
     test_so.obj.ikg = test_so.obj.ilbm * 3
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 68, test_suite , "multiplication with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 68, test_suite, "multiplication with int")
 
     test_so.obj.ikg = test_so.obj.ilbm * 2.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 65, test_suite , "multiplication with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 65, test_suite, "multiplication with float")
 
     test_so.obj.ilbm = 50
     test_so.obj.i = 2
     test_so.obj.ikg = test_so.obj.ilbm * test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 45, test_suite , "multiplication with unitless swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 45, test_suite, "multiplication with unitless swig_int"
+    )
 
     test_so.obj.ilbm = 50
     test_so.obj.dno_units = 2.2
     test_so.obj.ikg = test_so.obj.ilbm * test_so.obj.dno_units
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 49, test_suite , "multiplication with unitless swig_double" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 49, test_suite, "multiplication with unitless swig_double"
+    )
 
     # division
 
     test_so.obj.ilbm = 50
     test_so.obj.ikg = test_so.obj.ilbm / 3
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 7, test_suite , "division with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 7, test_suite, "division with int")
 
     test_so.obj.ikg = test_so.obj.ilbm / 2.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 7, test_suite , "division with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 7, test_suite, "division with float")
 
     # floor division
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = test_so.obj.ikg // 4
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 7, test_suite , "floor division with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 7, test_suite, "floor division with int")
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = test_so.obj.ikg // 4.5
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 6, test_suite , "floor division with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 6, test_suite, "floor division with int")
 
     # mod
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = test_so.obj.ikg % 4
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 1, test_suite , "mod with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 1, test_suite, "mod with int")
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = test_so.obj.ikg % 4.5
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 2, test_suite , "mod with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 2, test_suite, "mod with float")
 
     test_so.obj.ilbm = 50
     test_so.obj.i = 13
     test_so.obj.ikg = test_so.obj.ilbm % test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "mod with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "mod with unitless swig_int")
 
     test_so.obj.ilbm = 50
     test_so.obj.dno_units = 13.5
     test_so.obj.ikg = test_so.obj.ilbm % test_so.obj.dno_units
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "mod with unitless swig_double" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "mod with unitless swig_double")
 
     # pow
 
     test_so.obj.i = 5
-    test_so.obj.i = pow(test_so.obj.i , 4)
-    TRICK_EXPECT_EQ( test_so.obj.i , 625, test_suite , "pow with int" )
+    test_so.obj.i = pow(test_so.obj.i, 4)
+    TRICK_EXPECT_EQ(test_so.obj.i, 625, test_suite, "pow with int")
 
     test_so.obj.i = 5
-    test_so.obj.i = pow(test_so.obj.i , 2.5)
-    TRICK_EXPECT_EQ( test_so.obj.i , 55, test_suite , "pow with float" )
+    test_so.obj.i = pow(test_so.obj.i, 2.5)
+    TRICK_EXPECT_EQ(test_so.obj.i, 55, test_suite, "pow with float")
 
     test_so.obj.i = 5
-    test_so.obj.i = pow(test_so.obj.i , test_so.obj.i)
-    TRICK_EXPECT_EQ( test_so.obj.i , 3125, test_suite , "pow with unitless swig_int" )
+    test_so.obj.i = pow(test_so.obj.i, test_so.obj.i)
+    TRICK_EXPECT_EQ(test_so.obj.i, 3125, test_suite, "pow with unitless swig_int")
 
     test_so.obj.i = 5
     test_so.obj.dno_units = 5.0
-    test_so.obj.i = pow(test_so.obj.i , test_so.obj.dno_units)
-    TRICK_EXPECT_EQ( test_so.obj.i , 3125, test_suite , "pow with unitless swig_double" )
+    test_so.obj.i = pow(test_so.obj.i, test_so.obj.dno_units)
+    TRICK_EXPECT_EQ(test_so.obj.i, 3125, test_suite, "pow with unitless swig_double")
 
     # left shift
 
     test_so.obj.ikg = 16
     test_so.obj.ikg = test_so.obj.ikg << 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 64, test_suite , "left shift with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 64, test_suite, "left shift with int")
 
     test_so.obj.ikg = 16
     test_so.obj.i = 1
     test_so.obj.ikg = test_so.obj.ikg << test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 32, test_suite , "left shift with unitless swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 32, test_suite, "left shift with unitless swig_int"
+    )
 
     # right shift
 
     test_so.obj.ikg = 16
     test_so.obj.ikg = test_so.obj.ikg >> 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "right shift with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "right shift with int")
 
     test_so.obj.ikg = 16
     test_so.obj.i = 1
     test_so.obj.ikg = test_so.obj.ikg >> test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 8, test_suite , "left shift with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 8, test_suite, "left shift with unitless swig_int")
 
     # and
 
     test_so.obj.ikg = 12
     test_so.obj.ikg = test_so.obj.ikg & 5
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "and with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "and with int")
 
     test_so.obj.ikg = 12
     test_so.obj.i = 5
     test_so.obj.ikg = test_so.obj.ikg & test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "and with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "and with unitless swig_int")
 
     # xor
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = test_so.obj.ikg ^ 7
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 26, test_suite , "xor with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 26, test_suite, "xor with int")
 
     test_so.obj.ikg = 29
     test_so.obj.i = 7
     test_so.obj.ikg = test_so.obj.ikg ^ test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 26, test_suite , "xor with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 26, test_suite, "xor with unitless swig_int")
 
     # or
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = test_so.obj.ikg | 7
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "or with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "or with int")
 
     test_so.obj.ikg = 29
     test_so.obj.i = 7
     test_so.obj.ikg = test_so.obj.ikg | test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "or with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "or with unitless swig_int")
 
     # reverse addition
 
     test_so.obj.ikg = 20 + test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "reverse addition with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "reverse addition with integer")
 
     test_so.obj.ikg = 20.9 + test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 32, test_suite , "reverse addition with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 32, test_suite, "reverse addition with float")
 
     # reverse subtraction
 
     test_so.obj.ikg = 120 - test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "reverse subtraction with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "reverse subtraction with integer")
 
     test_so.obj.ikg = 120.9 - test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 32, test_suite , "reverse subtraction with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 32, test_suite, "reverse subtraction with float")
 
     # reverse multiplication
 
     test_so.obj.ilbm = 50
     test_so.obj.ikg = 3 * test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 68, test_suite , "reverse multiplication with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 68, test_suite, "reverse multiplication with int")
 
     test_so.obj.ikg = 2.9 * test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 65, test_suite , "reverse multiplication with float" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 65, test_suite, "reverse multiplication with float"
+    )
 
     # reverse division
 
     test_so.obj.i = 5
     test_so.obj.i = 62 / test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 12, test_suite , "reverse division with int" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 12, test_suite, "reverse division with int")
 
     test_so.obj.i = 5
     test_so.obj.i = 62.5 / test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 12, test_suite , "reverse division with float" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 12, test_suite, "reverse division with float")
 
     # reverse mod
 
     test_so.obj.i = 5
     test_so.obj.i = 62 % test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 2, test_suite , "reverse mod with int" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 2, test_suite, "reverse mod with int")
 
     test_so.obj.i = 5
     test_so.obj.i = 62.5 % test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 2, test_suite , "reverse mod with float" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 2, test_suite, "reverse mod with float")
 
     # pow
 
     test_so.obj.i = 4
-    test_so.obj.i = pow(4 , test_so.obj.i)
-    TRICK_EXPECT_EQ( test_so.obj.i , 256, test_suite , "reverse pow with int" )
+    test_so.obj.i = pow(4, test_so.obj.i)
+    TRICK_EXPECT_EQ(test_so.obj.i, 256, test_suite, "reverse pow with int")
 
     test_so.obj.i = 5
-    test_so.obj.i = pow(2.1 , test_so.obj.i)
-    TRICK_EXPECT_EQ( test_so.obj.i , 40, test_suite , "reverse pow with float" )
+    test_so.obj.i = pow(2.1, test_so.obj.i)
+    TRICK_EXPECT_EQ(test_so.obj.i, 40, test_suite, "reverse pow with float")
 
     # reverse lshift
     test_so.obj.i = 3
     test_so.obj.i = 8 << test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 64, test_suite , "reverse lshift with int" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 64, test_suite, "reverse lshift with int")
 
     # reverse rshift
     test_so.obj.i = 2
     test_so.obj.i = 8 >> test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 2, test_suite , "reverse rshift with int" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 2, test_suite, "reverse rshift with int")
 
     # reverse and
 
     test_so.obj.ikg = 12
     test_so.obj.ikg = 5 & test_so.obj.ikg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "reverse and with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "reverse and with int")
 
     # reverse xor
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = 7 ^ test_so.obj.ikg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 26, test_suite , "reverse xor with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 26, test_suite, "reverse xor with int")
 
     # reverse or
 
     test_so.obj.ikg = 29
     test_so.obj.ikg = 7 | test_so.obj.ikg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "reverse or with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "reverse or with int")
 
     # in-place addition
 
     test_so.obj.ikg = 10
     test_so.obj.ikg += 20
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 30, test_suite , "in-place addition with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 30, test_suite, "in-place addition with integer")
 
     test_so.obj.ikg += 20.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 51, test_suite , "in-place addition with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 51, test_suite, "in-place addition with float")
 
     test_so.obj.ilbm = 10
     test_so.obj.ikg += test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 55, test_suite , "in-place addition with swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 55, test_suite, "in-place addition with swig_int")
 
     test_so.obj.dkg = 10
     test_so.obj.ikg += test_so.obj.dkg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 65, test_suite , "in-place addition with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg,
+        65,
+        test_suite,
+        "in-place addition with swig_double and unit conversion",
+    )
 
     # in-place subtraction
 
     test_so.obj.ikg = 10
     test_so.obj.ikg -= 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 8, test_suite , "in-place subtraction with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 8, test_suite, "in-place subtraction with integer")
 
     test_so.obj.ikg -= 2.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 5, test_suite , "in-place subtraction with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 5, test_suite, "in-place subtraction with float")
 
     test_so.obj.ilbm = 10
     test_so.obj.ikg -= test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 1, test_suite , "in-place subtraction with swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 1, test_suite, "in-place subtraction with swig_int"
+    )
 
     test_so.obj.dkg = 1
     test_so.obj.ikg -= test_so.obj.dkg
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 0, test_suite , "in-place subtraction with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg,
+        0,
+        test_suite,
+        "in-place subtraction with swig_double and unit conversion",
+    )
 
     # in-place multiplication
 
     test_so.obj.ikg = 10
     test_so.obj.ikg *= 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 20, test_suite , "in-place multiplication with integer" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 20, test_suite, "in-place multiplication with integer"
+    )
 
     test_so.obj.ikg *= 3.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 78, test_suite , "in-place multiplication with float" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 78, test_suite, "in-place multiplication with float"
+    )
 
     test_so.obj.ikg = 10
     test_so.obj.i = 2
     test_so.obj.ikg *= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 20, test_suite , "in-place multiplication with unitless swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg,
+        20,
+        test_suite,
+        "in-place multiplication with unitless swig_int",
+    )
 
     test_so.obj.ikg = 10
     test_so.obj.dno_units = 3.9
     test_so.obj.ikg *= test_so.obj.dno_units
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 39, test_suite , "in-place multiplication with unitless swig_double" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg,
+        39,
+        test_suite,
+        "in-place multiplication with unitless swig_double",
+    )
     # in-place division
 
     test_so.obj.ikg = 10
     test_so.obj.ikg /= 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 5, test_suite , "in-place division with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 5, test_suite, "in-place division with integer")
 
     test_so.obj.ikg = 10
     test_so.obj.ikg /= 3.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 3, test_suite , "in-place division with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 3, test_suite, "in-place division with float")
 
     test_so.obj.ikg = 10
     test_so.obj.i = 2
     test_so.obj.ikg /= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 5, test_suite , "in-place division with unitless swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 5, test_suite, "in-place division with unitless swig_int"
+    )
 
     # in-place mod
 
     test_so.obj.ikg = 10
     test_so.obj.ikg %= 3
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 1, test_suite , "in-place mod with integer" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 1, test_suite, "in-place mod with integer")
 
     test_so.obj.ikg = 10
     test_so.obj.ikg %= 3.9
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 2, test_suite , "in-place mod with float" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 2, test_suite, "in-place mod with float")
 
     test_so.obj.ikg = 10
     test_so.obj.i = 3
     test_so.obj.ikg %= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 1, test_suite , "in-place mod with unitless swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ikg, 1, test_suite, "in-place mod with unitless swig_int"
+    )
 
     # in-place pow
 
     test_so.obj.i = 5
     test_so.obj.i **= 4
-    TRICK_EXPECT_EQ( test_so.obj.i , 625, test_suite , "in-place pow with int" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 625, test_suite, "in-place pow with int")
 
     test_so.obj.i = 5
     test_so.obj.i **= 2.5
-    TRICK_EXPECT_EQ( test_so.obj.i , 56, test_suite , "in-place pow with float" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 56, test_suite, "in-place pow with float")
 
     test_so.obj.i = 5
     test_so.obj.i **= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.i , 3125, test_suite , "in-place pow with unitless swig_int" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.i, 3125, test_suite, "in-place pow with unitless swig_int"
+    )
 
     test_so.obj.i = 5
     test_so.obj.dno_units = 5.0
     test_so.obj.i **= test_so.obj.dno_units
-    TRICK_EXPECT_EQ( test_so.obj.i , 3125, test_suite , "in-place pow with unitless swig_double" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.i, 3125, test_suite, "in-place pow with unitless swig_double"
+    )
 
     # in-place left shift
 
     test_so.obj.ikg = 16
     test_so.obj.ikg <<= 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 64, test_suite , "left shift with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 64, test_suite, "left shift with int")
 
     test_so.obj.i = 16
     test_so.obj.ia[0] = 1
     test_so.obj.i <<= test_so.obj.ia[0]
-    TRICK_EXPECT_EQ( test_so.obj.i , 32, test_suite , "left shift with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.i, 32, test_suite, "left shift with unitless swig_int")
 
     # in-place right shift
 
     test_so.obj.ikg = 16
     test_so.obj.ikg >>= 2
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "right shift with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "right shift with int")
 
     test_so.obj.ikg = 16
     test_so.obj.i = 1
     test_so.obj.ikg >>= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 8, test_suite , "left shift with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 8, test_suite, "left shift with unitless swig_int")
 
     # in-place and
 
     test_so.obj.ikg = 12
     test_so.obj.ikg &= 5
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "and with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "and with int")
 
     test_so.obj.ikg = 12
     test_so.obj.i = 5
     test_so.obj.ikg &= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 4, test_suite , "and with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 4, test_suite, "and with unitless swig_int")
 
     # in-place xor
 
     test_so.obj.ikg = 29
     test_so.obj.ikg ^= 7
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 26, test_suite , "xor with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 26, test_suite, "xor with int")
 
     test_so.obj.ikg = 29
     test_so.obj.i = 7
     test_so.obj.ikg ^= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 26, test_suite , "xor with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 26, test_suite, "xor with unitless swig_int")
 
     # in-place or
 
     test_so.obj.ikg = 29
     test_so.obj.ikg |= 7
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "or with int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "or with int")
 
     test_so.obj.ikg = 29
     test_so.obj.i = 7
     test_so.obj.ikg |= test_so.obj.i
-    TRICK_EXPECT_EQ( test_so.obj.ikg , 31, test_suite , "or with unitless swig_int" )
+    TRICK_EXPECT_EQ(test_so.obj.ikg, 31, test_suite, "or with unitless swig_int")
 
     # less than
 
@@ -2520,17 +4930,17 @@ def main():
     test_so.obj.ilbm = 20
 
     test = test_so.obj.ikg < 21
-    TRICK_EXPECT_EQ( test , True, test_suite , "lt with integer" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "lt with integer")
 
     test = test_so.obj.ikg < 20.5
-    TRICK_EXPECT_EQ( test , True, test_suite , "lt with float" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "lt with float")
 
     test = test_so.obj.ikg < test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test , False, test_suite , "lt with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "lt with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.ikg < test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , True, test_suite , "lt with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "lt with swig_double and unit conversion")
 
     # less than or equal
 
@@ -2538,47 +4948,47 @@ def main():
     test_so.obj.ilbm = 20
 
     test = test_so.obj.ikg <= 21
-    TRICK_EXPECT_EQ( test , True, test_suite , "le with integer" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "le with integer")
 
     test = test_so.obj.ikg <= 20.5
-    TRICK_EXPECT_EQ( test , True, test_suite , "le with float" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "le with float")
 
     test = test_so.obj.ikg <= test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test , False, test_suite , "le with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "le with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.ikg <= test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , True, test_suite , "le with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "le with swig_double and unit conversion")
 
     # equal
 
     test = test_so.obj.ikg == 21
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with integer" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with integer")
 
     test = test_so.obj.ikg == 20.5
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with float" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with float")
 
     test = test_so.obj.ikg == test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.ikg == test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with swig_double and unit conversion")
 
     # not equal
 
     test = test_so.obj.ikg != 21
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with integer" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with integer")
 
     test = test_so.obj.ikg != 20.5
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with float" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with float")
 
     test = test_so.obj.ikg != test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.ikg != test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with swig_double and unit conversion")
 
     # greater than
 
@@ -2586,17 +4996,17 @@ def main():
     test_so.obj.ilbm = 20
 
     test = test_so.obj.ikg > 21
-    TRICK_EXPECT_EQ( test , False, test_suite , "gt with integer" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "gt with integer")
 
     test = test_so.obj.ikg > 20.5
-    TRICK_EXPECT_EQ( test , False, test_suite , "gt with float" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "gt with float")
 
     test = test_so.obj.ikg > test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test , True, test_suite , "gt with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "gt with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.ikg > test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , False, test_suite , "gt with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "gt with swig_double and unit conversion")
 
     # greater than or equal
 
@@ -2604,61 +5014,61 @@ def main():
     test_so.obj.ilbm = 20
 
     test = test_so.obj.ikg >= 21
-    TRICK_EXPECT_EQ( test , False, test_suite , "ge with integer" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "ge with integer")
 
     test = test_so.obj.ikg >= 20.5
-    TRICK_EXPECT_EQ( test , False, test_suite , "ge with float" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "ge with float")
 
     test = test_so.obj.ikg >= test_so.obj.ilbm
-    TRICK_EXPECT_EQ( test , True, test_suite , "ge with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ge with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.ikg >= test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , False, test_suite , "ge with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "ge with swig_double and unit conversion")
 
     # unary operators
 
     test_so.obj.ikg = 20
     test = -test_so.obj.ikg
-    TRICK_EXPECT_EQ( test , -20, test_suite , "unary neg" )
+    TRICK_EXPECT_EQ(test, -20, test_suite, "unary neg")
 
     test = +test_so.obj.ikg
-    TRICK_EXPECT_EQ( test , 20, test_suite , "unary pos" )
+    TRICK_EXPECT_EQ(test, 20, test_suite, "unary pos")
 
     test_so.obj.ikg = -20
     test = abs(test_so.obj.ikg)
-    TRICK_EXPECT_EQ( test , 20, test_suite , "unary abs" )
+    TRICK_EXPECT_EQ(test, 20, test_suite, "unary abs")
 
     test_so.obj.ikg = 20
     test = ~test_so.obj.ikg
-    TRICK_EXPECT_EQ( test , -21, test_suite , "unary invert" )
+    TRICK_EXPECT_EQ(test, -21, test_suite, "unary invert")
 
     # conversion
     test_so.obj.ikg = 20
     test = int(test_so.obj.ikg)
-    TRICK_EXPECT_EQ( test , 20, test_suite , "int" )
+    TRICK_EXPECT_EQ(test, 20, test_suite, "int")
 
-    if sys.version_info < (3,0):
+    if sys.version_info < (3, 0):
         test_so.obj.ikg = 20
         test = long(test_so.obj.ikg)
-        TRICK_EXPECT_EQ( test , 20, test_suite , "long" )
+        TRICK_EXPECT_EQ(test, 20, test_suite, "long")
 
     test_so.obj.ikg = 20
     test = float(test_so.obj.ikg)
-    TRICK_EXPECT_EQ( test , 20, test_suite , "float" )
+    TRICK_EXPECT_EQ(test, 20, test_suite, "float")
 
     test_so.obj.ikg = 20
     test = oct(test_so.obj.ikg)
-    if sys.version_info >= (3,0):
-        TRICK_EXPECT_EQ( test , "0o24", test_suite , "oct" )
+    if sys.version_info >= (3, 0):
+        TRICK_EXPECT_EQ(test, "0o24", test_suite, "oct")
     else:
-        TRICK_EXPECT_EQ( test , "024", test_suite , "oct" )
+        TRICK_EXPECT_EQ(test, "024", test_suite, "oct")
 
     test_so.obj.ikg = 20
     test = hex(test_so.obj.ikg)
-    TRICK_EXPECT_EQ( test , "0x14", test_suite , "hex" )
+    TRICK_EXPECT_EQ(test, "0x14", test_suite, "hex")
 
-######################################################################################################################
+    ######################################################################################################################
 
     # swig_integer to swig_double assignment
     test_suite = "swig_double"
@@ -2668,359 +5078,586 @@ def main():
 
     # swig_double unitless to swig_double assignment
 
-    test_so.obj.dno_units = trick.attach_units("--" , 60.6)
-    TRICK_EXPECT_EQ( test_so.obj.dno_units , 60.6, test_suite , "assignment from unitless swig_double" )
-    trick.trick_test_add_parent( test_suite , "assignment from unitless swig_double" , "1164062396")
+    test_so.obj.dno_units = trick.attach_units("--", 60.6)
+    TRICK_EXPECT_EQ(
+        test_so.obj.dno_units, 60.6, test_suite, "assignment from unitless swig_double"
+    )
+    trick.trick_test_add_parent(
+        test_suite, "assignment from unitless swig_double", "1164062396"
+    )
 
     # addition
 
     test_so.obj.dlbm = 50
     test_so.obj.dkg = test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 22.6796, 0.0001, test_suite , "units conversion" )
+    TRICK_EXPECT_NEAR(test_so.obj.dkg, 22.6796, 0.0001, test_suite, "units conversion")
 
     test_so.obj.dkg = test_so.obj.dlbm + 20
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 31.7515, 0.0001, test_suite , "addition with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 31.7515, 0.0001, test_suite, "addition with integer"
+    )
 
     test_so.obj.dkg = test_so.obj.dlbm + 20.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 32.1597, 0.0001, test_suite , "addition with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 32.1597, 0.0001, test_suite, "addition with float"
+    )
 
     test_so.obj.ilbm = 50
     test_so.obj.dkg = test_so.obj.dlbm + test_so.obj.ilbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 45.3592, 0.0001, test_suite , "addition with swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 45.3592, 0.0001, test_suite, "addition with swig_int"
+    )
 
     test_so.obj.dkg = 50
     test_so.obj.ikg = 50
     test_so.obj.dkg = test_so.obj.dlbm + test_so.obj.ikg
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 72.6796, 0.0001, test_suite , "addition with swig_int and unit conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        72.6796,
+        0.0001,
+        test_suite,
+        "addition with swig_int and unit conversion",
+    )
 
     test_so.obj.dlbm = 10
     test_so.obj.dkg = test_so.obj.dlbm + test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 9.07185, 0.0001, test_suite , "addition with swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 9.07185, 0.0001, test_suite, "addition with swig_double"
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.dkg = test_so.obj.dlbm + test_so.obj.dkg
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 14.5359, 0.0001, test_suite , "addition with swig_double and unit conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        14.5359,
+        0.0001,
+        test_suite,
+        "addition with swig_double and unit conversion",
+    )
 
     # subtraction
 
     test_so.obj.dlbm = 50
     test_so.obj.dkg = test_so.obj.dlbm - 20
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 13.6078, 0.0001, test_suite , "subtraction with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 13.6078, 0.0001, test_suite, "subtraction with integer"
+    )
 
     test_so.obj.dkg = test_so.obj.dlbm - 20.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 13.1995, 0.0001, test_suite , "subtraction with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 13.1995, 0.0001, test_suite, "subtraction with float"
+    )
 
     test_so.obj.ilbm = 50
     test_so.obj.dkg = test_so.obj.dlbm - test_so.obj.ilbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 0, 0.0001, test_suite , "subtraction with swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 0, 0.0001, test_suite, "subtraction with swig_int"
+    )
 
     test_so.obj.dkg = 50
     test_so.obj.ikg = 50
     test_so.obj.dkg = test_so.obj.dlbm - test_so.obj.ikg
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , -27.3204, 0.0001, test_suite , "subtraction with swig_int and unit conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        -27.3204,
+        0.0001,
+        test_suite,
+        "subtraction with swig_int and unit conversion",
+    )
 
     test_so.obj.dlbm = 10
     test_so.obj.dkg = test_so.obj.dlbm - test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 0, 0.0001, test_suite , "subtraction with swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 0, 0.0001, test_suite, "subtraction with swig_double"
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.dkg = test_so.obj.dlbm - test_so.obj.dkg
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , -5.46408, 0.0001, test_suite , "subtraction with swig_double and unit conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        -5.46408,
+        0.0001,
+        test_suite,
+        "subtraction with swig_double and unit conversion",
+    )
 
     # multiplication
 
     test_so.obj.dlbm = 50
     test_so.obj.dkg = test_so.obj.dlbm * 3
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 68.0389, 0.0001, test_suite , "multiplication with int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 68.0389, 0.0001, test_suite, "multiplication with int"
+    )
 
     test_so.obj.dkg = test_so.obj.ilbm * 2.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 65.7709, 0.0001, test_suite , "multiplication with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 65.7709, 0.0001, test_suite, "multiplication with float"
+    )
 
     test_so.obj.dlbm = 50
     test_so.obj.i = 2
     test_so.obj.dkg = test_so.obj.dlbm * test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 45.3592, 0.0001, test_suite , "multiplication with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        45.3592,
+        0.0001,
+        test_suite,
+        "multiplication with unitless swig_int",
+    )
 
     test_so.obj.dlbm = 50
     test_so.obj.dno_units = 2.2
     test_so.obj.dkg = test_so.obj.dlbm * test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 49.8952, 0.0001, test_suite , "multiplication with unitless swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        49.8952,
+        0.0001,
+        test_suite,
+        "multiplication with unitless swig_double",
+    )
 
     # division
 
     test_so.obj.dlbm = 50
     test_so.obj.dkg = test_so.obj.dlbm / 3
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 7.55987, 0.0001, test_suite , "division with int" )
+    TRICK_EXPECT_NEAR(test_so.obj.dkg, 7.55987, 0.0001, test_suite, "division with int")
 
     test_so.obj.dkg = test_so.obj.dlbm / 2.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 7.82056, 0.0001, test_suite , "division with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 7.82056, 0.0001, test_suite, "division with float"
+    )
 
     test_so.obj.i = 5
     test_so.obj.dkg = test_so.obj.dlbm / test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 4.53592, 0.0001, test_suite , "division with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 4.53592, 0.0001, test_suite, "division with unitless swig_int"
+    )
 
     test_so.obj.dno_units = 5.1
     test_so.obj.dkg = test_so.obj.dlbm / test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 4.44698, 0.0001, test_suite , "division with unitless swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        4.44698,
+        0.0001,
+        test_suite,
+        "division with unitless swig_double",
+    )
 
     # floor division
 
     test_so.obj.dkg = 29
     test_so.obj.dkg = test_so.obj.dkg // 4
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 7, 0.0001, test_suite , "floor division with int" )
+    TRICK_EXPECT_NEAR(test_so.obj.dkg, 7, 0.0001, test_suite, "floor division with int")
 
     test_so.obj.dkg = 29
     test_so.obj.dkg = test_so.obj.dkg // 4.5
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 6, 0.0001, test_suite , "floor division with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 6, 0.0001, test_suite, "floor division with float"
+    )
 
     test_so.obj.dkg = 29
     test_so.obj.i = 4
     test_so.obj.dkg = test_so.obj.dkg // test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 7, 0.0001, test_suite , "floor division with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 7, 0.0001, test_suite, "floor division with unitless swig_int"
+    )
 
     test_so.obj.dkg = 29
     test_so.obj.dno_units = 4.5
     test_so.obj.dkg = test_so.obj.dkg // test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 6, 0.0001, test_suite , "floor division with unitless swig_double" )
-
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        6,
+        0.0001,
+        test_suite,
+        "floor division with unitless swig_double",
+    )
 
     # mod
 
     test_so.obj.dkg = 29
     test_so.obj.dkg = test_so.obj.dkg % 4
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 1, 0.0001, test_suite , "mod with int" )
+    TRICK_EXPECT_NEAR(test_so.obj.dkg, 1, 0.0001, test_suite, "mod with int")
 
     test_so.obj.dkg = 29
     test_so.obj.dkg = test_so.obj.dkg % 4.5
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 2, 0.0001, test_suite , "mod with float" )
+    TRICK_EXPECT_NEAR(test_so.obj.dkg, 2, 0.0001, test_suite, "mod with float")
 
     test_so.obj.dlbm = 50
     test_so.obj.i = 13
     test_so.obj.dlbm = test_so.obj.dlbm % test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dlbm , 11, 0.0001, test_suite , "mod with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dlbm, 11, 0.0001, test_suite, "mod with unitless swig_int"
+    )
 
     test_so.obj.dlbm = 50
     test_so.obj.dno_units = 13.5
     test_so.obj.dlbm = test_so.obj.dlbm % test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dlbm , 9.5, 0.0001, test_suite , "mod with unitless swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dlbm, 9.5, 0.0001, test_suite, "mod with unitless swig_double"
+    )
 
     # pow
 
     test_so.obj.dno_units = 5
-    test_so.obj.dno_units = pow(test_so.obj.dno_units , 4)
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 625, 0.0001, test_suite , "pow with int" )
+    test_so.obj.dno_units = pow(test_so.obj.dno_units, 4)
+    TRICK_EXPECT_NEAR(test_so.obj.dno_units, 625, 0.0001, test_suite, "pow with int")
 
     test_so.obj.dno_units = 5
-    test_so.obj.dno_units = pow(test_so.obj.dno_units , 2.5)
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 55.9017, 0.0001, test_suite , "pow with float" )
+    test_so.obj.dno_units = pow(test_so.obj.dno_units, 2.5)
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 55.9017, 0.0001, test_suite, "pow with float"
+    )
 
     test_so.obj.i = 5
     test_so.obj.dno_units = 5.0
-    test_so.obj.dno_units = pow(test_so.obj.dno_units , test_so.obj.i)
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 3125, 0.0001, test_suite , "pow with unitless swig_int" )
+    test_so.obj.dno_units = pow(test_so.obj.dno_units, test_so.obj.i)
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 3125, 0.0001, test_suite, "pow with unitless swig_int"
+    )
 
     test_so.obj.dno_units = 5.0
-    test_so.obj.dno_units = pow(test_so.obj.dno_units , test_so.obj.dno_units)
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 3125, 0.0001, test_suite , "pow with unitless swig_double" )
+    test_so.obj.dno_units = pow(test_so.obj.dno_units, test_so.obj.dno_units)
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 3125, 0.0001, test_suite, "pow with unitless swig_double"
+    )
 
     # reverse addition
 
     test_so.obj.dlbm = 10
     test_so.obj.dkg = 20 + test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 13.6078, 0.0001, test_suite , "reverse addition with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 13.6078, 0.0001, test_suite, "reverse addition with integer"
+    )
 
     test_so.obj.dkg = 20.9 + test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 14.016, 0.0001, test_suite , "reverse addition with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 14.016, 0.0001, test_suite, "reverse addition with float"
+    )
 
     # reverse subtraction
 
     test_so.obj.dkg = 120 - test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 49.8952, 0.0001, test_suite , "reverse subtraction with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 49.8952, 0.0001, test_suite, "reverse subtraction with integer"
+    )
 
     test_so.obj.dkg = 120.9 - test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 50.3034, 0.0001, test_suite , "reverse subtraction with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 50.3034, 0.0001, test_suite, "reverse subtraction with float"
+    )
 
     # reverse multiplication
 
     test_so.obj.dlbm = 50
     test_so.obj.dkg = 3 * test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 68.0389, 0.0001, test_suite , "reverse multiplication with int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 68.0389, 0.0001, test_suite, "reverse multiplication with int"
+    )
 
     test_so.obj.dkg = 2.9 * test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 65.7709, 0.0001, test_suite , "reverse multiplication with float" )
-
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        65.7709,
+        0.0001,
+        test_suite,
+        "reverse multiplication with float",
+    )
 
     # reverse division
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units = 62 / test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 12.4, 0.0001, test_suite , "reverse division with int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 12.4, 0.0001, test_suite, "reverse division with int"
+    )
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units = 62.5 / test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 12.5, 0.0001, test_suite , "reverse division with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 12.5, 0.0001, test_suite, "reverse division with float"
+    )
 
     # reverse floor division
     test_so.obj.dno_units = 5
     test_so.obj.dno_units = 62 // test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 12, 0.0001, test_suite , "reverse floor division with int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 12, 0.0001, test_suite, "reverse floor division with int"
+    )
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units = 62.5 // test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 12, 0.0001, test_suite , "reverse floor division with float" )
-
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units,
+        12,
+        0.0001,
+        test_suite,
+        "reverse floor division with float",
+    )
 
     # reverse mod
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units = 62 % test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 2, 0.0001, test_suite , "reverse mod with int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 2, 0.0001, test_suite, "reverse mod with int"
+    )
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units = 62.5 % test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 2.5, 0.0001, test_suite , "reverse mod with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 2.5, 0.0001, test_suite, "reverse mod with float"
+    )
 
     # reverse pow
 
     test_so.obj.dno_units = 4
-    test_so.obj.dno_units = pow(4 , test_so.obj.dno_units)
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 256, 0.0001, test_suite , "reverse pow with int" )
+    test_so.obj.dno_units = pow(4, test_so.obj.dno_units)
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 256, 0.0001, test_suite, "reverse pow with int"
+    )
 
     test_so.obj.dno_units = 5
-    test_so.obj.dno_units = pow(2.1 , test_so.obj.dno_units)
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 40.841 , 0.0001, test_suite , "reverse pow with float" )
+    test_so.obj.dno_units = pow(2.1, test_so.obj.dno_units)
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 40.841, 0.0001, test_suite, "reverse pow with float"
+    )
 
     # in-place addition
 
     test_so.obj.dkg = 10
     test_so.obj.dkg += 20
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 30, 0.0001, test_suite , "in-place addition with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 30, 0.0001, test_suite, "in-place addition with integer"
+    )
 
     test_so.obj.dkg += 20.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 50.9, 0.0001, test_suite , "in-place addition with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 50.9, 0.0001, test_suite, "in-place addition with float"
+    )
 
     test_so.obj.ilbm = 10
     test_so.obj.dkg += test_so.obj.ilbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 55.4359, 0.0001, test_suite , "in-place addition with swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 55.4359, 0.0001, test_suite, "in-place addition with swig_int"
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.dkg += test_so.obj.dkg
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 20, 0.0001, test_suite , "in-place addition with swig_double and unit conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        20,
+        0.0001,
+        test_suite,
+        "in-place addition with swig_double and unit conversion",
+    )
 
     # in-place subtraction
 
     test_so.obj.dkg = 10
     test_so.obj.dkg -= 2
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 8, 0.0001, test_suite , "in-place subtraction with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 8, 0.0001, test_suite, "in-place subtraction with integer"
+    )
 
     test_so.obj.dkg -= 2.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5.1, 0.0001, test_suite , "in-place subtraction with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 5.1, 0.0001, test_suite, "in-place subtraction with float"
+    )
 
     test_so.obj.dlbm = 10
     test_so.obj.dkg -= test_so.obj.dlbm
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 0.564076, 0.0001, test_suite , "in-place subtraction with swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        0.564076,
+        0.0001,
+        test_suite,
+        "in-place subtraction with swig_int",
+    )
 
     test_so.obj.dkg = 1
     test_so.obj.dkg -= test_so.obj.dkg
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 0, 0.0001, test_suite , "in-place subtraction with swig_double and unit conversion" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        0,
+        0.0001,
+        test_suite,
+        "in-place subtraction with swig_double and unit conversion",
+    )
 
     # in-place multiplication
 
     test_so.obj.dkg = 10
     test_so.obj.dkg *= 2
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 20, 0.0001, test_suite , "in-place multiplication with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 20, 0.0001, test_suite, "in-place multiplication with integer"
+    )
 
     test_so.obj.dkg *= 3.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 78, 0.0001, test_suite , "in-place multiplication with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 78, 0.0001, test_suite, "in-place multiplication with float"
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.i = 2
     test_so.obj.dkg *= test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 20, 0.0001, test_suite , "in-place multiplication with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        20,
+        0.0001,
+        test_suite,
+        "in-place multiplication with unitless swig_int",
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.dno_units = 2
     test_so.obj.dkg *= test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 20, 0.0001, test_suite , "in-place multiplication with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        20,
+        0.0001,
+        test_suite,
+        "in-place multiplication with unitless swig_int",
+    )
 
     # in-place division
 
     test_so.obj.dkg = 10
     test_so.obj.dkg /= 2
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5, 0.0001, test_suite , "in-place division with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 5, 0.0001, test_suite, "in-place division with integer"
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.dkg /= 3.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 2.5641, 0.0001, test_suite , "in-place division with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 2.5641, 0.0001, test_suite, "in-place division with float"
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.i = 2
     test_so.obj.dkg /= test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5, 0.0001, test_suite , "in-place division with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        5,
+        0.0001,
+        test_suite,
+        "in-place division with unitless swig_int",
+    )
 
     test_so.obj.dkg = 10
     test_so.obj.dno_units = 2
     test_so.obj.dkg /= test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5, 0.0001, test_suite , "in-place division with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        5,
+        0.0001,
+        test_suite,
+        "in-place division with unitless swig_int",
+    )
 
     # in-place floor division
 
     test_so.obj.dkg = 10.1
     test_so.obj.dkg //= 2
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5, 0.0001, test_suite , "in-place division with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 5, 0.0001, test_suite, "in-place division with integer"
+    )
 
     test_so.obj.dkg = 10.1
     test_so.obj.dkg //= 3.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 2, 0.0001, test_suite , "in-place division with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 2, 0.0001, test_suite, "in-place division with float"
+    )
 
     test_so.obj.dkg = 10.1
     test_so.obj.i = 2
     test_so.obj.dkg //= test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5, 0.0001, test_suite , "in-place division with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        5,
+        0.0001,
+        test_suite,
+        "in-place division with unitless swig_int",
+    )
 
     test_so.obj.dkg = 10.1
     test_so.obj.dno_units = 2
     test_so.obj.dkg //= test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 5, 0.0001, test_suite , "in-place division with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        5,
+        0.0001,
+        test_suite,
+        "in-place division with unitless swig_int",
+    )
 
     # in-place mod
 
     test_so.obj.dkg = 10.1
     test_so.obj.dkg %= 3
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 1.1, 0.0001, test_suite , "in-place mod with integer" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 1.1, 0.0001, test_suite, "in-place mod with integer"
+    )
 
     test_so.obj.dkg = 10.1
     test_so.obj.dkg %= 3.9
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 2.3, 0.0001, test_suite , "in-place mod with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 2.3, 0.0001, test_suite, "in-place mod with float"
+    )
 
     test_so.obj.dkg = 10.1
     test_so.obj.i = 3
     test_so.obj.dkg %= test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 1.1, 0.0001, test_suite , "in-place mod with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg, 1.1, 0.0001, test_suite, "in-place mod with unitless swig_int"
+    )
 
     test_so.obj.dkg = 10.1
     test_so.obj.dno_units = 4
     test_so.obj.dkg %= test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dkg , 2.1, 0.0001, test_suite , "in-place mod with unitless swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dkg,
+        2.1,
+        0.0001,
+        test_suite,
+        "in-place mod with unitless swig_double",
+    )
 
     # in-place pow
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units **= 4
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 625, 0.0001, test_suite , "in-place pow with int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 625, 0.0001, test_suite, "in-place pow with int"
+    )
 
     test_so.obj.dno_units = 5
     test_so.obj.dno_units **= 2.5
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 55.9017, 0.0001, test_suite , "in-place pow with float" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units, 55.9017, 0.0001, test_suite, "in-place pow with float"
+    )
 
     test_so.obj.i = 5
     test_so.obj.dno_units = 5.0
     test_so.obj.dno_units **= test_so.obj.i
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 3125, 0.0001, test_suite , "in-place pow with unitless swig_int" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units,
+        3125,
+        0.0001,
+        test_suite,
+        "in-place pow with unitless swig_int",
+    )
 
     test_so.obj.dno_units = 5.0
     test_so.obj.dno_units **= test_so.obj.dno_units
-    TRICK_EXPECT_NEAR( test_so.obj.dno_units , 3125, 0.0001, test_suite , "in-place pow with unitless swig_double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.dno_units,
+        3125,
+        0.0001,
+        test_suite,
+        "in-place pow with unitless swig_double",
+    )
 
     # less than
 
@@ -3028,17 +5665,17 @@ def main():
     test_so.obj.dlbm = 20
 
     test = test_so.obj.dkg < 21
-    TRICK_EXPECT_EQ( test , True, test_suite , "lt with integer" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "lt with integer")
 
     test = test_so.obj.dkg < 20.5
-    TRICK_EXPECT_EQ( test , True, test_suite , "lt with float" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "lt with float")
 
     test = test_so.obj.dkg < test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test , False, test_suite , "lt with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "lt with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.dkg < test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , False, test_suite , "lt with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "lt with swig_double and unit conversion")
 
     # less than or equal
 
@@ -3046,47 +5683,47 @@ def main():
     test_so.obj.dlbm = 20
 
     test = test_so.obj.dkg <= 21
-    TRICK_EXPECT_EQ( test , True, test_suite , "le with integer" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "le with integer")
 
     test = test_so.obj.dkg <= 20.5
-    TRICK_EXPECT_EQ( test , True, test_suite , "le with float" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "le with float")
 
     test = test_so.obj.dkg <= test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test , False, test_suite , "le with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "le with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.dkg <= test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , True, test_suite , "le with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "le with swig_double and unit conversion")
 
     # equal
 
     test = test_so.obj.dkg == 21
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with integer" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with integer")
 
     test = test_so.obj.dkg == 20.5
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with float" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with float")
 
     test = test_so.obj.dkg == test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test , False, test_suite , "eq with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "eq with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.dkg == test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , True, test_suite , "eq with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "eq with swig_double and unit conversion")
 
     # not equal
 
     test = test_so.obj.dkg != 21
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with integer" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with integer")
 
     test = test_so.obj.dkg != 20.5
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with float" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with float")
 
     test = test_so.obj.dkg != test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test , True, test_suite , "ne with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ne with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.dkg != test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , False, test_suite , "ne with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "ne with swig_double and unit conversion")
 
     # greater than
 
@@ -3094,17 +5731,17 @@ def main():
     test_so.obj.dlbm = 20
 
     test = test_so.obj.dkg > 21
-    TRICK_EXPECT_EQ( test , False, test_suite , "gt with integer" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "gt with integer")
 
     test = test_so.obj.dkg > 20.5
-    TRICK_EXPECT_EQ( test , False, test_suite , "gt with float" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "gt with float")
 
     test = test_so.obj.dkg > test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test , True, test_suite , "gt with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "gt with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.dkg > test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , False, test_suite , "gt with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "gt with swig_double and unit conversion")
 
     # greater than or equal
 
@@ -3112,46 +5749,46 @@ def main():
     test_so.obj.dlbm = 20
 
     test = test_so.obj.dkg >= 21
-    TRICK_EXPECT_EQ( test , False, test_suite , "ge with integer" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "ge with integer")
 
     test = test_so.obj.dkg >= 20.5
-    TRICK_EXPECT_EQ( test , False, test_suite , "ge with float" )
+    TRICK_EXPECT_EQ(test, False, test_suite, "ge with float")
 
     test = test_so.obj.dkg >= test_so.obj.dlbm
-    TRICK_EXPECT_EQ( test , True, test_suite , "ge with swig_int and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ge with swig_int and unit conversion")
 
     test_so.obj.dkg = 20.1
     test = test_so.obj.dkg >= test_so.obj.dkg
-    TRICK_EXPECT_EQ( test , True, test_suite , "ge with swig_double and unit conversion" )
+    TRICK_EXPECT_EQ(test, True, test_suite, "ge with swig_double and unit conversion")
 
     # unary operators
 
     test_so.obj.dkg = 20
     test = -test_so.obj.dkg
-    TRICK_EXPECT_NEAR( test , -20, 0.0001, test_suite , "unary neg" )
+    TRICK_EXPECT_NEAR(test, -20, 0.0001, test_suite, "unary neg")
 
     test = +test_so.obj.dkg
-    TRICK_EXPECT_NEAR( test , 20, 0.0001, test_suite , "unary pos" )
+    TRICK_EXPECT_NEAR(test, 20, 0.0001, test_suite, "unary pos")
 
     test_so.obj.dkg = -20
     test = abs(test_so.obj.dkg)
-    TRICK_EXPECT_NEAR( test , 20, 0.0001, test_suite , "unary abs" )
+    TRICK_EXPECT_NEAR(test, 20, 0.0001, test_suite, "unary abs")
 
     # conversion
     test_so.obj.dkg = 20
     test = int(test_so.obj.dkg)
-    TRICK_EXPECT_NEAR( test , 20, 0.0001, test_suite , "int" )
+    TRICK_EXPECT_NEAR(test, 20, 0.0001, test_suite, "int")
 
-    if sys.version_info < (3,0):
+    if sys.version_info < (3, 0):
         test_so.obj.dkg = 20
         test = long(test_so.obj.dkg)
-        TRICK_EXPECT_NEAR( test , 20, 0.0001, test_suite , "long" )
+        TRICK_EXPECT_NEAR(test, 20, 0.0001, test_suite, "long")
 
     test_so.obj.dkg = 20
     test = float(test_so.obj.dkg)
-    TRICK_EXPECT_NEAR( test , 20, 0.0001, test_suite , "float" )
+    TRICK_EXPECT_NEAR(test, 20, 0.0001, test_suite, "float")
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Typedefed integers
     test_suite = "typedef"
@@ -3160,29 +5797,45 @@ def main():
     test_so.obj.iii = test_so.obj.i
     test_so.obj.aiii = test_so.obj.iii
 
-    TRICK_EXPECT_EQ( test_so.obj.iii , 40, test_suite , "integer from integer" )
-    trick.trick_test_add_parent( test_suite , "integer from integer" , "1011083320")
-    TRICK_EXPECT_EQ( test_so.obj.aiii , 40, test_suite , "integer from another typedefed integer" )
-    trick.trick_test_add_parent( test_suite , "integer from another typedefed integer" , "1011083320")
+    TRICK_EXPECT_EQ(test_so.obj.iii, 40, test_suite, "integer from integer")
+    trick.trick_test_add_parent(test_suite, "integer from integer", "1011083320")
+    TRICK_EXPECT_EQ(
+        test_so.obj.aiii, 40, test_suite, "integer from another typedefed integer"
+    )
+    trick.trick_test_add_parent(
+        test_suite, "integer from another typedefed integer", "1011083320"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "structure"
 
     # Structs with more than one name
     test_so.t.i = 300
-    TRICK_EXPECT_EQ( test_so.t.i , 300, test_suite , "multi named structure no unit assignment" )
+    TRICK_EXPECT_EQ(
+        test_so.t.i, 300, test_suite, "multi named structure no unit assignment"
+    )
 
     test_so.t.i = trick.attach_units("in", 300)
-    TRICK_EXPECT_EQ( test_so.t.i , 7, test_suite , "multi named structure with unit assignment" )
+    TRICK_EXPECT_EQ(
+        test_so.t.i, 7, test_suite, "multi named structure with unit assignment"
+    )
 
     test_so.t.d = 300
-    TRICK_EXPECT_NEAR( test_so.t.d , 300, 0.0001 , test_suite , "multi named structure no unit assignment" )
+    TRICK_EXPECT_NEAR(
+        test_so.t.d, 300, 0.0001, test_suite, "multi named structure no unit assignment"
+    )
 
     test_so.t.d = trick.attach_units("in", 300)
-    TRICK_EXPECT_NEAR( test_so.t.d , 7.62 , 0.0001 , test_suite , "multi named structure with unit assignment" )
+    TRICK_EXPECT_NEAR(
+        test_so.t.d,
+        7.62,
+        0.0001,
+        test_suite,
+        "multi named structure with unit assignment",
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Templates
     test_suite = "template"
@@ -3191,51 +5844,75 @@ def main():
     test_so.obj.my_template_var.var1 = 30.0
     test_so.obj.my_template_var.var2 = 40
     test_so.obj.my_template_var.var3 = 50
-    TRICK_EXPECT_NEAR( test_so.obj.my_template_var.var1 , 30.0 , 0.000001 , test_suite , "double assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.my_template_var.var2 , 40 , test_suite , "int assignment" )
-    TRICK_EXPECT_EQ( test_so.obj.my_template_var.var3 , 50 , test_suite , "short assignment" )
-    trick.trick_test_add_parent( test_suite , "double assignment" , "2642836719")
-    trick.trick_test_add_parent( test_suite , "int assignment" , "2642836719")
-    trick.trick_test_add_parent( test_suite , "short assignment" , "2642836719")
-
+    TRICK_EXPECT_NEAR(
+        test_so.obj.my_template_var.var1,
+        30.0,
+        0.000001,
+        test_suite,
+        "double assignment",
+    )
+    TRICK_EXPECT_EQ(test_so.obj.my_template_var.var2, 40, test_suite, "int assignment")
+    TRICK_EXPECT_EQ(
+        test_so.obj.my_template_var.var3, 50, test_suite, "short assignment"
+    )
+    trick.trick_test_add_parent(test_suite, "double assignment", "2642836719")
+    trick.trick_test_add_parent(test_suite, "int assignment", "2642836719")
+    trick.trick_test_add_parent(test_suite, "short assignment", "2642836719")
 
     # using typedef from within template
     test_so.obj.my_template_var_int = 66
-    TRICK_EXPECT_EQ( test_so.obj.my_template_var_int , 66, test_suite , "use typedef from within a template" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.my_template_var_int,
+        66,
+        test_suite,
+        "use typedef from within a template",
+    )
 
     # a more convoluted template
     test_so.obj.TTT_var.aa = 1000
-    TRICK_EXPECT_EQ( test_so.obj.TTT_var.aa , 1000, test_suite , "class complicated integer" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.TTT_var.aa, 1000, test_suite, "class complicated integer"
+    )
 
     test_so.obj.TTT_var.bb = 2000.0
-    TRICK_EXPECT_NEAR( test_so.obj.TTT_var.bb , 2000, 0.0001, test_suite , "class complicated double" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.TTT_var.bb, 2000, 0.0001, test_suite, "class complicated double"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Namespace
     test_suite = "namespace"
 
     test_so.ns_test.mass = trick.attach_units("lb", 10)
-    TRICK_EXPECT_NEAR( test_so.ns_test.mass , 4.53592, 0.0001, test_suite , "Class variable with units" )
-    trick.trick_test_add_parent( test_suite , "Class variable with units" , "2546878004")
+    TRICK_EXPECT_NEAR(
+        test_so.ns_test.mass, 4.53592, 0.0001, test_suite, "Class variable with units"
+    )
+    trick.trick_test_add_parent(test_suite, "Class variable with units", "2546878004")
 
     test_so.ns_test.bbp = trick.alloc_type(2, "my_ns::BB")
     test_so.ns_test.bbp[0].str = "hello"
     test_so.ns_test.bbp[1].str = "there"
     temp = test_so.ns_test.bbp[0].str + " " + test_so.ns_test.bbp[1].str
-    TRICK_EXPECT_EQ( str(temp) , "hello there", test_suite , "1D Class allocation" )
-    trick.trick_test_add_parent( test_suite , "1D Class allocation" , "2546878004")
+    TRICK_EXPECT_EQ(str(temp), "hello there", test_suite, "1D Class allocation")
+    trick.trick_test_add_parent(test_suite, "1D Class allocation", "2546878004")
 
     test_so.ns_test.bbpp = trick.alloc_type(4, "my_ns::BB *")
     test_so.ns_test.bbpp[0] = trick.alloc_type(3, "my_ns::BB")
     test_so.ns_test.bbpp[0][0].str = "bark"
     test_so.ns_test.bbpp[0][1].str = "meow"
     test_so.ns_test.bbpp[0][2].str = "quack"
-    temp = test_so.ns_test.bbpp[0][0].str + " " + test_so.ns_test.bbpp[0][1].str + " " + test_so.ns_test.bbpp[0][2].str
-    TRICK_EXPECT_EQ( str(temp) , "bark meow quack", test_suite , "2D Class allocation" )
-    trick.trick_test_add_parent( test_suite , "2D Class allocation" , "2546878004")
+    temp = (
+        test_so.ns_test.bbpp[0][0].str
+        + " "
+        + test_so.ns_test.bbpp[0][1].str
+        + " "
+        + test_so.ns_test.bbpp[0][2].str
+    )
+    TRICK_EXPECT_EQ(str(temp), "bark meow quack", test_suite, "2D Class allocation")
+    trick.trick_test_add_parent(test_suite, "2D Class allocation", "2546878004")
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Miscellaneous
     test_suite = "misc"
@@ -3243,47 +5920,80 @@ def main():
     test_so.obj.d = 10
     test_so.obj.ds = 15
     temp = test_so.obj.d + float(test_so.obj.ds)
-    TRICK_EXPECT_NEAR( temp , 25 , 0.0001 , test_suite , "Forced remove units" )
-    trick.trick_test_add_parent( test_suite , "Forced remove units" , "3339258059")
+    TRICK_EXPECT_NEAR(temp, 25, 0.0001, test_suite, "Forced remove units")
+    trick.trick_test_add_parent(test_suite, "Forced remove units", "3339258059")
 
-    temp = [ test_so.obj.d , test_so.obj.ds ]
-    TRICK_EXPECT_EQ( str(temp) , "[10 kg, 15 s]", test_suite , "List with different objects" )
+    temp = [test_so.obj.d, test_so.obj.ds]
+    TRICK_EXPECT_EQ(
+        str(temp), "[10 kg, 15 s]", test_suite, "List with different objects"
+    )
 
     test_so.obj.dp = trick.get_address("test_so.obj.d")
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[10 kg]", test_suite , "Get address" )
+    TRICK_EXPECT_EQ(str(test_so.obj.dp), "[10 kg]", test_suite, "Get address")
 
     test_so.obj.d += 1
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[11 kg]", test_suite , "Get address verification" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.dp), "[11 kg]", test_suite, "Get address verification"
+    )
 
     test_so.obj.da[2] = 45
     test_so.obj.dp = trick.get_address("test_so.obj.da[2]")
-    TRICK_EXPECT_EQ( str(test_so.obj.dp) , "[45 kg]", test_suite , "Get address mid-array" )
+    TRICK_EXPECT_EQ(str(test_so.obj.dp), "[45 kg]", test_suite, "Get address mid-array")
 
     temp_array = test_so.obj.daa[1]
-    TRICK_EXPECT_EQ( str(temp_array) , "[50.1 kg, 60 kg, 52.3 kg]", test_suite , "Local variable reference to array" )
+    TRICK_EXPECT_EQ(
+        str(temp_array),
+        "[50.1 kg, 60 kg, 52.3 kg]",
+        test_suite,
+        "Local variable reference to array",
+    )
 
     # populate double da[3] ;
     compStr = []
     for ii in range(3):
         test_so.obj.da[ii] = ii
-        compStr.append(f'{ii} kg')
+        compStr.append(f"{ii} kg")
 
     # Compare each element for da
     currIndex = 0
     for ii in range(3):
-        daStr = f'test_so.obj.da[{ii}]'
-        expResult = f'[{", ".join(compStr[currIndex:])}]'
-        test_so.obj.dp = trick.get_address(daStr) 
-        TRICK_EXPECT_EQ( str(test_so.obj.dp), expResult, test_suite , f'dp, Get 1D address {daStr}') 
-        TRICK_EXPECT_EQ( str(test_so.obj.get_dp()), expResult, test_suite , f'get_dp(), Get 1D address {daStr}')    
-        test_so.obj.dpp = trick.get_address(daStr) 
-        TRICK_EXPECT_EQ( str(test_so.obj.dpp), expResult, test_suite , f'dpp, Get 1D address {daStr}') 
-        TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()), expResult, test_suite , f'get_dpp(), Get 1D address {daStr}')
-        test_so.obj.dppp = trick.get_address(daStr) 
-        TRICK_EXPECT_EQ( str(test_so.obj.dppp), expResult, test_suite , f'dppp, Get 1D address {daStr}') 
-        TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()), expResult, test_suite , f'get_dppp(), Get 1D address {daStr}')            
+        daStr = f"test_so.obj.da[{ii}]"
+        expResult = f"[{', '.join(compStr[currIndex:])}]"
+        test_so.obj.dp = trick.get_address(daStr)
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.dp), expResult, test_suite, f"dp, Get 1D address {daStr}"
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_dp()),
+            expResult,
+            test_suite,
+            f"get_dp(), Get 1D address {daStr}",
+        )
+        test_so.obj.dpp = trick.get_address(daStr)
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.dpp), expResult, test_suite, f"dpp, Get 1D address {daStr}"
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_dpp()),
+            expResult,
+            test_suite,
+            f"get_dpp(), Get 1D address {daStr}",
+        )
+        test_so.obj.dppp = trick.get_address(daStr)
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.dppp),
+            expResult,
+            test_suite,
+            f"dppp, Get 1D address {daStr}",
+        )
+        TRICK_EXPECT_EQ(
+            str(test_so.obj.get_dppp()),
+            expResult,
+            test_suite,
+            f"get_dppp(), Get 1D address {daStr}",
+        )
         currIndex += 1
-    
+
     del compStr, daStr, expResult, currIndex
 
     # populate double daa[2][3] ;
@@ -3292,43 +6002,72 @@ def main():
     for ii in range(2):
         comp2dStr.append([])
         for jj in range(3):
-            test_so.obj.daa[ii][jj] = ii*10+jj
-            compStr.append(f'{ii*10+jj} kg')
-            comp2dStr[ii].append(f'{ii*10+jj} kg')
-            
+            test_so.obj.daa[ii][jj] = ii * 10 + jj
+            compStr.append(f"{ii * 10 + jj} kg")
+            comp2dStr[ii].append(f"{ii * 10 + jj} kg")
 
     # Compare each element for daa
     currIndex = 0
     for ii in range(2):
         for jj in range(3):
-            daStr = f'test_so.obj.daa[{ii}][{jj}]'
-            expResult = f'[{", ".join(compStr[currIndex:])}]'
+            daStr = f"test_so.obj.daa[{ii}][{jj}]"
+            expResult = f"[{', '.join(compStr[currIndex:])}]"
             # if jj == 0:
-            startingIndex = ii*3 + jj
-            exp2dResult = '['
+            startingIndex = ii * 3 + jj
+            exp2dResult = "["
             for kk in range(2):
                 nextIdx = startingIndex - 3
-                if nextIdx >= 0:   
+                if nextIdx >= 0:
                     startingIndex = nextIdx
                     if startingIndex < 0:
                         startingIndex = 0
-                else:                    
-                    exp2dResult += f'[{", ".join(comp2dStr[kk][startingIndex:])}],'
+                else:
+                    exp2dResult += f"[{', '.join(comp2dStr[kk][startingIndex:])}],"
                     startingIndex -= 3
                     if startingIndex < 0:
                         startingIndex = 0
 
             exp2dResult = exp2dResult[:-1]
-            exp2dResult += ']'
-            test_so.obj.dp = trick.get_address(daStr) 
-            TRICK_EXPECT_EQ( str(test_so.obj.dp), expResult, test_suite , f'dp, Get 2D address {daStr}') 
-            TRICK_EXPECT_EQ( str(test_so.obj.get_dp()), expResult, test_suite , f'get_dp(), Get 2D address {daStr}')
-            test_so.obj.dpp = trick.get_address(daStr) 
-            TRICK_EXPECT_EQ( str(test_so.obj.dpp), exp2dResult, test_suite , f'dpp, Get 2D address {daStr}') 
-            TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()), exp2dResult, test_suite , f'get_dpp(), Get 2D address {daStr}')
-            test_so.obj.dppp = trick.get_address(daStr) 
-            TRICK_EXPECT_EQ( str(test_so.obj.dppp), expResult, test_suite , f'dppp, Get 2D address {daStr}') 
-            TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()), expResult, test_suite , f'get_dppp(), Get 2D address {daStr}')            
+            exp2dResult += "]"
+            test_so.obj.dp = trick.get_address(daStr)
+            TRICK_EXPECT_EQ(
+                str(test_so.obj.dp),
+                expResult,
+                test_suite,
+                f"dp, Get 2D address {daStr}",
+            )
+            TRICK_EXPECT_EQ(
+                str(test_so.obj.get_dp()),
+                expResult,
+                test_suite,
+                f"get_dp(), Get 2D address {daStr}",
+            )
+            test_so.obj.dpp = trick.get_address(daStr)
+            TRICK_EXPECT_EQ(
+                str(test_so.obj.dpp),
+                exp2dResult,
+                test_suite,
+                f"dpp, Get 2D address {daStr}",
+            )
+            TRICK_EXPECT_EQ(
+                str(test_so.obj.get_dpp()),
+                exp2dResult,
+                test_suite,
+                f"get_dpp(), Get 2D address {daStr}",
+            )
+            test_so.obj.dppp = trick.get_address(daStr)
+            TRICK_EXPECT_EQ(
+                str(test_so.obj.dppp),
+                expResult,
+                test_suite,
+                f"dppp, Get 2D address {daStr}",
+            )
+            TRICK_EXPECT_EQ(
+                str(test_so.obj.get_dppp()),
+                expResult,
+                test_suite,
+                f"get_dppp(), Get 2D address {daStr}",
+            )
             currIndex += 1
 
     del compStr, daStr, expResult, exp2dResult, currIndex
@@ -3341,9 +6080,9 @@ def main():
         for jj in range(3):
             comp3dStr[ii].append([])
             for kk in range(4):
-                test_so.obj.daaa[ii][jj][kk] = ii*100+jj*10+kk
-                compStr.append(f'{ii*100+jj*10+kk} kg')
-                comp3dStr[ii][jj].append(f'{ii*100+jj*10+kk} kg')
+                test_so.obj.daaa[ii][jj][kk] = ii * 100 + jj * 10 + kk
+                compStr.append(f"{ii * 100 + jj * 10 + kk} kg")
+                comp3dStr[ii][jj].append(f"{ii * 100 + jj * 10 + kk} kg")
     print(comp3dStr)
 
     currIndex = 0
@@ -3351,140 +6090,189 @@ def main():
     for ii in range(2):
         for jj in range(3):
             for kk in range(4):
-                daStr = f'test_so.obj.daaa[{ii}][{jj}][{kk}]'
-                expResult = f'[{", ".join(compStr[currIndex:])}]'
-                startingIndex = ii*3*4 + jj*4 + kk
-                exp3dResult = '['
+                daStr = f"test_so.obj.daaa[{ii}][{jj}][{kk}]"
+                expResult = f"[{', '.join(compStr[currIndex:])}]"
+                startingIndex = ii * 3 * 4 + jj * 4 + kk
+                exp3dResult = "["
                 for ll in range(2):
-                    nextIdx = startingIndex - 3*4
-                    if nextIdx >= 0:   
+                    nextIdx = startingIndex - 3 * 4
+                    if nextIdx >= 0:
                         startingIndex = nextIdx
                         if startingIndex < 0:
                             startingIndex = 0
-                    else: 
-                        exp3dResult += '['
-                        for mm in range(3):                            
+                    else:
+                        exp3dResult += "["
+                        for mm in range(3):
                             nextIdx = startingIndex - 4
-                            if nextIdx >= 0:   
+                            if nextIdx >= 0:
                                 startingIndex = nextIdx
                                 if startingIndex < 0:
                                     startingIndex = 0
                             else:
-                                exp3dResult += f'[{", ".join(comp3dStr[ll][mm][startingIndex:])}],'
+                                exp3dResult += (
+                                    f"[{', '.join(comp3dStr[ll][mm][startingIndex:])}],"
+                                )
                                 startingIndex -= 4
                                 if startingIndex < 0:
                                     startingIndex = 0
                         exp3dResult = exp3dResult[:-1]
-                        exp3dResult += '],'
+                        exp3dResult += "],"
                 exp3dResult = exp3dResult[:-1]
-                exp3dResult += ']'
-                test_so.obj.dp = trick.get_address(daStr) 
-                TRICK_EXPECT_EQ( str(test_so.obj.dp), expResult, test_suite , f'dp, Get 3D address {daStr}') 
-                TRICK_EXPECT_EQ( str(test_so.obj.get_dp()), expResult, test_suite , f'get_dp(), Get 3D address {daStr}')    
-                test_so.obj.dpp = trick.get_address(daStr) 
-                TRICK_EXPECT_EQ( str(test_so.obj.dpp), expResult, test_suite , f'dpp, Get 3D address {daStr}') 
-                TRICK_EXPECT_EQ( str(test_so.obj.get_dpp()), expResult, test_suite , f'get_dpp(), Get 3D address {daStr}')
-                test_so.obj.dppp = trick.get_address(daStr) 
-                TRICK_EXPECT_EQ( str(test_so.obj.dppp), exp3dResult, test_suite , f'dppp, Get 3D address {daStr}') 
-                TRICK_EXPECT_EQ( str(test_so.obj.get_dppp()), exp3dResult, test_suite , f'get_dppp(), Get 3D address {daStr}')            
+                exp3dResult += "]"
+                test_so.obj.dp = trick.get_address(daStr)
+                TRICK_EXPECT_EQ(
+                    str(test_so.obj.dp),
+                    expResult,
+                    test_suite,
+                    f"dp, Get 3D address {daStr}",
+                )
+                TRICK_EXPECT_EQ(
+                    str(test_so.obj.get_dp()),
+                    expResult,
+                    test_suite,
+                    f"get_dp(), Get 3D address {daStr}",
+                )
+                test_so.obj.dpp = trick.get_address(daStr)
+                TRICK_EXPECT_EQ(
+                    str(test_so.obj.dpp),
+                    expResult,
+                    test_suite,
+                    f"dpp, Get 3D address {daStr}",
+                )
+                TRICK_EXPECT_EQ(
+                    str(test_so.obj.get_dpp()),
+                    expResult,
+                    test_suite,
+                    f"get_dpp(), Get 3D address {daStr}",
+                )
+                test_so.obj.dppp = trick.get_address(daStr)
+                TRICK_EXPECT_EQ(
+                    str(test_so.obj.dppp),
+                    exp3dResult,
+                    test_suite,
+                    f"dppp, Get 3D address {daStr}",
+                )
+                TRICK_EXPECT_EQ(
+                    str(test_so.obj.get_dppp()),
+                    exp3dResult,
+                    test_suite,
+                    f"get_dppp(), Get 3D address {daStr}",
+                )
                 currIndex += 1
-
 
     # "const int & cir" and "int const & icr" are pointed to i in the Ball_alex constructor
     test_so.obj.i = 55
-    TRICK_EXPECT_EQ( test_so.obj.cir , 55, test_suite , "Const reference" )
-    TRICK_EXPECT_EQ( test_so.obj.icr , 55, test_suite , "Const reference" )
+    TRICK_EXPECT_EQ(test_so.obj.cir, 55, test_suite, "Const reference")
+    TRICK_EXPECT_EQ(test_so.obj.icr, 55, test_suite, "Const reference")
 
-    #test_so.obj.cir = 99
-    #TRICK_EXPECT_EQ( test_so.obj.cir , 55, test_suite , "Const reference immutable test 1" )
-    #TRICK_EXPECT_EQ( test_so.obj.icr , 55, test_suite , "Const reference immutable test 1" )
+    # test_so.obj.cir = 99
+    # TRICK_EXPECT_EQ( test_so.obj.cir , 55, test_suite , "Const reference immutable test 1" )
+    # TRICK_EXPECT_EQ( test_so.obj.icr , 55, test_suite , "Const reference immutable test 1" )
 
-    #test_so.obj.icr = 98
-    #TRICK_EXPECT_EQ( test_so.obj.cir , 55, test_suite , "Const reference immutable test 2" )
-    #TRICK_EXPECT_EQ( test_so.obj.icr , 55, test_suite , "Const reference immutable test 2" )
+    # test_so.obj.icr = 98
+    # TRICK_EXPECT_EQ( test_so.obj.cir , 55, test_suite , "Const reference immutable test 2" )
+    # TRICK_EXPECT_EQ( test_so.obj.icr , 55, test_suite , "Const reference immutable test 2" )
 
-    test_so.obj.iiia = [ 300 , 400 , 500 , 600 , 700 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.iiia) , "[300, 400, 500, 600, 700, 0]", test_suite , "Typedeffed integer type" )
+    test_so.obj.iiia = [300, 400, 500, 600, 700]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.iiia),
+        "[300, 400, 500, 600, 700, 0]",
+        test_suite,
+        "Typedeffed integer type",
+    )
 
     # scd = static const double, csd = const static double, sdc = static double const
-    TRICK_EXPECT_NEAR( test_so.obj.scd , 1.2345 , 0.0001 , test_suite , "Static const access" )
-    TRICK_EXPECT_NEAR( test_so.obj.csd , 6.7890 , 0.0001 , test_suite , "Static const access" )
-    TRICK_EXPECT_NEAR( test_so.obj.sdc , 9.8765 , 0.0001 , test_suite , "Static const access" )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.scd, 1.2345, 0.0001, test_suite, "Static const access"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.csd, 6.7890, 0.0001, test_suite, "Static const access"
+    )
+    TRICK_EXPECT_NEAR(
+        test_so.obj.sdc, 9.8765, 0.0001, test_suite, "Static const access"
+    )
 
     # Attempt to change a static const double
-    #test_so.obj.scd = 90.0 ;
-    #TRICK_EXPECT_NEAR( test_so.obj.scd , 1.2345 , 0.0001 , test_suite , "Static const immutable test 1" )
-    #trick_mm.mmw.mm.read_checkpoint_from_string("test_so.obj.scd = 2.2222 ;")
-    #TRICK_EXPECT_NEAR( test_so.obj.scd , 1.2345 , 0.0001 , test_suite , "Static const immutable test 2" )
-    #test_so.obj.csd = 90.0 ;
-    #TRICK_EXPECT_NEAR( test_so.obj.csd , 6.7890 , 0.0001 , test_suite , "Static const immutable test 3" )
-    #trick_mm.mmw.mm.read_checkpoint_from_string("test_so.obj.csd = 2.2222 ;")
-    #TRICK_EXPECT_NEAR( test_so.obj.csd , 6.7890 , 0.0001 , test_suite , "Static const immutable test 4" )
-    #test_so.obj.sdc = 90.0 ;
-    #TRICK_EXPECT_NEAR( test_so.obj.sdc , 9.8765 , 0.0001 , test_suite , "Static const immutable test 5" )
-    #trick_mm.mmw.mm.read_checkpoint_from_string("test_so.obj.sdc = 2.2222 ;")
-    #TRICK_EXPECT_NEAR( test_so.obj.sdc , 9.8765 , 0.0001 , test_suite , "Static const immutable test 6" )
+    # test_so.obj.scd = 90.0 ;
+    # TRICK_EXPECT_NEAR( test_so.obj.scd , 1.2345 , 0.0001 , test_suite , "Static const immutable test 1" )
+    # trick_mm.mmw.mm.read_checkpoint_from_string("test_so.obj.scd = 2.2222 ;")
+    # TRICK_EXPECT_NEAR( test_so.obj.scd , 1.2345 , 0.0001 , test_suite , "Static const immutable test 2" )
+    # test_so.obj.csd = 90.0 ;
+    # TRICK_EXPECT_NEAR( test_so.obj.csd , 6.7890 , 0.0001 , test_suite , "Static const immutable test 3" )
+    # trick_mm.mmw.mm.read_checkpoint_from_string("test_so.obj.csd = 2.2222 ;")
+    # TRICK_EXPECT_NEAR( test_so.obj.csd , 6.7890 , 0.0001 , test_suite , "Static const immutable test 4" )
+    # test_so.obj.sdc = 90.0 ;
+    # TRICK_EXPECT_NEAR( test_so.obj.sdc , 9.8765 , 0.0001 , test_suite , "Static const immutable test 5" )
+    # trick_mm.mmw.mm.read_checkpoint_from_string("test_so.obj.sdc = 2.2222 ;")
+    # TRICK_EXPECT_NEAR( test_so.obj.sdc , 9.8765 , 0.0001 , test_suite , "Static const immutable test 6" )
 
     tester = trick.Test()
     output = tester.foo()
-    TRICK_EXPECT_EQ( output , "called foo", test_suite , "Instantiate class and capture return value" )
+    TRICK_EXPECT_EQ(
+        output, "called foo", test_suite, "Instantiate class and capture return value"
+    )
 
     tester.t = trick.Test()
     output = tester.t.foo()
-    TRICK_EXPECT_EQ( output , "called foo", test_suite , "Instantiate class pointer within class and capture return value" )
+    TRICK_EXPECT_EQ(
+        output,
+        "called foo",
+        test_suite,
+        "Instantiate class pointer within class and capture return value",
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Standard typedeffed integer types
     test_suite = "typedef_ints"
 
-    test_so.obj.i8t = 70 ;
-    TRICK_EXPECT_EQ( test_so.obj.i8t , 70, test_suite , "int8_t" )
-    trick.trick_test_add_parent( test_suite , "int8_t" , "2939597198")
+    test_so.obj.i8t = 70
+    TRICK_EXPECT_EQ(test_so.obj.i8t, 70, test_suite, "int8_t")
+    trick.trick_test_add_parent(test_suite, "int8_t", "2939597198")
 
-    test_so.obj.ui8t = 71 ;
-    TRICK_EXPECT_EQ( test_so.obj.ui8t , 71, test_suite , "uint8_t" )
+    test_so.obj.ui8t = 71
+    TRICK_EXPECT_EQ(test_so.obj.ui8t, 71, test_suite, "uint8_t")
 
-    test_so.obj.i16t = 80 ;
-    TRICK_EXPECT_EQ( test_so.obj.i16t , 80, test_suite , "int16_t" )
+    test_so.obj.i16t = 80
+    TRICK_EXPECT_EQ(test_so.obj.i16t, 80, test_suite, "int16_t")
 
-    test_so.obj.ui16t = 81 ;
-    TRICK_EXPECT_EQ( test_so.obj.ui16t , 81, test_suite , "uint16_t" )
+    test_so.obj.ui16t = 81
+    TRICK_EXPECT_EQ(test_so.obj.ui16t, 81, test_suite, "uint16_t")
 
-    test_so.obj.i32t = 90 ;
-    TRICK_EXPECT_EQ( test_so.obj.i32t , 90, test_suite , "int32_t" )
+    test_so.obj.i32t = 90
+    TRICK_EXPECT_EQ(test_so.obj.i32t, 90, test_suite, "int32_t")
 
-    test_so.obj.ui32t = 91 ;
-    TRICK_EXPECT_EQ( test_so.obj.ui32t , 91, test_suite , "uint32_t" )
+    test_so.obj.ui32t = 91
+    TRICK_EXPECT_EQ(test_so.obj.ui32t, 91, test_suite, "uint32_t")
 
-    test_so.obj.i64t = 100 ;
-    TRICK_EXPECT_EQ( test_so.obj.i64t , 100, test_suite , "int64_t" )
+    test_so.obj.i64t = 100
+    TRICK_EXPECT_EQ(test_so.obj.i64t, 100, test_suite, "int64_t")
 
-    test_so.obj.ui64t = 101 ;
-    TRICK_EXPECT_EQ( test_so.obj.ui64t , 101, test_suite , "uint64_t" )
+    test_so.obj.ui64t = 101
+    TRICK_EXPECT_EQ(test_so.obj.ui64t, 101, test_suite, "uint64_t")
 
-    test_so.obj.sizet = 111 ;
-    TRICK_EXPECT_EQ( test_so.obj.sizet , 111, test_suite , "size_t" )
+    test_so.obj.sizet = 111
+    TRICK_EXPECT_EQ(test_so.obj.sizet, 111, test_suite, "size_t")
 
-    test_so.obj.u_c = 121 ;
-    TRICK_EXPECT_EQ( test_so.obj.u_c , 121, test_suite , "u_char" )
+    test_so.obj.u_c = 121
+    TRICK_EXPECT_EQ(test_so.obj.u_c, 121, test_suite, "u_char")
 
-    test_so.obj.u_s = 131 ;
-    TRICK_EXPECT_EQ( test_so.obj.u_s , 131, test_suite , "u_short" )
+    test_so.obj.u_s = 131
+    TRICK_EXPECT_EQ(test_so.obj.u_s, 131, test_suite, "u_short")
 
-    test_so.obj.u_i = 141 ;
-    TRICK_EXPECT_EQ( test_so.obj.u_i , 141, test_suite , "u_int" )
+    test_so.obj.u_i = 141
+    TRICK_EXPECT_EQ(test_so.obj.u_i, 141, test_suite, "u_int")
 
-    test_so.obj.u_l = 151 ;
-    TRICK_EXPECT_EQ( test_so.obj.u_l , 151, test_suite , "u_long" )
+    test_so.obj.u_l = 151
+    TRICK_EXPECT_EQ(test_so.obj.u_l, 151, test_suite, "u_long")
 
-    test_so.obj.q = 161 ;
-    TRICK_EXPECT_EQ( test_so.obj.q , 161, test_suite , "quad_t" )
+    test_so.obj.q = 161
+    TRICK_EXPECT_EQ(test_so.obj.q, 161, test_suite, "quad_t")
 
-    test_so.obj.uq = 171 ;
-    TRICK_EXPECT_EQ( test_so.obj.uq , 171, test_suite , "u_quad_t" )
+    test_so.obj.uq = 171
+    TRICK_EXPECT_EQ(test_so.obj.uq, 171, test_suite, "u_quad_t")
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Exceptions
 
@@ -3493,82 +6281,98 @@ def main():
     test_case = "Array index out of bounds"
     try:
         test_so.obj.da[5] = 2.0
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "Double dimension array first index out of bounds"
     try:
         test_so.obj.daa[20][0] = 2.0
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "Double dimension array second index out of bounds"
     try:
         test_so.obj.daa[0][20] = 2.0
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "String too long"
     try:
         test_so.obj.ca = "dfjdslfjdsajfldjalfjdslafjdlsajfdsd"
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "Units mismatch"
     try:
-        test_so.obj.da[2] = trick.attach_units("s" , 2.0)
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        test_so.obj.da[2] = trick.attach_units("s", 2.0)
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "unit-ed value assigned to unitless variable"
     try:
-        test_so.obj.dno_units = trick.attach_units("in" , 60.6)
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        test_so.obj.dno_units = trick.attach_units("in", 60.6)
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "unit-ed value assigned to unitless integer array variable"
     try:
-        test_so.obj.ia = trick.attach_units("in" , [60, 70])
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        test_so.obj.ia = trick.attach_units("in", [60, 70])
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
     test_case = "unit-ed value assigned to unitless integer pointer variable"
     try:
-        test_so.obj.ip = trick.attach_units("in" , [60, 70])
-        trick.add_test_result( test_suite , test_case , "TRICK_EXPECT_EXCEPTION not tripped")
+        test_so.obj.ip = trick.attach_units("in", [60, 70])
+        trick.add_test_result(
+            test_suite, test_case, "TRICK_EXPECT_EXCEPTION not tripped"
+        )
     except:
-        trick.add_test_result( test_suite , test_case , "")
+        trick.add_test_result(test_suite, test_case, "")
 
-######################################################################################################################
+    ######################################################################################################################
 
     # Polymorphic assignments and access
     test_suite = "polymorphism"
 
-    #test_so.a = trick.Cat()
-    # use MM to allocate memory for a pointer declared in S_define 
+    # test_so.a = trick.Cat()
+    # use MM to allocate memory for a pointer declared in S_define
     test_so.a = trick.TMM_declare_var_s("Cat")
-    TRICK_EXPECT_EQ( test_so.a.id , 1, test_suite , "single abstract ptr" )
-    trick.trick_test_add_parent( test_suite , "single abstract ptr" , "1770735610")
-    #test_so.a.speak()
-    #test_so.a[0].speak()
-    #test_so.a = trick.Dog()
-    # use MM to allocate memory for a pointer declared in S_define 
+    TRICK_EXPECT_EQ(test_so.a.id, 1, test_suite, "single abstract ptr")
+    trick.trick_test_add_parent(test_suite, "single abstract ptr", "1770735610")
+    # test_so.a.speak()
+    # test_so.a[0].speak()
+    # test_so.a = trick.Dog()
+    # use MM to allocate memory for a pointer declared in S_define
     test_so.a = trick.TMM_declare_var_s("Dog")
-    TRICK_EXPECT_EQ( test_so.a.id , 2, test_suite , "single abstract ptr" )
+    TRICK_EXPECT_EQ(test_so.a.id, 2, test_suite, "single abstract ptr")
 
     test_so.aarray[0] = trick.Cat()
     test_so.aarray[1] = trick.Dog()
-    ids = [ test_so.aarray[0].id , test_so.aarray[1].id ]
-    TRICK_EXPECT_EQ( str(ids), "[1, 2]", test_suite , "fixed array of abstract ptrs" )
-    #test_so.aarray[0].speak()
-    #test_so.aarray[1].speak()
+    ids = [test_so.aarray[0].id, test_so.aarray[1].id]
+    TRICK_EXPECT_EQ(str(ids), "[1, 2]", test_suite, "fixed array of abstract ptrs")
+    # test_so.aarray[0].speak()
+    # test_so.aarray[1].speak()
 
     test_so.alist = trick.TMM_declare_var_1d("Abstract *", 4)
 
@@ -3576,32 +6380,39 @@ def main():
     test_so.alist[1] = trick.TMM_declare_var_s("Dog")
     test_so.alist[2] = trick.Cat()
     test_so.alist[3] = trick.Dog()
-    ids = [ test_so.alist[0].id , test_so.alist[1].id , test_so.alist[2].id , test_so.alist[3].id ]
-    TRICK_EXPECT_EQ( str(ids), "[1, 2, 1, 2]", test_suite , "fixed array of abstract ptrs" )
-    #test_so.alist[0].speak()
-    #test_so.alist[1].speak()
-    #test_so.alist[2].speak()
-    #test_so.alist[3].speak()
+    ids = [
+        test_so.alist[0].id,
+        test_so.alist[1].id,
+        test_so.alist[2].id,
+        test_so.alist[3].id,
+    ]
+    TRICK_EXPECT_EQ(
+        str(ids), "[1, 2, 1, 2]", test_suite, "fixed array of abstract ptrs"
+    )
+    # test_so.alist[0].speak()
+    # test_so.alist[1].speak()
+    # test_so.alist[2].speak()
+    # test_so.alist[3].speak()
 
     # test vector of abstract pointers
-    new_cat = trick.TMM_declare_var(trick.TRICK_STRUCTURED,"Cat",0,"my_cat",0,None)
+    new_cat = trick.TMM_declare_var(trick.TRICK_STRUCTURED, "Cat", 0, "my_cat", 0, None)
     test_so.vap.push_back(new_cat)
-    TRICK_EXPECT_EQ( test_so.vap[0].id , 1, test_suite , "std::vector of abstract ptrs" )
+    TRICK_EXPECT_EQ(test_so.vap[0].id, 1, test_suite, "std::vector of abstract ptrs")
 
-    new_dog = trick.TMM_declare_var(trick.TRICK_STRUCTURED,"Dog",0,"my_dog",0,None)
+    new_dog = trick.TMM_declare_var(trick.TRICK_STRUCTURED, "Dog", 0, "my_dog", 0, None)
     test_so.vap.push_back(new_dog)
-    TRICK_EXPECT_EQ( test_so.vap[1].id , 2, test_suite , "std::vector of abstract ptrs" )
+    TRICK_EXPECT_EQ(test_so.vap[1].id, 2, test_suite, "std::vector of abstract ptrs")
 
-    #test_so.vap[0].speak()
-    #test_so.vap[1].speak()
+    # test_so.vap[0].speak()
+    # test_so.vap[1].speak()
 
-    #drg0 = trick.DRAscii("cat_stuff")
-    #drg0.add_variable("my_cat.id")
-    #drg0.add_variable("my_dog.id")
-    #drg0.set_cycle(0.1)
-    #drg0.freq = trick.DR_Always
-    #drg0.thisown = 0
-    #trick.add_data_record_group(drg0, trick.DR_Buffer)
+    # drg0 = trick.DRAscii("cat_stuff")
+    # drg0.add_variable("my_cat.id")
+    # drg0.add_variable("my_dog.id")
+    # drg0.set_cycle(0.1)
+    # drg0.freq = trick.DR_Always
+    # drg0.thisown = 0
+    # trick.add_data_record_group(drg0, trick.DR_Buffer)
 
     test_so.vap2.push_back(new_dog)
     test_so.vap2.push_back(new_cat)
@@ -3609,181 +6420,352 @@ def main():
     # vector of vectors (experimental.  It does work!)
     test_so.vvap.push_back(test_so.vap)
     test_so.vvap.push_back(test_so.vap2)
-    #test_so.vvap[0][0].speak()
-    #test_so.vvap[0][1].speak()
-    #test_so.vvap[1][0].speak()
-    #test_so.vvap[1][1].speak()
+    # test_so.vvap[0][0].speak()
+    # test_so.vvap[0][1].speak()
+    # test_so.vvap[1][0].speak()
+    # test_so.vvap[1][1].speak()
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "array_sclicing"
 
     # fixed array
-    test_so.obj.ia = [ 10 , 20 , 30 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia[:]), "[10, 20, 30]", test_suite , "full slice, fixed array" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ia[1:]), "[20, 30]", test_suite , "slice with start value, fixed array" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ia[:2]), "[10, 20]", test_suite , "slice with end value, fixed array" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ia[::2]), "[10, 30]", test_suite , "sclice with step value, fixed array" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ia[-3:-1]), "[10, 20]", test_suite , "slice with negative start and end value, fixed array" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ia[::-2]), "[30, 10]", test_suite , "slice with negative step, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia[:]), "[10, 20, 30]", test_suite, "full slice, fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia[1:]),
+        "[20, 30]",
+        test_suite,
+        "slice with start value, fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia[:2]),
+        "[10, 20]",
+        test_suite,
+        "slice with end value, fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia[::2]),
+        "[10, 30]",
+        test_suite,
+        "sclice with step value, fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia[-3:-1]),
+        "[10, 20]",
+        test_suite,
+        "slice with negative start and end value, fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia[::-2]),
+        "[30, 10]",
+        test_suite,
+        "slice with negative step, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
+    test_so.obj.ia = [10, 20, 30]
     test_so.obj.ia[1:1] = 400
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[10, 400, 20]", test_suite , "slice insertion with scalar value, fixed array" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[10, 400, 20]",
+        test_suite,
+        "slice insertion with scalar value, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
-    test_so.obj.ia[1:1] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[10, 400, 500]", test_suite , "slice insertion of list, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    test_so.obj.ia[1:1] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[10, 400, 500]",
+        test_suite,
+        "slice insertion of list, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
+    test_so.obj.ia = [10, 20, 30]
     test_so.obj.ia[1:2] = 400
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[10, 400, 30]", test_suite , "slice replacement with scalar value, fixed array" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[10, 400, 30]",
+        test_suite,
+        "slice replacement with scalar value, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
-    test_so.obj.ia[0:1] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[400, 500, 20]", test_suite , "slice replacement list larger than sclice, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    test_so.obj.ia[0:1] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[400, 500, 20]",
+        test_suite,
+        "slice replacement list larger than sclice, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
-    test_so.obj.ia[0:2] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[400, 500, 30]", test_suite , "slice replacement list same size as sclice, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    test_so.obj.ia[0:2] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[400, 500, 30]",
+        test_suite,
+        "slice replacement list same size as sclice, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
-    test_so.obj.ia[0:3] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[400, 500, 0]", test_suite , "slice replacement list smaller than slice, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    test_so.obj.ia[0:3] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[400, 500, 0]",
+        test_suite,
+        "slice replacement list smaller than slice, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
-    test_so.obj.ia[:] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[400, 500, 0]", test_suite , "slice replacement full array, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    test_so.obj.ia[:] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[400, 500, 0]",
+        test_suite,
+        "slice replacement full array, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
+    test_so.obj.ia = [10, 20, 30]
     test_so.obj.ia[0:2:2] = 400
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[400, 20, 30]", test_suite , "slice replacement with scalar and step, fixed array" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[400, 20, 30]",
+        test_suite,
+        "slice replacement with scalar and step, fixed array",
+    )
 
-    test_so.obj.ia = [ 10 , 20 , 30]
-    test_so.obj.ia[0:3:2] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ia), "[400, 20, 500]", test_suite , "slice replacement with list and step, fixed array" )
+    test_so.obj.ia = [10, 20, 30]
+    test_so.obj.ia[0:3:2] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ia),
+        "[400, 20, 500]",
+        test_suite,
+        "slice replacement with list and step, fixed array",
+    )
 
     # pointer
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 ]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip[:]), "[10, 20, 30, 40]", test_suite , "full slice, pointer" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ip[1:]), "[20, 30, 40]", test_suite , "slice with start value, pointer" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ip[:2]), "[10, 20]", test_suite , "slice with end value, pointer" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ip[::2]), "[10, 30]", test_suite , "sclice with step value, pointer" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ip[-3:-1]), "[20, 30]", test_suite , "slice with negative start and end value, pointer" )
-    TRICK_EXPECT_EQ( str(test_so.obj.ip[::-2]), "[40, 20]", test_suite , "slice with negative step, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip[:]), "[10, 20, 30, 40]", test_suite, "full slice, pointer"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip[1:]),
+        "[20, 30, 40]",
+        test_suite,
+        "slice with start value, pointer",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip[:2]), "[10, 20]", test_suite, "slice with end value, pointer"
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip[::2]),
+        "[10, 30]",
+        test_suite,
+        "sclice with step value, pointer",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip[-3:-1]),
+        "[20, 30]",
+        test_suite,
+        "slice with negative start and end value, pointer",
+    )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip[::-2]),
+        "[40, 20]",
+        test_suite,
+        "slice with negative step, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
+    test_so.obj.ip = [10, 20, 30, 40, 50]
     test_so.obj.ip[1:1] = 400
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 20, 30, 40]", test_suite , "slice insertion with scalar value, pointer" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 20, 30, 40]",
+        test_suite,
+        "slice insertion with scalar value, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[1:1] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 500, 20, 30]", test_suite , "slice insertion of list, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[1:1] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 500, 20, 30]",
+        test_suite,
+        "slice insertion of list, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
+    test_so.obj.ip = [10, 20, 30, 40, 50]
     test_so.obj.ip[1:2] = 400
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 30, 40, 50]", test_suite , "slice replacement with scalar value, pointer" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 30, 40, 50]",
+        test_suite,
+        "slice replacement with scalar value, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[1:2] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 500, 30, 40]", test_suite , "slice replacement list larger than sclice, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[1:2] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 500, 30, 40]",
+        test_suite,
+        "slice replacement list larger than sclice, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[1:3] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 500, 40, 50]", test_suite , "slice replacement list same size as sclice, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[1:3] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 500, 40, 50]",
+        test_suite,
+        "slice replacement list same size as sclice, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[1:4] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 500, 50, 0]", test_suite , "slice replacement list smaller than slice, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[1:4] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 500, 50, 0]",
+        test_suite,
+        "slice replacement list smaller than slice, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[:] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[400, 500, 0, 0, 0]", test_suite , "slice replacement full array, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[:] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[400, 500, 0, 0, 0]",
+        test_suite,
+        "slice replacement full array, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
+    test_so.obj.ip = [10, 20, 30, 40, 50]
     test_so.obj.ip[1:3:2] = 400
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 30, 40, 50]", test_suite , "slice replacement with scalar and step, pointer" )
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 30, 40, 50]",
+        test_suite,
+        "slice replacement with scalar and step, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[1:4:2] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 30, 500, 50]", test_suite , "slice replacement with list and step, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[1:4:2] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 30, 500, 50]",
+        test_suite,
+        "slice replacement with list and step, pointer",
+    )
 
-    test_so.obj.ip = [ 10 , 20 , 30 , 40 , 50]
-    test_so.obj.ip[1:5:2] = [400 , 500]
-    TRICK_EXPECT_EQ( str(test_so.obj.ip), "[10, 400, 30, 500, 50]", test_suite , "slice replacement with list and step, pointer" )
+    test_so.obj.ip = [10, 20, 30, 40, 50]
+    test_so.obj.ip[1:5:2] = [400, 500]
+    TRICK_EXPECT_EQ(
+        str(test_so.obj.ip),
+        "[10, 400, 30, 500, 50]",
+        test_suite,
+        "slice replacement with list and step, pointer",
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "STL list support"
 
-    #print dir(test_so.obj.ls)
+    # print dir(test_so.obj.ls)
 
-    TRICK_EXPECT_EQ( test_so.obj.ls.empty(), 1, test_suite , "STL list empty true" )
-    test_so.obj.ls.push_back('string 1')
-    test_so.obj.ls.push_front('string 2')
-    test_so.obj.ls.push_back('string 3')
-    TRICK_EXPECT_EQ( test_so.obj.ls.empty(), 0, test_suite , "STL list empty false" )
-    TRICK_EXPECT_EQ( test_so.obj.ls.front(), "string 2", test_suite , "STL list front access" )
-    TRICK_EXPECT_EQ( test_so.obj.ls.back(), "string 3", test_suite , "STL list back access" )
-    TRICK_EXPECT_EQ( test_so.obj.ls.size(), 3, test_suite , "STL list size command" )
+    TRICK_EXPECT_EQ(test_so.obj.ls.empty(), 1, test_suite, "STL list empty true")
+    test_so.obj.ls.push_back("string 1")
+    test_so.obj.ls.push_front("string 2")
+    test_so.obj.ls.push_back("string 3")
+    TRICK_EXPECT_EQ(test_so.obj.ls.empty(), 0, test_suite, "STL list empty false")
+    TRICK_EXPECT_EQ(
+        test_so.obj.ls.front(), "string 2", test_suite, "STL list front access"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ls.back(), "string 3", test_suite, "STL list back access"
+    )
+    TRICK_EXPECT_EQ(test_so.obj.ls.size(), 3, test_suite, "STL list size command")
 
-    #test_so.obj.ls.insert(test_so.obj.ls.begin(), 'string 4')
-    #test_so.obj.ls.pop_front()
-    #test_so.obj.ls.erase(test_so.obj.ls.begin())
-    #for l in test_so.obj.ls:
+    # test_so.obj.ls.insert(test_so.obj.ls.begin(), 'string 4')
+    # test_so.obj.ls.pop_front()
+    # test_so.obj.ls.erase(test_so.obj.ls.begin())
+    # for l in test_so.obj.ls:
     #   print l
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "STL map support"
 
-    TRICK_EXPECT_EQ( test_so.obj.msi.empty(), 1, test_suite , "STL map empty true" )
+    TRICK_EXPECT_EQ(test_so.obj.msi.empty(), 1, test_suite, "STL map empty true")
 
-    test_so.obj.msi['key1'] = 50
-    test_so.obj.msi['key2'] = 60
-    test_so.obj.msi['key3'] = 70
-    
-    TRICK_EXPECT_EQ( test_so.obj.msi.empty(), 0, test_suite , "STL map empty false" )
-    TRICK_EXPECT_EQ( test_so.obj.msi['key1'], 50, test_suite , "STL map key/data insertion/access" )
-    TRICK_EXPECT_EQ( list(str(k) for k in test_so.obj.msi.keys()), ['key1', 'key2', 'key3'], test_suite , "STL map keys command" )
-    TRICK_EXPECT_EQ( test_so.obj.msi.values(), [50, 60, 70], test_suite , "STL map values command" )
-    TRICK_EXPECT_EQ( test_so.obj.msi.has_key('key1'), 1, test_suite , "STL map has_key true" )
-    TRICK_EXPECT_EQ( test_so.obj.msi.has_key('key4'), 0, test_suite , "STL map has_key false" )
-    TRICK_EXPECT_EQ( test_so.obj.msi.size(), 3, test_suite , "STL map size command" )
-    #print dict(test_so.obj.msi)
+    test_so.obj.msi["key1"] = 50
+    test_so.obj.msi["key2"] = 60
+    test_so.obj.msi["key3"] = 70
 
-######################################################################################################################
+    TRICK_EXPECT_EQ(test_so.obj.msi.empty(), 0, test_suite, "STL map empty false")
+    TRICK_EXPECT_EQ(
+        test_so.obj.msi["key1"], 50, test_suite, "STL map key/data insertion/access"
+    )
+    TRICK_EXPECT_EQ(
+        list(str(k) for k in test_so.obj.msi.keys()),
+        ["key1", "key2", "key3"],
+        test_suite,
+        "STL map keys command",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.msi.values(), [50, 60, 70], test_suite, "STL map values command"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.msi.has_key("key1"), 1, test_suite, "STL map has_key true"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.msi.has_key("key4"), 0, test_suite, "STL map has_key false"
+    )
+    TRICK_EXPECT_EQ(test_so.obj.msi.size(), 3, test_suite, "STL map size command")
+    # print dict(test_so.obj.msi)
+
+    ######################################################################################################################
 
     test_suite = "Templated SimObject"
 
-    TRICK_EXPECT_EQ( tso.t, 25, test_suite , "templated sim_object access member" )
-    TRICK_EXPECT_EQ( iftso.t, 25, test_suite , "inherit from templated sim_object access member" )
+    TRICK_EXPECT_EQ(tso.t, 25, test_suite, "templated sim_object access member")
+    TRICK_EXPECT_EQ(
+        iftso.t, 25, test_suite, "inherit from templated sim_object access member"
+    )
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "Templated SimObject"
-    TRICK_EXPECT_TRUE( test_so.test_true(), test_suite , "boolean function return" )
-    TRICK_EXPECT_FALSE( test_so.test_false(), test_suite , "boolean function return" )
+    TRICK_EXPECT_TRUE(test_so.test_true(), test_suite, "boolean function return")
+    TRICK_EXPECT_FALSE(test_so.test_false(), test_suite, "boolean function return")
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "SWIG Templates"
 
     test_so.obj.class_no_ns.tnns.x = 1
-    test_so.obj.class_no_ns.tns.y  = 2
+    test_so.obj.class_no_ns.tns.y = 2
     test_so.obj.class_ns.tnns.x = 3
-    test_so.obj.class_ns.tns.y  = 4
-    test_so.obj.foo1.bar.z  = 5
-    test_so.obj.foo2.bar.z  = 6
+    test_so.obj.class_ns.tns.y = 4
+    test_so.obj.foo1.bar.z = 5
+    test_so.obj.foo2.bar.z = 6
 
-    TRICK_EXPECT_EQ( test_so.obj.class_no_ns.tnns.x, 1, test_suite , "template member access" )
-    TRICK_EXPECT_EQ( test_so.obj.class_no_ns.tns.y, 2, test_suite , "template member access" )
-    TRICK_EXPECT_EQ( test_so.obj.class_ns.tnns.x, 3, test_suite , "template member access" )
-    TRICK_EXPECT_EQ( test_so.obj.class_ns.tns.y, 4, test_suite , "template member access" )
-    TRICK_EXPECT_EQ( test_so.obj.foo1.bar.z, 5, test_suite , "template member access" )
-    TRICK_EXPECT_EQ( test_so.obj.foo2.bar.z, 6, test_suite , "template member access" )
+    TRICK_EXPECT_EQ(
+        test_so.obj.class_no_ns.tnns.x, 1, test_suite, "template member access"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.class_no_ns.tns.y, 2, test_suite, "template member access"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.class_ns.tnns.x, 3, test_suite, "template member access"
+    )
+    TRICK_EXPECT_EQ(test_so.obj.class_ns.tns.y, 4, test_suite, "template member access")
+    TRICK_EXPECT_EQ(test_so.obj.foo1.bar.z, 5, test_suite, "template member access")
+    TRICK_EXPECT_EQ(test_so.obj.foo2.bar.z, 6, test_suite, "template member access")
 
-######################################################################################################################
+    ######################################################################################################################
 
     test_suite = "swig wstring support"
 
@@ -3793,27 +6775,86 @@ def main():
     test_so.obj.vec3_wstring[1] = "Hello World2"
     test_so.obj.vec3_wstring[2] = "Hello World3"
 
-    test_so.obj.m3x3_wstring = [ [ "Hello World1", "Hello World2", "Hello World3" ] , [ "Hello World4", "Hello World5", "Hello World6" ] , [ "Hello World7", "Hello World8", "Hello World9" ] ]
+    test_so.obj.m3x3_wstring = [
+        ["Hello World1", "Hello World2", "Hello World3"],
+        ["Hello World4", "Hello World5", "Hello World6"],
+        ["Hello World7", "Hello World8", "Hello World9"],
+    ]
 
     test_so.obj.ptr_wstring = trick.TMM_declare_var_1d("std::wstring", 2)
     test_so.obj.ptr_wstring[0] = "Hello World1"
     test_so.obj.ptr_wstring[1] = "Hello World2"
 
-    TRICK_EXPECT_EQ( test_so.obj._wstring , "Hello World" , test_suite , "wstring" )
-    TRICK_EXPECT_EQ( test_so.obj.vec3_wstring[0] , "Hello World1" , test_suite , "wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.vec3_wstring[1] , "Hello World2" , test_suite , "wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.vec3_wstring[2] , "Hello World3" , test_suite , "wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[0][0] , "Hello World1" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[0][1] , "Hello World2" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[0][2] , "Hello World3" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[1][0] , "Hello World4" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[1][1] , "Hello World5" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[1][2] , "Hello World6" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[2][0] , "Hello World7" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[2][1] , "Hello World8" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_wstring[2][2] , "Hello World9" , test_suite , "2D wstring fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.ptr_wstring[0] , "Hello World1" , test_suite , "wstring dynamic array" )
-    TRICK_EXPECT_EQ( test_so.obj.ptr_wstring[1] , "Hello World2" , test_suite , "wstring dynamic array" )
+    TRICK_EXPECT_EQ(test_so.obj._wstring, "Hello World", test_suite, "wstring")
+    TRICK_EXPECT_EQ(
+        test_so.obj.vec3_wstring[0], "Hello World1", test_suite, "wstring fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.vec3_wstring[1], "Hello World2", test_suite, "wstring fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.vec3_wstring[2], "Hello World3", test_suite, "wstring fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[0][0],
+        "Hello World1",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[0][1],
+        "Hello World2",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[0][2],
+        "Hello World3",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[1][0],
+        "Hello World4",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[1][1],
+        "Hello World5",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[1][2],
+        "Hello World6",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[2][0],
+        "Hello World7",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[2][1],
+        "Hello World8",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_wstring[2][2],
+        "Hello World9",
+        test_suite,
+        "2D wstring fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ptr_wstring[0], "Hello World1", test_suite, "wstring dynamic array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ptr_wstring[1], "Hello World2", test_suite, "wstring dynamic array"
+    )
 
     ######################################################################################################################
 
@@ -3825,30 +6866,89 @@ def main():
     test_so.obj.vec3_string[1] = "Hello World2"
     test_so.obj.vec3_string[2] = "Hello World3"
 
-    test_so.obj.m3x3_string = [ [ "Hello World1", "Hello World2", "Hello World3" ] , [ "Hello World4", "Hello World5", "Hello World6" ] , [ "Hello World7", "Hello World8", "Hello World9" ] ]
+    test_so.obj.m3x3_string = [
+        ["Hello World1", "Hello World2", "Hello World3"],
+        ["Hello World4", "Hello World5", "Hello World6"],
+        ["Hello World7", "Hello World8", "Hello World9"],
+    ]
 
     test_so.obj.ptr_string = trick.TMM_declare_var_1d("std::string", 2)
     test_so.obj.ptr_string[0] = "Hello World1"
     test_so.obj.ptr_string[1] = "Hello World2"
 
-    TRICK_EXPECT_EQ( test_so.obj._string , "Hello World" , test_suite , "string" )
-    TRICK_EXPECT_EQ( test_so.obj.vec3_string[0] , "Hello World1" , test_suite , "string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.vec3_string[1] , "Hello World2" , test_suite , "string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.vec3_string[2] , "Hello World3" , test_suite , "string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[0][0] , "Hello World1" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[0][1] , "Hello World2" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[0][2] , "Hello World3" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[1][0] , "Hello World4" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[1][1] , "Hello World5" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[1][2] , "Hello World6" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[2][0] , "Hello World7" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[2][1] , "Hello World8" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.m3x3_string[2][2] , "Hello World9" , test_suite , "2D string fixed array" )
-    TRICK_EXPECT_EQ( test_so.obj.ptr_string[0] , "Hello World1" , test_suite , "string dynamic array" )
-    TRICK_EXPECT_EQ( test_so.obj.ptr_string[1] , "Hello World2" , test_suite , "string dynamic array" )
+    TRICK_EXPECT_EQ(test_so.obj._string, "Hello World", test_suite, "string")
+    TRICK_EXPECT_EQ(
+        test_so.obj.vec3_string[0], "Hello World1", test_suite, "string fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.vec3_string[1], "Hello World2", test_suite, "string fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.vec3_string[2], "Hello World3", test_suite, "string fixed array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[0][0],
+        "Hello World1",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[0][1],
+        "Hello World2",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[0][2],
+        "Hello World3",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[1][0],
+        "Hello World4",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[1][1],
+        "Hello World5",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[1][2],
+        "Hello World6",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[2][0],
+        "Hello World7",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[2][1],
+        "Hello World8",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.m3x3_string[2][2],
+        "Hello World9",
+        test_suite,
+        "2D string fixed array",
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ptr_string[0], "Hello World1", test_suite, "string dynamic array"
+    )
+    TRICK_EXPECT_EQ(
+        test_so.obj.ptr_string[1], "Hello World2", test_suite, "string dynamic array"
+    )
+
 
 ######################################################################################################################
 
 if __name__ == "__main__":
     main()
-

--- a/trick_source/trick_swig/units_attach.i
+++ b/trick_source/trick_swig/units_attach.i
@@ -78,10 +78,11 @@ PyObject * attach_units(PyObject * in_units_obj , PyObject * in_object) {
         result_obj = SWIG_NewPointerObj(SWIG_as_voidptr(container), SWIG_TypeQuery("swig_double *") , SWIG_POINTER_OWN);
     } else if ( SWIG_IsOK(SWIG_ConvertPtr(in_object, &my_argp,SWIG_TypeQuery("swig_double *"), 0 ))) {
         swig_double * temp_m = reinterpret_cast< swig_double * >(my_argp) ;
-        if ( temp_m->units.compare("1") ) {
-            ut_unit * from = ut_parse(Trick::UdUnits::get_u_system(), temp_m->units.c_str(), UT_ASCII) ;
+        swig_double converted = *temp_m ;
+        if ( converted.units.compare("1") ) {
+            ut_unit * from = ut_parse(Trick::UdUnits::get_u_system(), converted.units.c_str(), UT_ASCII) ;
             if ( !from ) {
-                std::string temp_str = std::string("could not covert from units "+temp_m->units);
+                std::string temp_str = std::string("could not covert from units "+converted.units);
                 PyErr_SetString(PyExc_AttributeError,(temp_str.c_str()));
                 return NULL ;
             }
@@ -94,8 +95,8 @@ PyObject * attach_units(PyObject * in_units_obj , PyObject * in_object) {
 
             cv_converter * converter = ut_get_converter(from,to) ;
             if ( converter ) {
-                temp_m->value = cv_convert_double(converter, temp_m->value ) ;
-                temp_m->units = in_units ;
+                converted.value = cv_convert_double(converter, converted.value ) ;
+                converted.units = in_units ;
                 cv_free(converter) ;
             } else {
                 PyErr_SetString(PyExc_AttributeError,"Units conversion Error");
@@ -104,15 +105,16 @@ PyObject * attach_units(PyObject * in_units_obj , PyObject * in_object) {
             ut_free(from) ;
             ut_free(to) ;
         } else {
-            temp_m->units = in_units ;
+            converted.units = in_units ;
         }
-        result_obj = SWIG_NewPointerObj(SWIG_as_voidptr(new swig_double(*temp_m)), SWIG_TypeQuery("swig_double *") , SWIG_POINTER_OWN);
+        result_obj = SWIG_NewPointerObj(SWIG_as_voidptr(new swig_double(converted)), SWIG_TypeQuery("swig_double *") , SWIG_POINTER_OWN);
     } else if ( SWIG_IsOK(SWIG_ConvertPtr(in_object, &my_argp,SWIG_TypeQuery("swig_int *"), 0 ))) {
         swig_int * temp_m = reinterpret_cast< swig_int * >(my_argp) ;
-        if ( temp_m->units.compare("1") ) {
-            ut_unit * from = ut_parse(Trick::UdUnits::get_u_system(), temp_m->units.c_str(), UT_ASCII) ;
+        swig_int converted = *temp_m ;
+        if ( converted.units.compare("1") ) {
+            ut_unit * from = ut_parse(Trick::UdUnits::get_u_system(), converted.units.c_str(), UT_ASCII) ;
             if ( !from ) {
-                std::string temp_str = std::string("could not covert from units "+temp_m->units);
+                std::string temp_str = std::string("could not covert from units "+converted.units);
                 PyErr_SetString(PyExc_AttributeError,(temp_str.c_str())) ;
                 return NULL ;
             }
@@ -125,8 +127,8 @@ PyObject * attach_units(PyObject * in_units_obj , PyObject * in_object) {
 
             cv_converter * converter = ut_get_converter(from,to) ;
             if ( converter ) {
-                temp_m->value = (long long)cv_convert_double(converter, (double)temp_m->value ) ;
-                temp_m->units = in_units ;
+                converted.value = (long long)cv_convert_double(converter, (double)converted.value ) ;
+                converted.units = in_units ;
                 cv_free(converter) ;
             } else {
                 PyErr_SetString(PyExc_AttributeError,"Units conversion Error");
@@ -135,9 +137,9 @@ PyObject * attach_units(PyObject * in_units_obj , PyObject * in_object) {
             ut_free(from) ;
             ut_free(to) ;
         } else {
-            temp_m->units = in_units ;
+            converted.units = in_units ;
         }
-        result_obj = SWIG_NewPointerObj(SWIG_as_voidptr(new swig_int(*temp_m)), SWIG_TypeQuery("swig_int *") , SWIG_POINTER_OWN);
+        result_obj = SWIG_NewPointerObj(SWIG_as_voidptr(new swig_int(converted)), SWIG_TypeQuery("swig_int *") , SWIG_POINTER_OWN);
     } else if ( PyTuple_Check(in_object)) {
         unsigned int size = PyTuple_Size(in_object) ;
         result_obj = PyTuple_New(size) ;


### PR DESCRIPTION
Preserve the incoming object in attach_units by making a copy of it instead of mutating the original if it is convertible to a SWIG wrapper and add a test.