### PR TITLE
Add code to close file handles of a job when it's done and a test case.

### DIFF
--- a/share/trick/trickops/WorkflowCommon.py
+++ b/share/trick/trickops/WorkflowCommon.py
@@ -6,20 +6,39 @@ subprocesses to get progress bars and curses display logic for free!
 """
 
 import argparse
-import curses, textwrap
-import pdb, sys, datetime, time, socket, stat
-import subprocess, signal, logging
-import os, re, collections
-import multiprocessing, platform
+import collections
+import curses
+import datetime
+import logging
+import multiprocessing
+import os
+import pdb
+import platform
+import re
+import signal
+import socket
+import stat
+import subprocess
+import sys
+import textwrap
+import time
 from contextlib import contextmanager
-from ColorStr import ColorStr
 from pathlib import Path
+
+from ColorStr import ColorStr
 
 # Create a global color printer
 printer = ColorStr()
 
+
 # UTILITY FUNCTIONS
-def run_subprocess(command, m_shell=False, m_cwd=None, m_stdout=subprocess.PIPE, m_stderr=subprocess.PIPE):
+def run_subprocess(
+    command,
+    m_shell=False,
+    m_cwd=None,
+    m_stdout=subprocess.PIPE,
+    m_stderr=subprocess.PIPE,
+):
     """
     Utility method for running a subprocess and returning stdout, stderr, and return code
 
