### PR TITLE
Always use libLTO from llvm installation.

### DIFF
--- a/trick_source/codegen/Interface_Code_Gen/makefile
+++ b/trick_source/codegen/Interface_Code_Gen/makefile
@@ -59,6 +59,7 @@ CLANGLIBS += -lc++abi -lclang-cpp
 else
 CLANGLIBS += -lc++abi
 endif
+LLVMLDFLAGS += -Wl,-lto_library,$(shell $(LLVM_HOME)/bin/llvm-config --libdir)/libLTO.dylib
 endif
 
 all: $(ICG)


### PR DESCRIPTION
Always use libLTO from llvm installation to address potential LTO bitcode parsing errors at link time for ICG on Mac.