### PR TITLE
Support Swig 4.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 object_*
 io_src
 swig
+!include/trick/swig
+!share/trick/swig
+share/trick/swig/sim_services.py
+share/trick/swig/swig_double.py
+share/trick/swig/swig_int.py
+share/trick/swig/swig_ref.py
 lib
 lib64
 lib_Linux_*

--- a/include/trick/swig/swig_int_templates.hh
+++ b/include/trick/swig/swig_int_templates.hh
@@ -6,6 +6,7 @@
 #ifndef SWIG_INT_TEMPLATES_HH
 #define SWIG_INT_TEMPLATES_HH
 
+#include "trick/swig/swig_python_compat.hh"
 #include "trick/MemoryManager.hh"
 #include "trick/UdUnits.hh"
 #include "trick/attributes.h"
@@ -787,7 +788,7 @@ template<typename T, typename baseT > static void * typemap_in_2d( PyObject *inp
 }
 
 // Fixed size 3D array input typemap
-template<typename T, typename baseT > static void * typemap_in_3d( PyObject *input , unsigned int out_dim0, 
+template<typename T, typename baseT > static void * typemap_in_3d( PyObject *input , unsigned int out_dim0,
                                                                     unsigned int out_dim1, unsigned int out_dim2,
                                                                     const char * symname ) {
 
@@ -1100,4 +1101,3 @@ template <typename T> static int str_typemap_in_ptr(PyObject *input, T **output)
 }
 
 #endif
-

--- a/include/trick/swig/swig_int_templates.hh
+++ b/include/trick/swig/swig_int_templates.hh
@@ -6,10 +6,10 @@
 #ifndef SWIG_INT_TEMPLATES_HH
 #define SWIG_INT_TEMPLATES_HH
 
-#include "trick/swig/swig_python_compat.hh"
 #include "trick/MemoryManager.hh"
 #include "trick/UdUnits.hh"
 #include "trick/attributes.h"
+#include "trick/swig/swig_python_compat.hh"
 
 #include <string>
 #include <type_traits>
@@ -788,10 +788,10 @@ template<typename T, typename baseT > static void * typemap_in_2d( PyObject *inp
 }
 
 // Fixed size 3D array input typemap
-template<typename T, typename baseT > static void * typemap_in_3d( PyObject *input , unsigned int out_dim0,
-                                                                    unsigned int out_dim1, unsigned int out_dim2,
-                                                                    const char * symname ) {
-
+template <typename T, typename baseT>
+static void* typemap_in_3d(PyObject* input, unsigned int out_dim0, unsigned int out_dim1, unsigned int out_dim2,
+                           const char* symname)
+{
     //INT[ANY][ANY][ANY] IN
 
     void * argp2 ;

--- a/include/trick/swig/swig_macros.hh
+++ b/include/trick/swig/swig_macros.hh
@@ -1,6 +1,7 @@
 
 //These appear in some files but not in others.  define them if we have to.
 
+#include "trick/swig/swig_python_compat.hh"
 
 #ifdef SWIG
 #define __attribute__(x)

--- a/include/trick/swig/swig_python_compat.hh
+++ b/include/trick/swig/swig_python_compat.hh
@@ -1,0 +1,35 @@
+/**
+ * Trick's SWIG interface code uses a handful of Python C API calls the Python 2 way.
+ * Through SWIG 4.4 those names were supplied for Python 3 builds by compatibility macros in SWIG.
+ * SWIG 4.5.0 removed them (swig commit 79f7a2b), so Trick defines them here instead.
+ *
+ * Only the macros Trick uses are defined.
+ */
+
+#ifndef SWIG_PYTHON_COMPAT_HH
+#define SWIG_PYTHON_COMPAT_HH
+
+#include <Python.h>
+
+/* Under Python 2 these are the real C API names and must not be redefined. */
+#if PY_VERSION_HEX >= 0x03000000
+
+#ifndef PyInt_Check
+#define PyInt_Check(x) PyLong_Check(x)
+#endif
+
+#ifndef PyInt_AsLong
+#define PyInt_AsLong(x) PyLong_AsLong(x)
+#endif
+
+#ifndef PyInt_FromLong
+#define PyInt_FromLong(x) PyLong_FromLong(x)
+#endif
+
+#ifndef PyString_FromString
+#define PyString_FromString(x) PyUnicode_FromString(x)
+#endif
+
+#endif
+
+#endif

--- a/include/trick/swig/trick_swig.i
+++ b/include/trick/swig/trick_swig.i
@@ -107,33 +107,34 @@
 
 %{
 #include <sstream>
+#include "trick/swig/swig_python_compat.hh"
 #include "trick/UnitsMap.hh"
 #include "trick/MemoryManager.hh"
 #include "trick/reference.h"
 #include "trick/memorymanager_c_intf.h"
 #include "trick/PythonPrint.hh"
 
-#ifndef SWIG_as_voidptr 
-#define SWIG_as_voidptr(a) const_cast< void * >(static_cast< const void * >(a)) 
+#ifndef SWIG_as_voidptr
+#define SWIG_as_voidptr(a) const_cast< void * >(static_cast< const void * >(a))
 #endif
 
-#ifndef SWIG_as_voidptrptr 
-#define SWIG_as_voidptrptr(a) ((void)SWIG_as_voidptr(*a),reinterpret_cast< void** >(a)) 
+#ifndef SWIG_as_voidptrptr
+#define SWIG_as_voidptrptr(a) ((void)SWIG_as_voidptr(*a),reinterpret_cast< void** >(a))
 #endif
 
 #ifndef SWIG_IsOK
 #define SWIG_IsOK(r)               (r >= 0)
 #endif
 
-#ifndef SWIG_Error 
+#ifndef SWIG_Error
 #define SWIG_Error(code, msg) std::cout<<"SWIG_Error(errorcode, "<<msg<<")"<<std::endl
 #endif
 
-#ifndef SWIG_exception_fail 
-#define SWIG_exception_fail(code, msg) std::cout<<"SWIG_exception_fail(errorcode, "<<msg<<")"<<std::endl 
+#ifndef SWIG_exception_fail
+#define SWIG_exception_fail(code, msg) std::cout<<"SWIG_exception_fail(errorcode, "<<msg<<")"<<std::endl
 #endif
 
-#ifndef Py_RETURN_TRUE 
+#ifndef Py_RETURN_TRUE
 #define Py_RETURN_TRUE return Py_INCREF(Py_True), Py_True
 #endif
 
@@ -141,7 +142,7 @@
 #define Py_RETURN_FALSE return Py_INCREF(Py_False), Py_False
 #endif
 
-#ifndef Py_RETURN_NONE 
+#ifndef Py_RETURN_NONE
 #define Py_RETURN_NONE return Py_INCREF(Py_None), Py_None
 #endif
 
@@ -186,4 +187,3 @@ def _swig_setattr(self,class_type,name,value):
     return _swig_setattr_nondynamic(self,class_type,name,value,1)
 %}
 #endif
-

--- a/trick_source/trick_swig/swig_ref.cpp
+++ b/trick_source/trick_swig/swig_ref.cpp
@@ -1,18 +1,19 @@
-
-#include <iostream>
-#include <sstream>
-#include <algorithm>
 #include <Python.h>
-#include <stdlib.h>
 
-#include "trick/swig/swig_python_compat.hh"
 #include "trick/swig/swig_ref.hh"
+
+#include "trick/MemoryManager.hh"
+#include "trick/PythonPrint.hh"
+#include "trick/memorymanager_c_intf.h"
+#include "trick/swig/swig_convert_units.hh"
 #include "trick/swig/swig_double.hh"
 #include "trick/swig/swig_int.hh"
-#include "trick/swig/swig_convert_units.hh"
-#include "trick/MemoryManager.hh"
-#include "trick/memorymanager_c_intf.h"
-#include "trick/PythonPrint.hh"
+#include "trick/swig/swig_python_compat.hh"
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <stdlib.h>
 
 #if PY_VERSION_HEX < 0x02050000
 #define Py_ssize_t int

--- a/trick_source/trick_swig/swig_ref.cpp
+++ b/trick_source/trick_swig/swig_ref.cpp
@@ -5,6 +5,7 @@
 #include <Python.h>
 #include <stdlib.h>
 
+#include "trick/swig/swig_python_compat.hh"
 #include "trick/swig/swig_ref.hh"
 #include "trick/swig/swig_double.hh"
 #include "trick/swig/swig_int.hh"
@@ -614,7 +615,7 @@ int swig_ref::__setitem__( int ii, PyObject * obj1 ) {
             } else {
                 // Original 1D assignment code for fixed-size arrays
                 first_node = curr_node = ( V_TREE * )calloc( 1 , sizeof(V_TREE) ) ;
-                
+
                 for( jj = 0 ; jj < size ; jj++ ) {
                     PyObject *o = PyTuple_GetItem( obj1 , jj ) ;
                     newVTreeNode(&curr_node) ;

--- a/trick_source/trick_swig/units_attach.i
+++ b/trick_source/trick_swig/units_attach.i
@@ -7,6 +7,7 @@
 %inline %{
 #include <frameobject.h>
 #include <udunits2.h>
+#include "trick/swig/swig_python_compat.hh"
 #include "trick/swig/swig_double.hh"
 #include "trick/map_trick_units_to_udunits.hh"
 #include "trick/IPPython.hh"


### PR DESCRIPTION
Swig 4.5.0 dropped support for Python 2. With that, they dropped compatibility `#define`s that allowed using the python 2 names for C API calls with Python 3.

This PR adds back the `#define`s that Trick uses.