@@ -48,14 +67,17 @@ def run_subprocess(command, m_shell=False, m_cwd=None, m_stdout=subprocess.PIPE,
         Collection of process's final exit code, stdout, and stderr
     """
     result = collections.namedtuple("Process", ["code", "stdout", "stderr"])
-    p = subprocess.Popen(command, shell=m_shell, cwd=m_cwd, stdout=m_stdout, stderr=m_stderr)
+    p = subprocess.Popen(
+        command, shell=m_shell, cwd=m_cwd, stdout=m_stdout, stderr=m_stderr
+    )
     result.stdout, result.stderr = p.communicate()
-    if (result.stdout != None):
-        result.stdout = result.stdout.decode(errors='ignore')
-    if (result.stderr != None):
-        result.stderr = result.stderr.decode(errors='ignore')
+    if result.stdout != None:
+        result.stdout = result.stdout.decode(errors="ignore")
+    if result.stderr != None:
+        result.stderr = result.stderr.decode(errors="ignore")
     result.code = p.returncode
     return result
+
 
 def validate_output_file(filename):
     """
@@ -80,9 +102,10 @@ def validate_output_file(filename):
     filename = os.path.abspath(filename)
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     Path(filename).touch(exist_ok=True)
-    return (filename)
+    return filename
 
-def tprint(line, color='ENDC', verbosity='INFO'):
+
+def tprint(line, color="ENDC", verbosity="INFO"):
     """
     Utility method for writing text to both the log and stdout, with optional
     color for stdout
@@ -95,17 +118,18 @@ def tprint(line, color='ENDC', verbosity='INFO'):
         Color/style of text. Options are listed in Colorstr() class.
     """
     colorLine = printer.colorstr(line, color)
-    sys.stdout.write(colorLine+"\n")
-    if verbosity == 'INFO':
+    sys.stdout.write(colorLine + "\n")
+    if verbosity == "INFO":
         logging.info(line)
-    elif verbosity == 'DEBUG':
+    elif verbosity == "DEBUG":
         logging.debug(line)
-    elif verbosity == 'ERROR':
+    elif verbosity == "ERROR":
         logging.error(line)
-    elif verbosity == 'WARNING':
+    elif verbosity == "WARNING":
         logging.warning(line)
     else:
         pass
+
 
 def create_progress_bar(fraction, text):
     """
@@ -127,12 +151,13 @@ def create_progress_bar(fraction, text):
     str
         A text-based progress bar string of length 80
     """
-    text = ' ' + text + ' '
+    text = " " + text + " "
     length = len(text)
-    bar = list('[{0:<78}]'.format('=' * min(78, int(round(fraction * 78)))))
+    bar = list("[{0:<78}]".format("=" * min(78, int(round(fraction * 78)))))
     index = int((len(bar) - length) / 2)
     bar[index : index + length] = text
-    return ''.join(bar)
+    return "".join(bar)
+
 
 def sanitize_cpus(num_cpus, num_tasks, fallback_cpus):
     """
@@ -161,23 +186,24 @@ def sanitize_cpus(num_cpus, num_tasks, fallback_cpus):
         - a description of the boundary violated (may be None)
     """
     if num_cpus < 1:
-        return (1, 'minimum allowable value')
+        return (1, "minimum allowable value")
     else:
         try:
             maximum = multiprocessing.cpu_count()
-            source = 'number of logical CPUs'
+            source = "number of logical CPUs"
         except:
             maximum = 16
-            source = 'maximum allowed value'
+            source = "maximum allowed value"
 
         if num_tasks < maximum:
             maximum = num_tasks
-            source = 'number of runs'
+            source = "number of runs"
 
         if num_cpus > maximum:
             return (maximum, source)
 
     return (num_cpus, None)
+
 
 def unixify_string(string):
     """
@@ -196,7 +222,8 @@ def unixify_string(string):
     str
         the sanitized string
     """
-    return re.sub("['/]", '_', re.sub('[()!?,]', '', string)).replace(' ', '_')
+    return re.sub("['/]", "_", re.sub("[()!?,]", "", string)).replace(" ", "_")
+
 
 # CLASSES
 class Job(object):
@@ -205,11 +232,12 @@ class Job(object):
     for getting status information. More specific types of Jobs should inherit from
     this base clasee.
     """
-    enums = ['NOT_STARTED', 'RUNNING', 'SUCCESS', 'FAILED', 'TIMEOUT']
-    Status = collections.namedtuple('Status', enums)(*(range(len(enums))))
 
-    _success_progress_bar = create_progress_bar(1, 'Success')
-    _failed_progress_bar = create_progress_bar(1, 'Failed')
+    enums = ["NOT_STARTED", "RUNNING", "SUCCESS", "FAILED", "TIMEOUT"]
+    Status = collections.namedtuple("Status", enums)(*(range(len(enums))))
+
+    _success_progress_bar = create_progress_bar(1, "Success")
+    _failed_progress_bar = create_progress_bar(1, "Failed")
 
     def _translate_status(self):
         """
@@ -217,12 +245,20 @@ class Job(object):
         codes if FAIL.
         """
         text, color = {
-            Job.Status.NOT_STARTED: ('NOT RUN', 'DARK_YELLOW'),
-            Job.Status.SUCCESS: ('OK', 'DARK_GREEN'),
-            Job.Status.FAILED: ('FAIL:' + str(self._expected_exit_status) + '/' +
-             str(self._exit_status), 'DARK_RED'),
-            Job.Status.TIMEOUT: ('TIMEOUT after ' + str(self._timeout) + ' seconds', 'YELLOW') 
-            }[self.get_status()]
+            Job.Status.NOT_STARTED: ("NOT RUN", "DARK_YELLOW"),
+            Job.Status.SUCCESS: ("OK", "DARK_GREEN"),
+            Job.Status.FAILED: (
+                "FAIL:"
+                + str(self._expected_exit_status)
+                + "/"
+                + str(self._exit_status),
+                "DARK_RED",
+            ),
+            Job.Status.TIMEOUT: (
+                "TIMEOUT after " + str(self._timeout) + " seconds",
+                "YELLOW",
+            ),
+        }[self.get_status()]
         return printer.colorstr(text, color)
 
     def __init__(self, name, command, log_file, expected_exit_status=0):
@@ -256,14 +292,19 @@ class Job(object):
         """
         # Guard against multiple starts
         if self.get_status != self.Status.RUNNING:
-          logging.debug('Executing command: ' + self._command)
-          self._start_time = time.time()
-          self._stdin_file = open(os.devnull, 'r')
-          self._log_file = open(self.log_file, 'w')
-          self._process = subprocess.Popen(
-            self._command, stdout=self._log_file, stderr=self._log_file,
-            stdin=self._stdin_file, shell=True, preexec_fn=os.setsid,
-            close_fds=True)
+            logging.debug("Executing command: " + self._command)
+            self._start_time = time.time()
+            self._stdin_file = open(os.devnull, "r")
+            self._log_file = open(self.log_file, "w")
+            self._process = subprocess.Popen(
+                self._command,
+                stdout=self._log_file,
+                stderr=self._log_file,
+                stdin=self._stdin_file,
+                shell=True,
+                preexec_fn=os.setsid,
+                close_fds=True,
+            )
 
     def _close_files(self):
         """
@@ -310,7 +351,11 @@ class Job(object):
         if self._stop_time is None:
             self._stop_time = time.time()
 
-        return self.Status.SUCCESS if self._exit_status is self._expected_exit_status else self.Status.FAILED
+        return (
+            self.Status.SUCCESS
+            if self._exit_status is self._expected_exit_status
+            else self.Status.FAILED
+        )
 
     def get_expected_exit_status(self):
         return self._expected_exit_status
@@ -356,7 +401,7 @@ class Job(object):
         str
             A string to be displayed when in the NOT_STARTED state.
         """
-        return 'Not started yet'
+        return "Not started yet"
 
     def _running_string(self):
         """
@@ -367,8 +412,7 @@ class Job(object):
         str
             A string to be displayed when in the RUNNING state.
         """
-        return 'Elapsed Time: {0:7.1f} sec'.format(
-          time.time() - self._start_time)
+        return "Elapsed Time: {0:7.1f} sec".format(time.time() - self._start_time)
 
     def _success_string(self):
         """
@@ -413,11 +457,9 @@ class Job(object):
         str
             A string to be displayed when this Job is done.
         """
-        return 'Total Time:   {0:7.1f} sec'.format(
-          self._stop_time - self._start_time)
+        return "Total Time:   {0:7.1f} sec".format(self._stop_time - self._start_time)
 
-
-    def report( self, indent='', width=100):
+    def report(self, indent="", width=100):
         """
         Return a colored report string for this job.
 
@@ -426,16 +468,26 @@ class Job(object):
         str
             A olored report string
         """
-        if self.get_status() ==  Job.Status.NOT_STARTED:
-           prepend = printer.colorstr('NOT RUN     ', 'DARK_YELLOW')
-        elif self.get_expected_exit_status() ==  self.get_exit_status():
-           prepend = printer.colorstr('OK          ', 'DARK_GREEN')
+        if self.get_status() == Job.Status.NOT_STARTED:
+            prepend = printer.colorstr("NOT RUN     ", "DARK_YELLOW")
+        elif self.get_expected_exit_status() == self.get_exit_status():
+            prepend = printer.colorstr("OK          ", "DARK_GREEN")
         else:
-           prepend = printer.colorstr('FAIL:%-10s ' %
-               (str(self.get_exit_status())+'/'+str(self.get_expected_exit_status())) , 'DARK_RED')
-        reportStr = indent + prepend + ("  %-s" % ( textwrap.shorten(self.name, width=width-10)))
+            prepend = printer.colorstr(
+                "FAIL:%-10s "
+                % (
+                    str(self.get_exit_status())
+                    + "/"
+                    + str(self.get_expected_exit_status())
+                ),
+                "DARK_RED",
+            )
+        reportStr = (
+            indent
+            + prepend
+            + ("  %-s" % (textwrap.shorten(self.name, width=width - 10)))
+        )
         return reportStr
-
 
     def die(self):
         """
@@ -449,10 +501,12 @@ class Job(object):
             pass
         self._close_files()
 
+
 class FileSizeJob(Job):
     """
     A build job is a subclass of Job() which estimates its progress via file size.
     """
+
     def __init__(self, name, command, log_file, size):
         """
         Initialize this instance.
@@ -476,20 +530,27 @@ class FileSizeJob(Job):
         return super(FileSizeJob, self).get_status_string_line_count() + 1
 
     def _not_started_string(self):
-        return super(FileSizeJob, self)._not_started_string() + '\n'
+        return super(FileSizeJob, self)._not_started_string() + "\n"
 
     def _running_string(self):
         progress = os.path.getsize(self._log_file.name) / float(self.size)
-        return (super(FileSizeJob, self)._running_string() + '\n' +
-          create_progress_bar(progress, '{0:.1f}%'.format(100 * progress)))
+        return (
+            super(FileSizeJob, self)._running_string()
+            + "\n"
+            + create_progress_bar(progress, "{0:.1f}%".format(100 * progress))
+        )
 
     def _success_string(self):
-        return (super(FileSizeJob, self)._success_string() + '\n' +
-          self._success_progress_bar)
+        return (
+            super(FileSizeJob, self)._success_string()
+            + "\n"
+            + self._success_progress_bar
+        )
 
     def _failed_string(self):
-        return (super(FileSizeJob, self)._failed_string() + '\n' +
-          self._failed_progress_bar)
+        return (
+            super(FileSizeJob, self)._failed_string() + "\n" + self._failed_progress_bar
+        )
 
 
 class WorkflowCommon:
@@ -501,7 +562,15 @@ class WorkflowCommon:
       * Provide log directory where output for jobs can be written
       * Get installed packages, host, and other OS information
     """
-    def __init__( self, project_top_level, log_dir='/tmp/', log_level=logging.DEBUG, env='', quiet=False ):
+
+    def __init__(
+        self,
+        project_top_level,
+        log_dir="/tmp/",
+        log_level=logging.DEBUG,
+        env="",
+        quiet=False,
+    ):
         """
         Initialize this instance.
 
@@ -524,8 +593,14 @@ class WorkflowCommon:
         self.project_top_level = project_top_level
         self.log_dir = log_dir  # Where all logged output will go
         # self.log is where all logging for python script layer goes
-        self.log = validate_output_file( os.path.join(self.log_dir,'log.' +
-          unixify_string(str(datetime.datetime.now()).replace(':','-')) + '.txt'))
+        self.log = validate_output_file(
+            os.path.join(
+                self.log_dir,
+                "log."
+                + unixify_string(str(datetime.datetime.now()).replace(":", "-"))
+                + ".txt",
+            )
+        )
         self.env = env  # Project environment literal string, e.g. "source bashrc"
         self.creation_time = time.time()  # When this instance was created
         self.host_name = socket.gethostname()
@@ -537,7 +612,7 @@ class WorkflowCommon:
         else:
             self.quiet = True
         logging.basicConfig(filename=self.log, level=log_level)
-        os.chdir(self.project_top_level) # Automatically chdir to top of project
+        os.chdir(self.project_top_level)  # Automatically chdir to top of project
 
     def _cleanup(self):
         """
@@ -563,20 +638,28 @@ class WorkflowCommon:
             A list of installed packages, or None if they cannot be determined
         """
         self.this_os = self.get_operating_system()
-        if self.this_os == 'debian':
+        if self.this_os == "debian":
             list_cmd = "dpkg-query -W -f='${binary:Package}\n'"
-        elif self.this_os == 'redhat':
+        elif self.this_os == "redhat":
             list_cmd = "rpm -qa "
         else:
             return None
 
-        result = run_subprocess(command=list_cmd, m_shell=True,
-                                m_stdout=subprocess.PIPE, m_stderr=subprocess.PIPE)
+        result = run_subprocess(
+            command=list_cmd,
+            m_shell=True,
+            m_stdout=subprocess.PIPE,
+            m_stderr=subprocess.PIPE,
+        )
         if result.code != 0:
             if verbose:
-                tprint("ERROR: Trouble finding platform packages, error:\n" + result.stderr, 'DARK_RED')
+                tprint(
+                    "ERROR: Trouble finding platform packages, error:\n"
+                    + result.stderr,
+                    "DARK_RED",
+                )
             return None
-        return(result.stdout.strip().split("\n"))
+        return result.stdout.strip().split("\n")
 
     def get_operating_system(self):
         """
@@ -588,26 +671,34 @@ class WorkflowCommon:
             Returns one of these strings: debian, redhat, windows, darwin, unknown
         """
         # Windows is easy
-        if platform.system().lower() == 'windows':
-            return 'windows'
+        if platform.system().lower() == "windows":
+            return "windows"
         # Darwin (Mac OSX) is easy
-        if platform.system().lower() == 'darwin':
-            return 'darwin'
+        if platform.system().lower() == "darwin":
+            return "darwin"
         # Linux is hard
         # NOTE: sys.platform will not distinguish between flavors of linux and platform.linux_distribution()
         #   doesn't exist on all linux distributions! Also we can't rely on 'import distro' because it's
         #   only pip-installable at the moment. -Jordan 2/2021
         # Determine platform the old fashioned way, by seeing what package manager exists
-        rpm_exist = not run_subprocess(command='which rpm', m_shell=True,
-            m_stdout=subprocess.PIPE, m_stderr=subprocess.PIPE).code
-        apt_exist = not run_subprocess(command='which apt', m_shell=True,
-            m_stdout=subprocess.PIPE, m_stderr=subprocess.PIPE).code
+        rpm_exist = not run_subprocess(
+            command="which rpm",
+            m_shell=True,
+            m_stdout=subprocess.PIPE,
+            m_stderr=subprocess.PIPE,
+        ).code
+        apt_exist = not run_subprocess(
+            command="which apt",
+            m_shell=True,
+            m_stdout=subprocess.PIPE,
+            m_stderr=subprocess.PIPE,
+        ).code
         if rpm_exist:
-            return 'redhat'
+            return "redhat"
         elif apt_exist:
-            return 'debian'
+            return "debian"
         else:
-            return 'unknown'
+            return "unknown"
 
     def execute_jobs(self, jobs, max_concurrent=None, header=None, job_timeout=None):
         """
@@ -628,14 +719,16 @@ class WorkflowCommon:
             True if any job failed or was not run.
             False if all jobs completed successfully.
         """
-        if not os.environ.get('TERM') and not self.quiet:
+        if not os.environ.get("TERM") and not self.quiet:
             tprint(
-              'The TERM environment variable must be set when\n'
-              'TrickWorkflow.quiet is False. This is usually set by one\n'
-              "of the shell's configuration files (.profile, .cshrc, etc).\n"
-              'However, if this was executed via a non-interactive,\n'
-              "non-login shell (for instance: ssh <machine> '<command>'), it\n"
-              'may not be automatically set.', 'DARK_RED')
+                "The TERM environment variable must be set when\n"
+                "TrickWorkflow.quiet is False. This is usually set by one\n"
+                "of the shell's configuration files (.profile, .cshrc, etc).\n"
+                "However, if this was executed via a non-interactive,\n"
+                "non-login shell (for instance: ssh <machine> '<command>'), it\n"
+                "may not be automatically set.",
+                "DARK_RED",
+            )
             return True
 
         num_jobs = len(jobs)
