### PR TITLE
ci: update publish_commit.yml

### DIFF
--- a/.github/workflows/publish_commit.yml
+++ b/.github/workflows/publish_commit.yml
@@ -113,6 +113,7 @@ jobs:
           git checkout ${{ env.PRIMARY_BRANCH }}
           git pull origin ${{ env.PRIMARY_BRANCH }}
           git merge --no-edit "origin/pr-${{ env.PR_NUMBER }}"
+          brew trust --formula ${{ env.REPO_OWNER }}/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}
           brew bottle --merge --write \
             "$GITHUB_WORKSPACE"/bottles/*.bottle.json
 


### PR DESCRIPTION
Homebrew distrusts taps by default. We must trust `nasa/trick` before running `brew` commands on it