### PR TITLE
fix: Update STL checkpoint name encoding so _ becomes __, while all other punctuation characters become _.

### DIFF
--- a/include/trick/checkpoint_map.hh
+++ b/include/trick/checkpoint_map.hh
@@ -51,7 +51,7 @@ int checkpoint_map_ik_id(STL & in_map , std::string object_name , std::string va
     typename STL::key_type * keys = nullptr ;
     typename STL::mapped_type * items = nullptr ;
 
-    cont_size = in_map.size() ;
+    cont_size = in_map.size();
 
     if ( cont_size > 0 ) {
         std::string type_string ;
@@ -129,7 +129,7 @@ int checkpoint_map_ik_sd(STL & in_map , std::string object_name , std::string va
     typename STL::key_type * keys = nullptr ;
     std::string * items = nullptr ;
 
-    cont_size = in_map.size() ;
+    cont_size = in_map.size();
 
     if ( cont_size > 0 ) {
         std::string type_string ;
@@ -209,7 +209,7 @@ int checkpoint_map_sk_id(STL & in_map , std::string object_name , std::string va
     std::string * keys = nullptr ;
     typename STL::mapped_type * items = nullptr ;
 
-    cont_size = in_map.size() ;
+    cont_size = in_map.size();
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -288,7 +288,7 @@ int checkpoint_map_stl_sk_sd(STL & in_map , std::string object_name , std::strin
     std::string * keys = nullptr ;
     std::string * items = nullptr ;
 
-    cont_size = in_map.size() ;
+    cont_size = in_map.size();
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -351,7 +351,8 @@ int checkpoint_stl(std::multimap<KEY,DATA,_Compare,_Alloc> & in_map , std::strin
 /* =================================================================================================*/
 
 template <class STL>
-int delete_map_allocs(STL & in_map __attribute__ ((unused)), std::string object_name , std::string var_name ) {
+int delete_map_allocs(STL& in_map __attribute__((unused)), std::string object_name, std::string var_name)
+{
     REF2 * items_ref ;
     std::string temp_str;
     temp_str = object_name + std::string("_") + var_name + std::string("_keys");
@@ -447,7 +448,6 @@ int restore_map_ik_sd(STL & in_map , std::string object_name , std::string var_n
 
     //message_publish(1, "in regular map template restore\n") ;
 
-
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes(temp_str.c_str()) ;
     temp_str = object_name + "_" + var_name + "_data";
@@ -500,7 +500,6 @@ int restore_map_sk_id(STL & in_map , std::string object_name , std::string var_n
 
     //message_publish(1, "in regular map template restore\n") ;
 
-
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes(temp_str.c_str()) ;
     temp_str = object_name + "_" + var_name + "_data";
@@ -552,7 +551,6 @@ int restore_map_sk_sd(STL & in_map , std::string object_name , std::string var_n
     std::string * items ;
 
     //message_publish(1, "in regular map template restore\n") ;
-
 
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes((char *)temp_str.c_str()) ;

--- a/include/trick/checkpoint_map.hh
+++ b/include/trick/checkpoint_map.hh
@@ -52,7 +52,6 @@ int checkpoint_map_ik_id(STL & in_map , std::string object_name , std::string va
     typename STL::mapped_type * items = nullptr ;
 
     cont_size = in_map.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         std::string type_string ;
@@ -131,7 +130,6 @@ int checkpoint_map_ik_sd(STL & in_map , std::string object_name , std::string va
     std::string * items = nullptr ;
 
     cont_size = in_map.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         std::string type_string ;
@@ -212,7 +210,6 @@ int checkpoint_map_sk_id(STL & in_map , std::string object_name , std::string va
     typename STL::mapped_type * items = nullptr ;
 
     cont_size = in_map.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -292,7 +289,6 @@ int checkpoint_map_stl_sk_sd(STL & in_map , std::string object_name , std::strin
     std::string * items = nullptr ;
 
     cont_size = in_map.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -356,7 +352,6 @@ int checkpoint_stl(std::multimap<KEY,DATA,_Compare,_Alloc> & in_map , std::strin
 
 template <class STL>
 int delete_map_allocs(STL & in_map __attribute__ ((unused)), std::string object_name , std::string var_name ) {
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     REF2 * items_ref ;
     std::string temp_str;
     temp_str = object_name + std::string("_") + var_name + std::string("_keys");
@@ -404,7 +399,6 @@ int restore_map_ik_id(STL & in_map , std::string object_name , std::string var_n
 
     //message_publish(1, "in regular map template restore\n") ;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes(temp_str.c_str()) ;
     temp_str = object_name + "_" + var_name + "_data";
@@ -453,7 +447,6 @@ int restore_map_ik_sd(STL & in_map , std::string object_name , std::string var_n
 
     //message_publish(1, "in regular map template restore\n") ;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes(temp_str.c_str()) ;
@@ -507,7 +500,6 @@ int restore_map_sk_id(STL & in_map , std::string object_name , std::string var_n
 
     //message_publish(1, "in regular map template restore\n") ;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes(temp_str.c_str()) ;
@@ -561,7 +553,6 @@ int restore_map_sk_sd(STL & in_map , std::string object_name , std::string var_n
 
     //message_publish(1, "in regular map template restore\n") ;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     temp_str = object_name + "_" + var_name + "_keys";
     keys_ref = ref_attributes((char *)temp_str.c_str()) ;

--- a/include/trick/checkpoint_pair.hh
+++ b/include/trick/checkpoint_pair.hh
@@ -33,7 +33,6 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 
     FIRST * first = nullptr ;
     SECOND * second = nullptr ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     std::string type_string ;
     try {
@@ -84,7 +83,6 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
     std::string temp_str;
     FIRST * first = nullptr ;
     std::string * second = nullptr ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     std::string type_string;
     try {
     type_string = stl_type_name_convert(abi::__cxa_demangle(typeid(*first).name(), 0, 0, &status )) ;
@@ -130,7 +128,6 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 
     std::string * first = nullptr ;
     SECOND * second = nullptr ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     var_declare << "std::string "
      << object_name << "_" << var_name << "_first[1]" ;
@@ -173,7 +170,6 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 
     std::string temp_str;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     var_declare << "std::string "
      << object_name << "_" << var_name << "_first[1]" ;
@@ -202,7 +198,6 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 
 template <class FIRST, class SECOND>
 int delete_stl(std::pair<FIRST, SECOND> & in_stl __attribute__ ((unused)) , std::string object_name , std::string var_name ) {
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     REF2 * items_ref ;
     std::string temp_str = object_name + "_" + var_name + "_first";
     items_ref = ref_attributes(temp_str.c_str()) ;
@@ -230,7 +225,6 @@ int restore_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name , 
     SECOND * second ;
 
     std::string temp_str; 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name + "_first";
     first_ref = ref_attributes((char *)temp_str.c_str()) ;
@@ -263,7 +257,6 @@ int restore_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name , 
 
     std::string temp_str;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name + "_first";
     first_ref = ref_attributes((char *)temp_str.c_str()) ;
@@ -295,7 +288,6 @@ int restore_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name , 
     SECOND * second ;
 
     std::string temp_str; 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name + "_first";
     first_ref = ref_attributes((char *)temp_str.c_str()) ;
@@ -327,7 +319,6 @@ int restore_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name , 
 
     std::string temp_str;
 
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name + "_first";
     first_ref = ref_attributes((char *)temp_str.c_str()) ;

--- a/include/trick/checkpoint_pair.hh
+++ b/include/trick/checkpoint_pair.hh
@@ -32,7 +32,7 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
     std::string temp_str;
 
     FIRST * first = nullptr ;
-    SECOND * second = nullptr ;
+    SECOND* second = nullptr;
 
     std::string type_string ;
     try {
@@ -82,7 +82,7 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 
     std::string temp_str;
     FIRST * first = nullptr ;
-    std::string * second = nullptr ;
+    std::string* second = nullptr;
     std::string type_string;
     try {
     type_string = stl_type_name_convert(abi::__cxa_demangle(typeid(*first).name(), 0, 0, &status )) ;
@@ -127,7 +127,7 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
     std::string  temp_str ;
 
     std::string * first = nullptr ;
-    SECOND * second = nullptr ;
+    SECOND* second      = nullptr;
 
     var_declare << "std::string "
      << object_name << "_" << var_name << "_first[1]" ;
@@ -170,7 +170,6 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 
     std::string temp_str;
 
-
     var_declare << "std::string "
      << object_name << "_" << var_name << "_first[1]" ;
     temp_str = var_declare.str();
@@ -197,7 +196,8 @@ int checkpoint_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name
 /* =================================================================================================*/
 
 template <class FIRST, class SECOND>
-int delete_stl(std::pair<FIRST, SECOND> & in_stl __attribute__ ((unused)) , std::string object_name , std::string var_name ) {
+int delete_stl(std::pair<FIRST, SECOND>& in_stl __attribute__((unused)), std::string object_name, std::string var_name)
+{
     REF2 * items_ref ;
     std::string temp_str = object_name + "_" + var_name + "_first";
     items_ref = ref_attributes(temp_str.c_str()) ;
@@ -224,7 +224,7 @@ int restore_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name , 
     FIRST * first ;
     SECOND * second ;
 
-    std::string temp_str; 
+    std::string temp_str;
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name + "_first";
     first_ref = ref_attributes((char *)temp_str.c_str()) ;
@@ -287,7 +287,7 @@ int restore_stl(std::pair<FIRST , SECOND> & in_pair , std::string object_name , 
     std::string * first_inner ;
     SECOND * second ;
 
-    std::string temp_str; 
+    std::string temp_str;
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name + "_first";
     first_ref = ref_attributes((char *)temp_str.c_str()) ;

--- a/include/trick/checkpoint_queue.hh
+++ b/include/trick/checkpoint_queue.hh
@@ -41,7 +41,6 @@ int checkpoint_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object
     std::queue<ITEM_TYPE,_Sequence> temp_queue(in_stl) ;
 
     cont_size = temp_queue.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -85,7 +84,6 @@ int checkpoint_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object
     std::queue<ITEM_TYPE,_Sequence> temp_queue(in_stl) ;
 
     cont_size = temp_queue.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -128,7 +126,6 @@ int checkpoint_stl(std::priority_queue<ITEM_TYPE, _Container, _Compare> & in_stl
     std::priority_queue<ITEM_TYPE,_Container,_Compare> temp_queue(in_stl) ;
 
     cont_size = temp_queue.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -173,7 +170,6 @@ int checkpoint_stl(std::priority_queue<ITEM_TYPE, _Container, _Compare> & in_stl
     std::priority_queue<ITEM_TYPE,_Container,_Compare> temp_queue(in_stl) ;
 
     cont_size = temp_queue.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -235,7 +231,6 @@ int restore_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
 
     REF2 * items_ref ;
     ITEM_TYPE * items ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -269,7 +264,6 @@ int restore_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
 
     REF2 * items_ref ;
     std::string * items ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name ;
@@ -308,7 +302,6 @@ int restore_stl(std::priority_queue<ITEM_TYPE,_Container,_Compare> & in_stl ,
 
     REF2 * items_ref ;
     ITEM_TYPE * items ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -343,7 +336,6 @@ int restore_stl(std::priority_queue<ITEM_TYPE,_Container,_Compare> & in_stl ,
 
     REF2 * items_ref ;
     std::string * items ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name ;

--- a/include/trick/checkpoint_queue.hh
+++ b/include/trick/checkpoint_queue.hh
@@ -40,7 +40,7 @@ int checkpoint_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object
     ITEM_TYPE * items = nullptr ;
     std::queue<ITEM_TYPE,_Sequence> temp_queue(in_stl) ;
 
-    cont_size = temp_queue.size() ;
+    cont_size = temp_queue.size();
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -83,7 +83,7 @@ int checkpoint_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object
     std::string * items = nullptr ;
     std::queue<ITEM_TYPE,_Sequence> temp_queue(in_stl) ;
 
-    cont_size = temp_queue.size() ;
+    cont_size = temp_queue.size();
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -125,7 +125,7 @@ int checkpoint_stl(std::priority_queue<ITEM_TYPE, _Container, _Compare> & in_stl
     ITEM_TYPE * items = nullptr ;
     std::priority_queue<ITEM_TYPE,_Container,_Compare> temp_queue(in_stl) ;
 
-    cont_size = temp_queue.size() ;
+    cont_size = temp_queue.size();
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -169,7 +169,7 @@ int checkpoint_stl(std::priority_queue<ITEM_TYPE, _Container, _Compare> & in_stl
     std::string * items = nullptr ;
     std::priority_queue<ITEM_TYPE,_Container,_Compare> temp_queue(in_stl) ;
 
-    cont_size = temp_queue.size() ;
+    cont_size = temp_queue.size();
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -230,7 +230,7 @@ int restore_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
     std::string temp_str ;
 
     REF2 * items_ref ;
-    ITEM_TYPE * items ;
+    ITEM_TYPE* items;
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -263,7 +263,7 @@ int restore_stl(std::queue<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
     std::string temp_str ;
 
     REF2 * items_ref ;
-    std::string * items ;
+    std::string* items;
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name ;
@@ -301,7 +301,7 @@ int restore_stl(std::priority_queue<ITEM_TYPE,_Container,_Compare> & in_stl ,
     std::string temp_str ;
 
     REF2 * items_ref ;
-    ITEM_TYPE * items ;
+    ITEM_TYPE* items;
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -335,7 +335,7 @@ int restore_stl(std::priority_queue<ITEM_TYPE,_Container,_Compare> & in_stl ,
     std::string temp_str ;
 
     REF2 * items_ref ;
-    std::string * items ;
+    std::string* items;
 
     //message_publish(1, "RESTORE_STL_queue %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + "_" + var_name ;

--- a/include/trick/checkpoint_sequence_stl.hh
+++ b/include/trick/checkpoint_sequence_stl.hh
@@ -44,7 +44,6 @@ int checkpoint_sequence_i(STL & in_stl , std::string object_name , std::string v
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
 
     cont_size = in_stl.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -88,7 +87,6 @@ int checkpoint_sequence_s(STL & in_stl , std::string object_name , std::string v
 
 
     cont_size = in_stl.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
 
@@ -221,7 +219,6 @@ int checkpoint_stl(std::multiset<ITEM_TYPE,_Alloc> & in_stl , std::string object
 
 template <class STL>
 int delete_sequence_alloc(STL & in_stl __attribute__ ((unused)), std::string object_name , std::string var_name ) {
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
     REF2 * items_ref ;
     std::string temp_str = object_name + std::string("_") + var_name ;
     items_ref = ref_attributes((char *)temp_str.c_str()) ;
@@ -280,7 +277,6 @@ int restore_sequence_i(STL & in_stl , std::string object_name , std::string var_
 
     REF2 * items_ref ;
     typename STL::value_type * items ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_SEQUENCE_STL %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -309,7 +305,6 @@ int restore_sequence_s(STL & in_stl , std::string object_name , std::string var_
     REF2 * items_ref ;
     std::string * items ;
     std::string temp_str ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
     temp_str = object_name + "_" + var_name ;
@@ -346,7 +341,6 @@ int restore_stl(std::array<ITEM_TYPE,N> & in_stl , std::string object_name , std
     REF2 * items_ref ;
     std::string * items ;
     std::string temp_str ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
     temp_str = object_name + "_" + var_name ;
@@ -379,7 +373,6 @@ int restore_stl(std::array<ITEM_TYPE,N> & in_stl , std::string object_name , std
 
     REF2 * items_ref ;
     typename std::array<ITEM_TYPE,N>::value_type * items ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_SEQUENCE_STL %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;

--- a/include/trick/checkpoint_sequence_stl.hh
+++ b/include/trick/checkpoint_sequence_stl.hh
@@ -43,7 +43,7 @@ int checkpoint_sequence_i(STL & in_stl , std::string object_name , std::string v
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
 
-    cont_size = in_stl.size() ;
+    cont_size = in_stl.size();
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -85,8 +85,7 @@ int checkpoint_sequence_s(STL & in_stl , std::string object_name , std::string v
     typename STL::iterator it ;
     typename STL::iterator end ;
 
-
-    cont_size = in_stl.size() ;
+    cont_size = in_stl.size();
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
 
@@ -218,7 +217,8 @@ int checkpoint_stl(std::multiset<ITEM_TYPE,_Alloc> & in_stl , std::string object
 /* =================================================================================================*/
 
 template <class STL>
-int delete_sequence_alloc(STL & in_stl __attribute__ ((unused)), std::string object_name , std::string var_name ) {
+int delete_sequence_alloc(STL& in_stl __attribute__((unused)), std::string object_name, std::string var_name)
+{
     REF2 * items_ref ;
     std::string temp_str = object_name + std::string("_") + var_name ;
     items_ref = ref_attributes((char *)temp_str.c_str()) ;
@@ -276,7 +276,7 @@ int restore_sequence_i(STL & in_stl , std::string object_name , std::string var_
     std::string temp_str ;
 
     REF2 * items_ref ;
-    typename STL::value_type * items ;
+    typename STL::value_type* items;
 
     //message_publish(1, "RESTORE_SEQUENCE_STL %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -304,7 +304,7 @@ int restore_sequence_s(STL & in_stl , std::string object_name , std::string var_
 
     REF2 * items_ref ;
     std::string * items ;
-    std::string temp_str ;
+    std::string temp_str;
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
     temp_str = object_name + "_" + var_name ;
@@ -340,7 +340,7 @@ int restore_stl(std::array<ITEM_TYPE,N> & in_stl , std::string object_name , std
 
     REF2 * items_ref ;
     std::string * items ;
-    std::string temp_str ;
+    std::string temp_str;
 
     //message_publish(1, "%s\n", __PRETTY_FUNCTION__) ;
     temp_str = object_name + "_" + var_name ;
@@ -372,7 +372,7 @@ int restore_stl(std::array<ITEM_TYPE,N> & in_stl , std::string object_name , std
     std::string temp_str ;
 
     REF2 * items_ref ;
-    typename std::array<ITEM_TYPE,N>::value_type * items ;
+    typename std::array<ITEM_TYPE, N>::value_type* items;
 
     //message_publish(1, "RESTORE_SEQUENCE_STL %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;

--- a/include/trick/checkpoint_stack.hh
+++ b/include/trick/checkpoint_stack.hh
@@ -38,7 +38,6 @@ int checkpoint_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object
     std::stack<ITEM_TYPE,_Sequence> temp_stack(in_stl) ;
 
     cont_size = temp_stack.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -81,7 +80,6 @@ int checkpoint_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object
     std::stack<ITEM_TYPE,_Sequence> temp_stack(in_stl) ;
 
     cont_size = temp_stack.size() ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -134,7 +132,6 @@ int restore_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
 
     REF2 * items_ref ;
     ITEM_TYPE * items = nullptr ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_STL_STACK %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -166,7 +163,6 @@ int restore_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
 
     REF2 * items_ref ;
     std::string * items = nullptr ;
-    std::replace_if(object_name.begin(), object_name.end(), static_cast<int (*)(int)>(std::ispunct), '_');
 
     //message_publish(1, "RESTORE_STL_STACK %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;

--- a/include/trick/checkpoint_stack.hh
+++ b/include/trick/checkpoint_stack.hh
@@ -37,7 +37,7 @@ int checkpoint_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object
     ITEM_TYPE * items = nullptr ;
     std::stack<ITEM_TYPE,_Sequence> temp_stack(in_stl) ;
 
-    cont_size = temp_stack.size() ;
+    cont_size = temp_stack.size();
 
     if ( cont_size > 0 ) {
         std::string type_string;
@@ -79,7 +79,7 @@ int checkpoint_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object
     std::string * items = nullptr ;
     std::stack<ITEM_TYPE,_Sequence> temp_stack(in_stl) ;
 
-    cont_size = temp_stack.size() ;
+    cont_size = temp_stack.size();
 
     if ( cont_size > 0 ) {
         var_declare << "std::string "
@@ -131,7 +131,7 @@ int restore_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
     std::string temp_str ;
 
     REF2 * items_ref ;
-    ITEM_TYPE * items = nullptr ;
+    ITEM_TYPE* items = nullptr;
 
     //message_publish(1, "RESTORE_STL_STACK %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;
@@ -162,7 +162,7 @@ int restore_stl(std::stack<ITEM_TYPE,_Sequence> & in_stl , std::string object_na
     std::string temp_str ;
 
     REF2 * items_ref ;
-    std::string * items = nullptr ;
+    std::string* items = nullptr;
 
     //message_publish(1, "RESTORE_STL_STACK %s_%s\n", object_name.c_str() , var_name.c_str()) ;
     temp_str = object_name + std::string("_") + var_name ;

--- a/include/trick/checkpoint_stl_protos.hh
+++ b/include/trick/checkpoint_stl_protos.hh
@@ -3,6 +3,47 @@
 #define CHECKPOINT_STL_PROTOS_HH
 
 #include <string>
+#include <cctype>
+#include "trick/memorymanager_c_intf.h"
+
+inline std::string checkpoint_stl_name_encode(const std::string& name) {
+	std::string encoded_name;
+	encoded_name.reserve(name.size());
+
+	for (const char character : name) {
+		if (character == '_') {
+			encoded_name += "__";
+		} else if (std::ispunct(static_cast<unsigned char>(character))) {
+			encoded_name += '_';
+		} else {
+			encoded_name += character;
+		}
+	}
+
+	return encoded_name;
+}
+
+inline std::string checkpoint_stl_name_encode_legacy(const std::string& name) {
+	std::string encoded_name;
+	encoded_name.reserve(name.size());
+
+	for (const char character : name) {
+		if (std::ispunct(static_cast<unsigned char>(character))) {
+			encoded_name += '_';
+		} else {
+			encoded_name += character;
+		}
+	}
+
+	return encoded_name;
+}
+
+inline bool checkpoint_stl_allocation_exists(const std::string& object_name, const std::string& var_name) {
+	const std::string base_name = object_name + "_" + var_name;
+	return TMM_var_exists(base_name.c_str()) ||
+		   TMM_var_exists((base_name + "_keys").c_str()) ||
+		   TMM_var_exists((base_name + "_first").c_str());
+}
 
 // prototype of functions used in checkpoint_stl templates
 

--- a/include/trick/checkpoint_stl_protos.hh
+++ b/include/trick/checkpoint_stl_protos.hh
@@ -2,47 +2,60 @@
 #ifndef CHECKPOINT_STL_PROTOS_HH
 #define CHECKPOINT_STL_PROTOS_HH
 
-#include <string>
-#include <cctype>
 #include "trick/memorymanager_c_intf.h"
 
-inline std::string checkpoint_stl_name_encode(const std::string& name) {
-	std::string encoded_name;
-	encoded_name.reserve(name.size());
+#include <cctype>
+#include <string>
 
-	for (const char character : name) {
-		if (character == '_') {
-			encoded_name += "__";
-		} else if (std::ispunct(static_cast<unsigned char>(character))) {
-			encoded_name += '_';
-		} else {
-			encoded_name += character;
-		}
-	}
+inline std::string checkpoint_stl_name_encode(const std::string& name)
+{
+    std::string encoded_name;
+    encoded_name.reserve(name.size());
 
-	return encoded_name;
+    for (const char character : name)
+    {
+        if (character == '_')
+        {
+            encoded_name += "__";
+        }
+        else if (std::ispunct(static_cast<unsigned char>(character)))
+        {
+            encoded_name += '_';
+        }
+        else
+        {
+            encoded_name += character;
+        }
+    }
+
+    return encoded_name;
 }
 
-inline std::string checkpoint_stl_name_encode_legacy(const std::string& name) {
-	std::string encoded_name;
-	encoded_name.reserve(name.size());
+inline std::string checkpoint_stl_name_encode_legacy(const std::string& name)
+{
+    std::string encoded_name;
+    encoded_name.reserve(name.size());
 
-	for (const char character : name) {
-		if (std::ispunct(static_cast<unsigned char>(character))) {
-			encoded_name += '_';
-		} else {
-			encoded_name += character;
-		}
-	}
+    for (const char character : name)
+    {
+        if (std::ispunct(static_cast<unsigned char>(character)))
+        {
+            encoded_name += '_';
+        }
+        else
+        {
+            encoded_name += character;
+        }
+    }
 
-	return encoded_name;
+    return encoded_name;
 }
 
-inline bool checkpoint_stl_allocation_exists(const std::string& object_name, const std::string& var_name) {
-	const std::string base_name = object_name + "_" + var_name;
-	return TMM_var_exists(base_name.c_str()) ||
-		   TMM_var_exists((base_name + "_keys").c_str()) ||
-		   TMM_var_exists((base_name + "_first").c_str());
+inline bool checkpoint_stl_allocation_exists(const std::string& object_name, const std::string& var_name)
+{
+    const std::string base_name = object_name + "_" + var_name;
+    return TMM_var_exists(base_name.c_str()) || TMM_var_exists((base_name + "_keys").c_str())
+        || TMM_var_exists((base_name + "_first").c_str());
 }
 
 // prototype of functions used in checkpoint_stl templates

--- a/trick_source/codegen/Interface_Code_Gen/PrintFileContents10.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintFileContents10.cpp
@@ -390,15 +390,15 @@ void PrintFileContents10::print_io_src_delete( std::ostream & ostream , ClassVal
 }
 
 void PrintFileContents10::print_checkpoint_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {
-    printStlFunction("checkpoint", "void* start_address, const char* obj_name , const char* var_name", "checkpoint_stl(*stl, obj_name, var_name)", ostream, *fdes, *cv);
+    printStlFunction("checkpoint", "void* start_address, const char* obj_name , const char* var_name", "checkpoint_stl(*stl, checkpoint_stl_name_encode(obj_name), checkpoint_stl_name_encode(var_name))", ostream, *fdes, *cv);
 }
 
 void PrintFileContents10::print_post_checkpoint_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {
-    printStlFunction("post_checkpoint", "void* start_address, const char* obj_name , const char* var_name", "delete_stl(*stl, obj_name, var_name)", ostream, *fdes, *cv);
+    printStlFunction("post_checkpoint", "void* start_address, const char* obj_name , const char* var_name", "delete_stl(*stl, checkpoint_stl_name_encode(obj_name), checkpoint_stl_name_encode(var_name))", ostream, *fdes, *cv);
 }
 
 void PrintFileContents10::print_restore_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {
-    printStlFunction("restore", "void* start_address, const char* obj_name , const char* var_name", "restore_stl(*stl, obj_name, var_name)",ostream, *fdes, *cv);
+    printStlFunction("restore", "void* start_address, const char* obj_name , const char* var_name", "const std::string encoded_object_name = checkpoint_stl_name_encode(obj_name);\n    const std::string encoded_var_name = checkpoint_stl_name_encode(var_name);\n    if (checkpoint_stl_allocation_exists(encoded_object_name, encoded_var_name)) {\n        restore_stl(*stl, encoded_object_name, encoded_var_name);\n    } else {\n        restore_stl(*stl, checkpoint_stl_name_encode_legacy(obj_name), checkpoint_stl_name_encode_legacy(var_name));\n    }",ostream, *fdes, *cv);
 }
 
 void PrintFileContents10::print_clear_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {

--- a/trick_source/codegen/Interface_Code_Gen/PrintFileContents10.cpp
+++ b/trick_source/codegen/Interface_Code_Gen/PrintFileContents10.cpp
@@ -390,15 +390,26 @@ void PrintFileContents10::print_io_src_delete( std::ostream & ostream , ClassVal
 }
 
 void PrintFileContents10::print_checkpoint_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {
-    printStlFunction("checkpoint", "void* start_address, const char* obj_name , const char* var_name", "checkpoint_stl(*stl, checkpoint_stl_name_encode(obj_name), checkpoint_stl_name_encode(var_name))", ostream, *fdes, *cv);
+    printStlFunction("checkpoint", "void* start_address, const char* obj_name , const char* var_name",
+                     "checkpoint_stl(*stl, checkpoint_stl_name_encode(obj_name), checkpoint_stl_name_encode(var_name))",
+                     ostream, *fdes, *cv);
 }
 
 void PrintFileContents10::print_post_checkpoint_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {
-    printStlFunction("post_checkpoint", "void* start_address, const char* obj_name , const char* var_name", "delete_stl(*stl, checkpoint_stl_name_encode(obj_name), checkpoint_stl_name_encode(var_name))", ostream, *fdes, *cv);
+    printStlFunction("post_checkpoint", "void* start_address, const char* obj_name , const char* var_name",
+                     "delete_stl(*stl, checkpoint_stl_name_encode(obj_name), checkpoint_stl_name_encode(var_name))",
+                     ostream, *fdes, *cv);
 }
 
 void PrintFileContents10::print_restore_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {
-    printStlFunction("restore", "void* start_address, const char* obj_name , const char* var_name", "const std::string encoded_object_name = checkpoint_stl_name_encode(obj_name);\n    const std::string encoded_var_name = checkpoint_stl_name_encode(var_name);\n    if (checkpoint_stl_allocation_exists(encoded_object_name, encoded_var_name)) {\n        restore_stl(*stl, encoded_object_name, encoded_var_name);\n    } else {\n        restore_stl(*stl, checkpoint_stl_name_encode_legacy(obj_name), checkpoint_stl_name_encode_legacy(var_name));\n    }",ostream, *fdes, *cv);
+    printStlFunction(
+        "restore", "void* start_address, const char* obj_name , const char* var_name",
+        "const std::string encoded_object_name = checkpoint_stl_name_encode(obj_name);\n    const std::string "
+        "encoded_var_name = checkpoint_stl_name_encode(var_name);\n    if "
+        "(checkpoint_stl_allocation_exists(encoded_object_name, encoded_var_name)) {\n        restore_stl(*stl, "
+        "encoded_object_name, encoded_var_name);\n    } else {\n        restore_stl(*stl, "
+        "checkpoint_stl_name_encode_legacy(obj_name), checkpoint_stl_name_encode_legacy(var_name));\n    }",
+        ostream, *fdes, *cv);
 }
 
 void PrintFileContents10::print_clear_stl(std::ostream & ostream , FieldDescription * fdes , ClassValues * cv ) {

--- a/trick_source/sim_services/MemoryManager/test/MM_stl_checkpoint.cc
+++ b/trick_source/sim_services/MemoryManager/test/MM_stl_checkpoint.cc
@@ -2,10 +2,12 @@
 #define private public
 
 #include "trick/MemoryManager.hh"
+
+#include "MM_stl_testbed.hh"
+#include "MM_test.hh"
+
 #include "trick/checkpoint_stl_protos.hh"
 #include "trick/memorymanager_c_intf.h"
-#include "MM_test.hh"
-#include "MM_stl_testbed.hh"
 
 /*
  This tests the implementations of checkpoint_stl
@@ -29,42 +31,46 @@ protected:
     void TearDown() {} 
 };
 
-TEST(STLCheckpointNameEncoding, distinguishes_member_separators_from_literal_underscores) {
+TEST(STLCheckpointNameEncoding, distinguishes_member_separators_from_literal_underscores)
+{
     EXPECT_EQ("vehicle_lvlh_lvlh__frame_links",
               checkpoint_stl_name_encode("vehicle.lvlh.lvlh_frame") + "_" + checkpoint_stl_name_encode("links"));
     EXPECT_EQ("vehicle_lvlh_lvlh_frame_links",
               checkpoint_stl_name_encode("vehicle.lvlh.lvlh.frame") + "_" + checkpoint_stl_name_encode("links"));
 }
 
-std::string checkpoint_test_name(const std::string& object_name, const std::string& suffix) {
+std::string checkpoint_test_name(const std::string& object_name, const std::string& suffix)
+{
     size_t encoded_suffix_end = suffix.size();
 
-    for (size_t index = 0; index < suffix.size(); ++index) {
-        if (suffix[index] != '_') {
+    for (size_t index = 0; index < suffix.size(); ++index)
+    {
+        if (suffix[index] != '_')
+        {
             continue;
         }
 
-        if ((suffix.compare(index, 5, "_keys") == 0) ||
-            (suffix.compare(index, 5, "_data") == 0) ||
-            (suffix.compare(index, 6, "_first") == 0) ||
-            (suffix.compare(index, 7, "_second") == 0)) {
+        if ((suffix.compare(index, 5, "_keys") == 0) || (suffix.compare(index, 5, "_data") == 0)
+            || (suffix.compare(index, 6, "_first") == 0) || (suffix.compare(index, 7, "_second") == 0))
+        {
             encoded_suffix_end = index;
             break;
         }
 
         size_t digit = index + 1;
-        while ((digit < suffix.size()) && std::isdigit(static_cast<unsigned char>(suffix[digit]))) {
+        while ((digit < suffix.size()) && std::isdigit(static_cast<unsigned char>(suffix[digit])))
+        {
             ++digit;
         }
-        if ((digit > index + 1) && ((digit == suffix.size()) || (suffix[digit] == '_'))) {
+        if ((digit > index + 1) && ((digit == suffix.size()) || (suffix[digit] == '_')))
+        {
             encoded_suffix_end = index;
             break;
         }
     }
 
-    return checkpoint_stl_name_encode(object_name) + "_" +
-           checkpoint_stl_name_encode(suffix.substr(0, encoded_suffix_end)) +
-           suffix.substr(encoded_suffix_end);
+    return checkpoint_stl_name_encode(object_name) + "_"
+        + checkpoint_stl_name_encode(suffix.substr(0, encoded_suffix_end)) + suffix.substr(encoded_suffix_end);
 }
 
 template <typename T>
@@ -173,7 +179,7 @@ void validate_temp_set (Trick::MemoryManager * memmgr, std::string object_name, 
 
 template <typename First, typename Second>
 void validate_temp_pair (Trick::MemoryManager * memmgr, std::string object_name, std::string var_name, std::pair<First, Second> expected_data) {
-    std::string temp_name = checkpoint_test_name(object_name, var_name);
+    std::string temp_name   = checkpoint_test_name(object_name, var_name);
     std::string first_name = temp_name + "_first";
     std::string second_name = temp_name + "_second";
 
@@ -1220,7 +1226,7 @@ TEST_F(MM_stl_checkpoint, vec_user_defined ) {
     // ASSERT
     ASSERT_TRUE(memmgr->var_exists("my__alloc_vec__user__defined") == 1);
 
-    REF2 * data_ref = memmgr->ref_attributes("my__alloc_vec__user__defined");
+    REF2* data_ref   = memmgr->ref_attributes("my__alloc_vec__user__defined");
     UserClass * data = (UserClass *) data_ref->address;
 
     ASSERT_TRUE(data != NULL);

--- a/trick_source/sim_services/MemoryManager/test/MM_stl_checkpoint.cc
+++ b/trick_source/sim_services/MemoryManager/test/MM_stl_checkpoint.cc
@@ -2,6 +2,7 @@
 #define private public
 
 #include "trick/MemoryManager.hh"
+#include "trick/checkpoint_stl_protos.hh"
 #include "trick/memorymanager_c_intf.h"
 #include "MM_test.hh"
 #include "MM_stl_testbed.hh"
@@ -28,9 +29,47 @@ protected:
     void TearDown() {} 
 };
 
+TEST(STLCheckpointNameEncoding, distinguishes_member_separators_from_literal_underscores) {
+    EXPECT_EQ("vehicle_lvlh_lvlh__frame_links",
+              checkpoint_stl_name_encode("vehicle.lvlh.lvlh_frame") + "_" + checkpoint_stl_name_encode("links"));
+    EXPECT_EQ("vehicle_lvlh_lvlh_frame_links",
+              checkpoint_stl_name_encode("vehicle.lvlh.lvlh.frame") + "_" + checkpoint_stl_name_encode("links"));
+}
+
+std::string checkpoint_test_name(const std::string& object_name, const std::string& suffix) {
+    size_t encoded_suffix_end = suffix.size();
+
+    for (size_t index = 0; index < suffix.size(); ++index) {
+        if (suffix[index] != '_') {
+            continue;
+        }
+
+        if ((suffix.compare(index, 5, "_keys") == 0) ||
+            (suffix.compare(index, 5, "_data") == 0) ||
+            (suffix.compare(index, 6, "_first") == 0) ||
+            (suffix.compare(index, 7, "_second") == 0)) {
+            encoded_suffix_end = index;
+            break;
+        }
+
+        size_t digit = index + 1;
+        while ((digit < suffix.size()) && std::isdigit(static_cast<unsigned char>(suffix[digit]))) {
+            ++digit;
+        }
+        if ((digit > index + 1) && ((digit == suffix.size()) || (suffix[digit] == '_'))) {
+            encoded_suffix_end = index;
+            break;
+        }
+    }
+
+    return checkpoint_stl_name_encode(object_name) + "_" +
+           checkpoint_stl_name_encode(suffix.substr(0, encoded_suffix_end)) +
+           suffix.substr(encoded_suffix_end);
+}
+
 template <typename T>
 void validate_single (Trick::MemoryManager * memmgr, std::string object_name, std::string var_name, T expected_data) {
-    std::string temp_name = object_name + "_" + var_name;
+    std::string temp_name = checkpoint_test_name(object_name, var_name);
     ASSERT_TRUE(memmgr->var_exists(temp_name) == 1);
 
     REF2 * data_ref = memmgr->ref_attributes(temp_name.c_str());
@@ -45,7 +84,7 @@ void validate_single (Trick::MemoryManager * memmgr, std::string object_name, st
 
 template <typename T>
 void validate_temp_sequence (Trick::MemoryManager * memmgr, std::string object_name, std::string var_name, std::vector<T> expected_data) {
-    std::string temp_name = object_name + "_" + var_name;
+    std::string temp_name = checkpoint_test_name(object_name, var_name);
     ASSERT_TRUE(memmgr->var_exists(temp_name) == 1);
 
     REF2 * data_ref = memmgr->ref_attributes(temp_name.c_str());
@@ -64,7 +103,7 @@ void validate_temp_sequence (Trick::MemoryManager * memmgr, std::string object_n
 }
 
 void validate_links_sequences (Trick::MemoryManager * memmgr, std::string object_name, std::string top_level_name, std::vector<int> lengths) {
-    std::string temp_name = object_name + "_" + top_level_name;
+    std::string temp_name = checkpoint_test_name(object_name, top_level_name);
     ASSERT_TRUE(memmgr->var_exists(temp_name) == 1);
 
     REF2 * data_ref = memmgr->ref_attributes(temp_name.c_str());
@@ -80,7 +119,7 @@ void validate_links_sequences (Trick::MemoryManager * memmgr, std::string object
 }
 
 void validate_links_pairs (Trick::MemoryManager * memmgr, std::string object_name, std::string top_level_name, int num_pairs) {
-    std::string temp_name = object_name + "_" + top_level_name;
+    std::string temp_name = checkpoint_test_name(object_name, top_level_name);
     ASSERT_TRUE(memmgr->var_exists(temp_name) == 1);
 
     REF2 * data_ref = memmgr->ref_attributes(temp_name.c_str());
@@ -99,7 +138,7 @@ void validate_links_pairs (Trick::MemoryManager * memmgr, std::string object_nam
 }
 
 void validate_link_from_pair (Trick::MemoryManager * memmgr, std::string object_name, std::string top_level_name) {
-    std::string temp_name = object_name + "_" + top_level_name;
+    std::string temp_name = checkpoint_test_name(object_name, top_level_name);
     ASSERT_TRUE(memmgr->var_exists(temp_name) == 1);
 
     REF2 * link_ref = memmgr->ref_attributes(temp_name.c_str());
@@ -110,7 +149,7 @@ void validate_link_from_pair (Trick::MemoryManager * memmgr, std::string object_
 
 template <typename T>
 void validate_temp_set (Trick::MemoryManager * memmgr, std::string object_name, std::string var_name, std::set<T> expected_data) {
-    std::string temp_name = object_name + "_" + var_name;
+    std::string temp_name = checkpoint_test_name(object_name, var_name);
     ASSERT_TRUE(memmgr->var_exists(temp_name) == 1);
 
     REF2 * data_ref = memmgr->ref_attributes(temp_name.c_str());
@@ -134,7 +173,7 @@ void validate_temp_set (Trick::MemoryManager * memmgr, std::string object_name, 
 
 template <typename First, typename Second>
 void validate_temp_pair (Trick::MemoryManager * memmgr, std::string object_name, std::string var_name, std::pair<First, Second> expected_data) {
-    std::string temp_name = object_name + "_" + var_name;
+    std::string temp_name = checkpoint_test_name(object_name, var_name);
     std::string first_name = temp_name + "_first";
     std::string second_name = temp_name + "_second";
 
@@ -160,7 +199,7 @@ void validate_temp_pair (Trick::MemoryManager * memmgr, std::string object_name,
 
 template <typename Key, typename Val>
 void validate_temp_map (Trick::MemoryManager * memmgr, std::string object_name, std::string var_name, std::map<Key, Val> expected_data) {
-    std::string temp_name = object_name + "_" + var_name;
+    std::string temp_name = checkpoint_test_name(object_name, var_name);
     std::string keys_name = temp_name + "_keys";
     std::string vals_name = temp_name + "_data";
 
@@ -1179,9 +1218,9 @@ TEST_F(MM_stl_checkpoint, vec_user_defined ) {
     (vec_attr->checkpoint_stl)((void *) &testbed->vec_user_defined, "my_alloc", vec_attr->name) ;
 
     // ASSERT
-    ASSERT_TRUE(memmgr->var_exists("my_alloc_vec_user_defined") == 1);
+    ASSERT_TRUE(memmgr->var_exists("my__alloc_vec__user__defined") == 1);
 
-    REF2 * data_ref = memmgr->ref_attributes("my_alloc_vec_user_defined");
+    REF2 * data_ref = memmgr->ref_attributes("my__alloc_vec__user__defined");
     UserClass * data = (UserClass *) data_ref->address;
 
     ASSERT_TRUE(data != NULL);

--- a/trick_source/sim_services/MemoryManager/test/MM_write_checkpoint.cc
+++ b/trick_source/sim_services/MemoryManager/test/MM_write_checkpoint.cc
@@ -1117,16 +1117,17 @@ TEST_F(MM_write_checkpoint, WrappedStl ) {
     std::string result= ss.str();
     ASSERT_NE (result.size(), 0);
 
-    EXPECT_EQ( strcmp_IgnoringWhiteSpace(            
-            "// Variable Declarations."
-            "VectorWrapper vec_allocation;"
-            "int vec__allocation_vec[4];"
-            "// Clear all allocations to 0."
-            "clear_all_vars();"
-            "// Variable Assignments."
-            "// STL: vec_allocation.vec"
-            "vec__allocation_vec = "
-            "{10, 20, 30, 40};", result.c_str()), 0);
+    EXPECT_EQ(strcmp_IgnoringWhiteSpace("// Variable Declarations."
+                                        "VectorWrapper vec_allocation;"
+                                        "int vec__allocation_vec[4];"
+                                        "// Clear all allocations to 0."
+                                        "clear_all_vars();"
+                                        "// Variable Assignments."
+                                        "// STL: vec_allocation.vec"
+                                        "vec__allocation_vec = "
+                                        "{10, 20, 30, 40};",
+                                        result.c_str()),
+              0);
 }
 
 // ================================================================================

--- a/trick_source/sim_services/MemoryManager/test/MM_write_checkpoint.cc
+++ b/trick_source/sim_services/MemoryManager/test/MM_write_checkpoint.cc
@@ -1120,12 +1120,12 @@ TEST_F(MM_write_checkpoint, WrappedStl ) {
     EXPECT_EQ( strcmp_IgnoringWhiteSpace(            
             "// Variable Declarations."
             "VectorWrapper vec_allocation;"
-            "int vec_allocation_vec[4];"
+            "int vec__allocation_vec[4];"
             "// Clear all allocations to 0."
             "clear_all_vars();"
             "// Variable Assignments."
             "// STL: vec_allocation.vec"
-            "vec_allocation_vec = "
+            "vec__allocation_vec = "
             "{10, 20, 30, 40};", result.c_str()), 0);
 }
 


### PR DESCRIPTION
Update STL checkpoint name encoding so _ becomes __, while all other punctuation characters become _.