@@ -643,14 +736,16 @@ class WorkflowCommon:
             max_concurrent = num_jobs
 
         if header:
-            header += '\n'
+            header += "\n"
         else:
-            header = ''
+            header = ""
 
         header += (
-          'Executing {0} total jobs, running up to {1} simultaneously.\n'
-          .format(num_jobs, max_concurrent) +
-          'Press CTRL+C to terminate early.\n')
+            "Executing {0} total jobs, running up to {1} simultaneously.\n".format(
+                num_jobs, max_concurrent
+            )
+            + "Press CTRL+C to terminate early.\n"
+        )
 
         logging.info(header)
 
@@ -695,7 +790,7 @@ class WorkflowCommon:
                 # extra lines, so pick a realy big width that isn't
                 # likely to cause wrapping. We also need a final
                 # additional line for the cursor to end on.
-                header_pad = curses.newpad(header.count('\n') + 1, 1000)
+                header_pad = curses.newpad(header.count("\n") + 1, 1000)
                 header_pad.addstr(header)
 
                 # Create a pad for the status.
@@ -705,9 +800,11 @@ class WorkflowCommon:
                 # + a blank line after each status string
                 # + a final line for the cursor to end on
                 status_pad = curses.newpad(
-                  sum(job.get_status_string_line_count() for job in jobs) +
-                    2 * len(jobs) + 1,
-                  1000)
+                    sum(job.get_status_string_line_count() for job in jobs)
+                    + 2 * len(jobs)
+                    + 1,
+                    1000,
+                )
 
                 # The top visible status pad line.
                 # Used for scrolling.
@@ -715,24 +812,28 @@ class WorkflowCommon:
                 header_height = header_pad.getmaxyx()[0]
                 status_height = status_pad.getmaxyx()[0]
 
-            while any(job.get_status() in
-              [job.Status.NOT_STARTED, job.Status.RUNNING]
-              for job in jobs):
-
+            while any(
+                job.get_status() in [job.Status.NOT_STARTED, job.Status.RUNNING]
+                for job in jobs
+            ):
                 # Start waiting jobs if cpus are available
-                waitingJobs = [job for job in jobs
-                  if job.get_status() is job.Status.NOT_STARTED]
+                waitingJobs = [
+                    job for job in jobs if job.get_status() is job.Status.NOT_STARTED
+                ]
 
                 if waitingJobs:
-                    available_cpus = max_concurrent - sum(1 for job in jobs
-                      if job.get_status() is job.Status.RUNNING)
+                    available_cpus = max_concurrent - sum(
+                        1 for job in jobs if job.get_status() is job.Status.RUNNING
+                    )
 
                     for i in range(min(len(waitingJobs), available_cpus)):
                         waitingJobs[i].start()
 
                 if job_timeout is not None:
                     # Check if any jobs have timed out
-                    runningJobs = [job for job in jobs if job.get_status() is job.Status.RUNNING]
+                    runningJobs = [
+                        job for job in jobs if job.get_status() is job.Status.RUNNING
+                    ]
                     for runningJob in runningJobs:
                         if time.time() - runningJob._start_time > job_timeout:
                             runningJob._timeout = job_timeout
@@ -744,9 +845,12 @@ class WorkflowCommon:
                     status_pad.erase()
                     for i, job in enumerate(jobs):
                         # print the name
-                        status_pad.addstr('Job {0:{width}d}/{1}: '.format(
-                          i + 1, num_jobs, width=len(str(num_jobs))))
-                        status_pad.addstr(job.name + '\n', curses.A_BOLD)
+                        status_pad.addstr(
+                            "Job {0:{width}d}/{1}: ".format(
+                                i + 1, num_jobs, width=len(str(num_jobs))
+                            )
+                        )
+                        status_pad.addstr(job.name + "\n", curses.A_BOLD)
 
                         # print the status string
                         if use_colors:
@@ -758,11 +862,9 @@ class WorkflowCommon:
                                 color = curses.color_pair(2)
                             else:
                                 color = curses.color_pair(0)
-                            status_pad.addstr(
-                              job.get_status_string() + '\n\n', color)
+                            status_pad.addstr(job.get_status_string() + "\n\n", color)
                         else:
-                            status_pad.addstr(
-                              job.get_status_string() + '\n\n')
+                            status_pad.addstr(job.get_status_string() + "\n\n")
 
                     # handle scrolling
                     while True:
@@ -778,9 +880,12 @@ class WorkflowCommon:
                     # prevent scrolling beyond the bounds of status_pad
                     screen_height, screen_width = stdscr.getmaxyx()
                     top_line = max(
-                      0,
-                      min(top_line,
-                          status_height - 2 - (screen_height - header_height)))
+                        0,
+                        min(
+                            top_line,
+                            status_height - 2 - (screen_height - header_height),
+                        ),
+                    )
 
                     # Resizing the terminal can cause the actual
                     # screen width or height to become smaller than
@@ -794,10 +899,16 @@ class WorkflowCommon:
                     # have and ignore errors.
                     try:
                         header_pad.noutrefresh(
-                          0, 0, 0, 0, screen_height - 1, screen_width - 1)
+                            0, 0, 0, 0, screen_height - 1, screen_width - 1
+                        )
                         status_pad.noutrefresh(
-                          top_line, 0, header_height, 0,
-                          screen_height - 1, screen_width - 1)
+                            top_line,
+                            0,
+                            header_height,
+                            0,
+                            screen_height - 1,
+                            screen_width - 1,
+                        )
                     except curses.error:
                         pass
                     curses.doupdate()
@@ -821,36 +932,43 @@ class WorkflowCommon:
                 execute()
 
         except BaseException as exception:
-            logging.exception('')
+            logging.exception("")
             tprint(
-              'An exception occurred. See the log for details.\n\n'
-              '    ' + repr(exception) + "\n\n"
-              'Terminating all jobs. Please wait for cleanup to finish. '
-              'CTRL+C may leave orphaned processes.', 'DARK_RED',
-              'ERROR')
+                "An exception occurred. See the log for details.\n\n"
+                "    " + repr(exception) + "\n\n"
+                "Terminating all jobs. Please wait for cleanup to finish. "
+                "CTRL+C may leave orphaned processes.",
+                "DARK_RED",
+                "ERROR",
+            )
 
             # kill all the jobs
             for job in jobs:
                 job.die()
-            tprint('All jobs terminated.\n', 'DARK_RED')
+            tprint("All jobs terminated.\n", "DARK_RED")
 
         # print summary
-        summary = 'Job Summary\n'
+        summary = "Job Summary\n"
         for i, job in enumerate(jobs):
-            summary += 'Job {0:{width}d}/{1}: {2}\n{3}\n'.format(
-              i + 1, num_jobs, job.name, job.get_status_string(),
-              width=len(str(num_jobs)))
+            summary += "Job {0:{width}d}/{1}: {2}\n{3}\n".format(
+                i + 1,
+                num_jobs,
+                job.name,
+                job.get_status_string(),
+                width=len(str(num_jobs)),
+            )
 
         logging.info(summary)
 
         for job in jobs:
             text, color = {
-                job.Status.NOT_STARTED: ('was not run', 'GREY40'),
-                job.Status.SUCCESS: ('succeeded', 'DARK_GREEN'),
-                job.Status.FAILED: ('failed', 'DARK_RED'),
-                job.Status.TIMEOUT: ('timed out', 'YELLOW') }[job.get_status()]
+                job.Status.NOT_STARTED: ("was not run", "GREY40"),
+                job.Status.SUCCESS: ("succeeded", "DARK_GREEN"),
+                job.Status.FAILED: ("failed", "DARK_RED"),
+                job.Status.TIMEOUT: ("timed out", "YELLOW"),
+            }[job.get_status()]
 
-            text = job.name + ' ' + text
+            text = job.name + " " + text
 
             # Print the summary status even if self.quiet is True
             tprint(text, color)

--- a/share/trick/trickops/WorkflowCommon.py
+++ b/share/trick/trickops/WorkflowCommon.py
@@ -242,6 +242,7 @@ class Job(object):
         self._command = command
         self.log_file = log_file
         self._log_file = None
+        self._stdin_file = None
         self._process = None
         self._start_time = None
         self._stop_time = None
@@ -257,11 +258,24 @@ class Job(object):
         if self.get_status != self.Status.RUNNING:
           logging.debug('Executing command: ' + self._command)
           self._start_time = time.time()
+          self._stdin_file = open(os.devnull, 'r')
           self._log_file = open(self.log_file, 'w')
           self._process = subprocess.Popen(
             self._command, stdout=self._log_file, stderr=self._log_file,
-            stdin=open(os.devnull, 'r'), shell=True, preexec_fn=os.setsid,
+            stdin=self._stdin_file, shell=True, preexec_fn=os.setsid,
             close_fds=True)
+
+    def _close_files(self):
+        """
+        Close any outstanding file handles associated with this job.
+        """
+        if self._log_file is not None and not self._log_file.closed:
+            self._log_file.close()
+        self._log_file = None
+
+        if self._stdin_file is not None and not self._stdin_file.closed:
+            self._stdin_file.close()
+        self._stdin_file = None
 
     def get_status(self):
         """
@@ -287,6 +301,8 @@ class Job(object):
         self._exit_status = self._process.poll()
         if self._exit_status is None:
             return self.Status.RUNNING
+
+        self._close_files()
 
         if self._timeout is not None:
             return self.Status.TIMEOUT
@@ -431,6 +447,7 @@ class Job(object):
             self._process.wait()
         except:
             pass
+        self._close_files()
 
 class FileSizeJob(Job):
     """

--- a/share/trick/trickops/tests/ut_WorkflowCommon.py
+++ b/share/trick/trickops/tests/ut_WorkflowCommon.py
@@ -97,3 +97,11 @@ class WorkflowCommonTestCase(unittest.TestCase):
         f = open('/tmp/WorkflowCommonTestCase_hi.txt', 'r')
         self.assertTrue(f.readlines()[0].strip() == 'hi')
         f.close()
+
+    def test_job_closes_file_handles_after_completion(self):
+        job = Job(name='testname', command='echo hi',
+          log_file='/tmp/WorkflowCommonTestCase_handles.txt')
+        self.instance.execute_jobs([job], max_concurrent=1)
+        self.assertTrue(job.get_status() == Job.Status.SUCCESS)
+        self.assertTrue(job._log_file is None or job._log_file.closed)
+        self.assertTrue(job._stdin_file is None or job._stdin_file.closed)

--- a/share/trick/trickops/tests/ut_WorkflowCommon.py
+++ b/share/trick/trickops/tests/ut_WorkflowCommon.py
@@ -1,23 +1,35 @@
-import os, sys
-import unittest, time
+import os
 import pdb
-from testconfig import this_trick, tests_dir
+import sys
+import time
+import unittest
+
+from testconfig import tests_dir, this_trick
 from WorkflowCommon import *
+
 
 def suite():
     """Create test suite from WorkflowCommonTestCase unit test class and return"""
     return unittest.TestLoader().loadTestsFromTestCase(WorkflowCommonTestCase)
 
-class WorkflowCommonTestCase(unittest.TestCase):
 
+class WorkflowCommonTestCase(unittest.TestCase):
     def setUp(self):
         # Nominal instance, using this Trick as top level project
-        self.instance = WorkflowCommon(project_top_level=this_trick, log_dir='/tmp/', quiet=True)
+        self.instance = WorkflowCommon(
+            project_top_level=this_trick, log_dir="/tmp/", quiet=True
+        )
         # Nominal job that just echo's 'hi', this creates it, it doesn't execute it
-        self.job_nominal = Job(name='testname', command='echo hi',
-          log_file='/tmp/WorkflowCommonTestCase_hi.txt')
-        self.job_that_fails = Job(name='testname', command='echo hi',
-          log_file='/tmp/WorkflowCommonTestCase_hi.txt')
+        self.job_nominal = Job(
+            name="testname",
+            command="echo hi",
+            log_file="/tmp/WorkflowCommonTestCase_hi.txt",
+        )
+        self.job_that_fails = Job(
+            name="testname",
+            command="echo hi",
+            log_file="/tmp/WorkflowCommonTestCase_hi.txt",
+        )
         pass
 
     def tearDown(self):
@@ -26,26 +38,29 @@ class WorkflowCommonTestCase(unittest.TestCase):
         self.instance = None
 
     def test_run_subprocess(self):
-        result = run_subprocess(command='echo hi', m_shell=subprocess.PIPE, m_stdout=subprocess.PIPE)
+        result = run_subprocess(
+            command="echo hi", m_shell=subprocess.PIPE, m_stdout=subprocess.PIPE
+        )
         self.assertEqual(result.code, 0)
-        self.assertTrue('hi' in result.stdout )
+        self.assertTrue("hi" in result.stdout)
 
     def test_validate_output_file(self):
-        dir = '/tmp/aoeifmeganrsdfalk/'
-        rest = 'b/c/d/foo.txt'
+        dir = "/tmp/aoeifmeganrsdfalk/"
+        rest = "b/c/d/foo.txt"
         file = os.path.join(dir, rest)
         filename = validate_output_file(file)
         self.assertEqual(filename, file)
         self.assertTrue(os.path.exists(file))
         # Clean up everything we just created
         import shutil
+
         shutil.rmtree(dir)
 
     def test_create_progress_bar(self):
-        bar = create_progress_bar(fraction=0.25, text='hello')
-        self.assertTrue('hello' in bar)
-        self.assertTrue('====================' in bar)
-        self.assertTrue('=====================' not in bar)
+        bar = create_progress_bar(fraction=0.25, text="hello")
+        self.assertTrue("hello" in bar)
+        self.assertTrue("====================" in bar)
+        self.assertTrue("=====================" not in bar)
         self.assertTrue(len(bar) == 80)
 
     def test_sanitize_cpus(self):
@@ -59,48 +74,51 @@ class WorkflowCommonTestCase(unittest.TestCase):
 
     def test_init_nominal(self):
         self.assertEqual(self.instance.project_top_level, this_trick)
-        self.assertEqual(self.instance.log_dir, '/tmp/')
-        self.assertEqual(self.instance.env, '')
+        self.assertEqual(self.instance.log_dir, "/tmp/")
+        self.assertEqual(self.instance.env, "")
         self.assertTrue(self.instance.creation_time < time.time())
-        self.assertTrue(self.instance.host_name != '' )
-        self.assertTrue(self.instance.this_os == None )
-        self.assertTrue(self.instance.quiet == True )
-        self.assertTrue(os.getcwd() == this_trick )
-        self.assertTrue(self.job_nominal.name == 'testname')
+        self.assertTrue(self.instance.host_name != "")
+        self.assertTrue(self.instance.this_os == None)
+        self.assertTrue(self.instance.quiet == True)
+        self.assertTrue(os.getcwd() == this_trick)
+        self.assertTrue(self.job_nominal.name == "testname")
 
     def test_get_operating_system_nominal(self):
-        '''
+        """
         This test will respond differently per-platform. Nominal checks
         here should pass for all "supported platforms"
-        '''
-        self.assertTrue(self.instance.get_operating_system() != 'unknown')
+        """
+        self.assertTrue(self.instance.get_operating_system() != "unknown")
 
     def test_get_installed_packages_nominal(self):
-        '''
+        """
         This test will respond differently per-platform. Nominal checks
         here should pass for all "supported platforms"
-        '''
+        """
         pkgs = self.instance.get_installed_packages()
         self.assertTrue(len(pkgs) > 0)
 
     def test_job_nominal(self):
         self.instance.execute_jobs([self.job_nominal], max_concurrent=1)
         self.assertTrue(self.job_nominal.get_status() == Job.Status.SUCCESS)
-        f = open('/tmp/WorkflowCommonTestCase_hi.txt', 'r')
-        self.assertTrue(f.readlines()[0].strip() == 'hi')
+        f = open("/tmp/WorkflowCommonTestCase_hi.txt", "r")
+        self.assertTrue(f.readlines()[0].strip() == "hi")
         f.close()
 
     def test_job_nominal_quiet(self):
         self.instance.quiet = True
         self.instance.execute_jobs([self.job_nominal], max_concurrent=1)
         self.assertTrue(self.job_nominal.get_status() == Job.Status.SUCCESS)
-        f = open('/tmp/WorkflowCommonTestCase_hi.txt', 'r')
-        self.assertTrue(f.readlines()[0].strip() == 'hi')
+        f = open("/tmp/WorkflowCommonTestCase_hi.txt", "r")
+        self.assertTrue(f.readlines()[0].strip() == "hi")
         f.close()
 
     def test_job_closes_file_handles_after_completion(self):
-        job = Job(name='testname', command='echo hi',
-          log_file='/tmp/WorkflowCommonTestCase_handles.txt')
+        job = Job(
+            name="testname",
+            command="echo hi",
+            log_file="/tmp/WorkflowCommonTestCase_handles.txt",
+        )
         self.instance.execute_jobs([job], max_concurrent=1)
         self.assertTrue(job.get_status() == Job.Status.SUCCESS)
         self.assertTrue(job._log_file is None or job._log_file.closed)


### PR DESCRIPTION
Python 3.14 introduces aggressive optimization to the object lifecycle and garbage collection. If parallel loops run fast enough in subprocesses, Python could delay the cleanup. This would trigger an "OS Error: Too many open files" if system's file descriptor limits were reached. Older Python often closes the file descriptor immediately when out of scope as it basing on the old reference counting garbage collector. Adding to close file handles when the associated job is done works for both cases.