### PR TITLE
Bound error messages and grow table text safely

### DIFF
--- a/trick_source/data_products/DPX/APPS/FXPLOT/makefile
+++ b/trick_source/data_products/DPX/APPS/FXPLOT/makefile
@@ -93,3 +93,5 @@ fxplot: ../../../lib_${TRICK_HOST_CPU}/liblog.a \
 
 
 # Dependencies
+
+$(OBJDIR)/table_view_node.o: table_text_buffer.hh

--- a/trick_source/data_products/DPX/APPS/FXPLOT/table_text_buffer.hh
+++ b/trick_source/data_products/DPX/APPS/FXPLOT/table_text_buffer.hh
@@ -1,0 +1,67 @@
+#ifndef TRICK_FXPLOT_TABLE_TEXT_BUFFER_HH
+#define TRICK_FXPLOT_TABLE_TEXT_BUFFER_HH
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
+// Append formatted table text without limiting a row to a fixed-size scratch buffer.
+static char* twprint(char* text_buf, size_t *text_buf_size, size_t *insertion_pos,
+                     const char* format, ...) {
+    const size_t allocation_step = 0xFFFF;
+    const size_t max_size = std::numeric_limits<size_t>::max();
+    va_list args;
+    va_list sizing_args;
+    va_start(args, format);
+    va_copy(sizing_args, args);
+    int formatted_len = vsnprintf(NULL, 0, format, sizing_args);
+    va_end(sizing_args);
+    if (formatted_len < 0) {
+        va_end(args);
+        return text_buf;
+    }
+
+    size_t message_len = static_cast<size_t>(formatted_len);
+    if (*insertion_pos > max_size - message_len - 1) {
+        va_end(args);
+        fprintf(stderr, "OUT_OF_MEMORY in twprint.\n");
+        exit(1);
+    }
+    size_t required_size = *insertion_pos + message_len + 1;
+    if (text_buf == NULL) {
+        *text_buf_size = 0;
+    }
+    if (required_size > *text_buf_size) {
+        size_t new_size = *text_buf_size;
+        while (new_size < required_size) {
+            if (new_size > max_size - allocation_step) {
+                new_size = required_size;
+                break;
+            }
+            new_size += allocation_step;
+        }
+        char *grown = static_cast<char *>(realloc(text_buf, new_size));
+        if (grown == NULL) {
+            va_end(args);
+            fprintf(stderr, "OUT_OF_MEMORY in twprint.\n");
+            exit(1);
+        }
+        // Keep unused capacity zeroed, as it is also used by the table save callback.
+        memset(grown + *text_buf_size, 0, new_size - *text_buf_size);
+        text_buf = grown;
+        *text_buf_size = new_size;
+    }
+
+    int written = vsnprintf(text_buf + *insertion_pos, *text_buf_size - *insertion_pos, format, args);
+    va_end(args);
+    if (written < 0) {
+        text_buf[*insertion_pos] = '\0';
+    } else {
+        *insertion_pos += strlen(text_buf + *insertion_pos);
+    }
+    return text_buf;
+}
+
+#endif

--- a/trick_source/data_products/DPX/APPS/FXPLOT/table_view_node.cpp
+++ b/trick_source/data_products/DPX/APPS/FXPLOT/table_view_node.cpp
@@ -22,7 +22,7 @@
 #include "parse_format.h"
 #include "post_dialog.h"
 
-#define BYTES_PER_MALLOC 0xFFFF
+#include "table_text_buffer.hh"
 
 // CALLBACK
 static void FSB_cb( Widget w, XtPointer client_data, XtPointer call_data) {
@@ -73,37 +73,6 @@ static void save_table_cb( Widget w, XtPointer client_data, XtPointer call_data)
 
     XtManageChild( dialog);
 
-}
-
-static char* twprint( char* text_buf, size_t *text_buf_size, size_t *insertion_pos, char* format, ...) {
-    char message[4096];
-    va_list vargs;
-    size_t new_insertion_pos;
-    size_t message_len;
-
-    va_start(vargs, format);
-    vsprintf(message, format, vargs); // vsnprint ??
-    va_end(vargs);
-
-    message_len = strlen(message);
-    new_insertion_pos = *insertion_pos + message_len;
-
-    if (text_buf == NULL) {
-        text_buf = (char*)calloc(1, size_t(BYTES_PER_MALLOC));
-    }
-
-    while ( new_insertion_pos > *text_buf_size) {
-        *text_buf_size += (size_t)BYTES_PER_MALLOC;
-        if ((text_buf = (char *)realloc( text_buf, *text_buf_size )) == NULL) {
-            std::cerr << "OUT_OF_MEMORY in twprint." << std::endl;
-            exit(1);
-        }
-    }
-
-    strcpy(&text_buf[*insertion_pos], message);
-    *insertion_pos = new_insertion_pos;
-
-    return (text_buf);
 }
 
 // CLASS VARIABLE INITIALIZATION

--- a/trick_source/data_products/DPX/test/unit_test/TableTextBuffer_test.cpp
+++ b/trick_source/data_products/DPX/test/unit_test/TableTextBuffer_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "APPS/FXPLOT/table_text_buffer.hh"
+
+class TableTextBufferTest : public testing::Test {
+protected:
+    char *buffer = NULL;
+    size_t capacity = 0;
+    size_t position = 0;
+
+    void TearDown() {
+        free(buffer);
+    }
+};
+
+TEST_F(TableTextBufferTest, AppendsFormattedText) {
+    buffer = twprint(buffer, &capacity, &position, (char *)"%s: %d", "value", 42);
+    buffer = twprint(buffer, &capacity, &position, (char *)"%s", " done");
+    EXPECT_STREQ("value: 42 done", buffer);
+    EXPECT_EQ(strlen(buffer), position);
+    EXPECT_GT(capacity, position);
+}
+
+TEST_F(TableTextBufferTest, PreservesLongMessages) {
+    std::string input(16384, 'x');
+    buffer = twprint(buffer, &capacity, &position, (char *)"%s:%d", input.c_str(), 42);
+    EXPECT_EQ(input + ":42", buffer);
+    EXPECT_EQ(input.size() + 3, position);
+    EXPECT_GT(capacity, position);
+}
+
+TEST_F(TableTextBufferTest, HandlesLargeFormatWidths) {
+    buffer = twprint(buffer, &capacity, &position, (char *)"%10000d", 1);
+    EXPECT_EQ(std::string(9999, ' ') + "1", buffer);
+    EXPECT_EQ(10000u, position);
+}
+
+TEST_F(TableTextBufferTest, GrowsForTheNullTerminator) {
+    capacity = 8;
+    position = 7;
+    buffer = static_cast<char *>(calloc(capacity, 1));
+    strcpy(buffer, "1234567");
+    buffer = twprint(buffer, &capacity, &position, (char *)"%s", "8");
+    EXPECT_STREQ("12345678", buffer);
+    EXPECT_EQ(8u, position);
+    EXPECT_GT(capacity, position);
+}
+
+TEST_F(TableTextBufferTest, InitializesAnEmptyBuffer) {
+    buffer = twprint(buffer, &capacity, &position, (char *)"%s", "");
+    ASSERT_NE(nullptr, buffer);
+    EXPECT_STREQ("", buffer);
+    EXPECT_EQ(0u, position);
+    EXPECT_GT(capacity, position);
+}
+
+TEST_F(TableTextBufferTest, PreservesContentsAcrossRepeatedGrowth) {
+    std::string expected;
+    for (int i = 0; i < 40; ++i) {
+        std::string chunk(2000, 'a' + i % 26);
+        expected += chunk;
+        buffer = twprint(buffer, &capacity, &position, (char *)"%s", chunk.c_str());
+        EXPECT_EQ(expected, buffer);
+        EXPECT_EQ(expected.size(), position);
+        EXPECT_GT(capacity, position);
+    }
+}
+
+TEST_F(TableTextBufferTest, RejectsAnUnrepresentableBufferSize) {
+    position = std::numeric_limits<size_t>::max();
+    EXPECT_EXIT(twprint(buffer, &capacity, &position, "%s", "x"),
+                testing::ExitedWithCode(1), "OUT_OF_MEMORY in twprint");
+}

--- a/trick_source/data_products/DPX/test/unit_test/makefile
+++ b/trick_source/data_products/DPX/test/unit_test/makefile
@@ -57,7 +57,8 @@ DS_LIBS         = ${DP_LIBS} -ldl ${CONTROLLER_LIBS}
 
 TESTS = DPM_test \
 		DPC_test \
-		DS_test
+		DS_test \
+		TableTextBuffer_test
 
 #############################################################################
 ##                            MODEL TARGETS                                ##
@@ -75,6 +76,12 @@ test : $(TESTS)
 	./DPC_test --gtest_output=xml:${TRICK_HOME}/trick_test/DataProducts_C.xml
 	./DPM_test --gtest_output=xml:${TRICK_HOME}/trick_test/DataProducts_M.xml
 	./DS_test  --gtest_output=xml:${TRICK_HOME}/trick_test/DataStream.xml
+	./TableTextBuffer_test --gtest_output=xml:${TRICK_HOME}/trick_test/TableTextBuffer.xml
+
+TableTextBuffer_test: TableTextBuffer_test.o
+	${CPP} -o $@ $^ ${GTEST_LIBS} -lpthread
+
+TableTextBuffer_test.o: ${DPX_DIR}/APPS/FXPLOT/table_text_buffer.hh
 
 DPM_test: DPM_test.o ${LIB_DPX_DIR}/libDPM.a
 	@echo "===== Making DPM_test ====="

--- a/trick_source/trick_utils/comm/src/trick_error_hndlr.c
+++ b/trick_source/trick_utils/comm/src/trick_error_hndlr.c
@@ -613,7 +613,10 @@ void trick_error_report(TrickErrorHndlr * error_hndlr,  /* In: Error object */
         return;
     }
 
-    vsprintf(message, format, args);
+    /* Keep oversized diagnostics within the fixed error-message buffer. */
+    if (vsnprintf(message, sizeof(message), format, args) < 0) {
+        message[0] = '\0';
+    }
     va_end(args);
 
     /*

--- a/trick_source/trick_utils/comm/test/TrickErrorReportTest.cpp
+++ b/trick_source/trick_utils/comm/test/TrickErrorReportTest.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "trick/trick_error_hndlr.h"
+
+class TrickErrorReportTest : public testing::Test {
+protected:
+    TrickErrorHndlr handler;
+    std::string message;
+    TrickErrorLevel level;
+    int calls;
+
+    static void capture(TrickErrorHndlr *handler, TrickErrorLevel level,
+                        const char *, int, const char *message) {
+        TrickErrorReportTest *test = static_cast<TrickErrorReportTest *>(handler->data_ptr);
+        test->message = message;
+        test->level = level;
+        ++test->calls;
+    }
+
+    void SetUp() {
+        calls = 0;
+        trick_error_init(&handler, capture, this, TRICK_ERROR_ALL);
+    }
+};
+
+TEST_F(TrickErrorReportTest, PreservesShortFormattedMessages) {
+    trick_error_report(&handler, TRICK_ERROR_WARNING, __FILE__, __LINE__,
+                       "device %s returned %d", "alpha", 42);
+    EXPECT_EQ("device alpha returned 42", message);
+    EXPECT_EQ(TRICK_ERROR_WARNING, level);
+    EXPECT_EQ(1, calls);
+}
+
+TEST_F(TrickErrorReportTest, TerminatesMessagesAtTheBufferBoundary) {
+    for (size_t size = 4094; size <= 4097; ++size) {
+        std::string input(size, 'x');
+        trick_error_report(&handler, TRICK_ERROR_WARNING, __FILE__, __LINE__, "%s", input.c_str());
+        EXPECT_EQ(input.substr(0, 4095), message);
+    }
+}
+
+TEST_F(TrickErrorReportTest, TruncatesOversizedVariadicMessages) {
+    std::string input(16384, 'x');
+    trick_error_report(&handler, TRICK_ERROR_WARNING, __FILE__, __LINE__,
+                       "prefix:%s:%d", input.c_str(), 42);
+    EXPECT_EQ(("prefix:" + input).substr(0, 4095), message);
+    EXPECT_EQ(1, calls);
+}
+
+TEST_F(TrickErrorReportTest, BoundsFormatWidthExpansion) {
+    trick_error_report(&handler, TRICK_ERROR_WARNING, __FILE__, __LINE__, "%10000d", 1);
+    EXPECT_EQ(std::string(4095, ' '), message);
+}
+
+TEST_F(TrickErrorReportTest, SuppressesMessagesBelowReportLevel) {
+    handler.report_level = TRICK_ERROR_ALERT;
+    std::string input(16384, 'x');
+    trick_error_report(&handler, TRICK_ERROR_ADVISORY, __FILE__, __LINE__, "%s", input.c_str());
+    EXPECT_EQ(0, calls);
+}
+
+TEST_F(TrickErrorReportTest, PreservesEmptyFormatDiagnostic) {
+    trick_error_report(&handler, TRICK_ERROR_WARNING, __FILE__, __LINE__, "%s", "");
+    EXPECT_EQ("", message);
+    trick_error_report(&handler, TRICK_ERROR_WARNING, __FILE__, __LINE__, "");
+    EXPECT_EQ("Empty message for trick_error_report.\n", message);
+    EXPECT_EQ(TRICK_ERROR_ALERT, level);
+}


### PR DESCRIPTION
Closes #2178.

Bound `trick_error_report` formatting to its 4096-byte buffer. Replace FXPlot's fixed-size formatting scratch buffer with length-checked appends that preserve long rows, reserve the null terminator, and guard allocation-size overflow.

Move the table-text helper into a UI-independent header for direct regression coverage. Keep unused capacity zeroed for the existing save callback and add the test target to the DPX unit-test makefile.

### Validation

On macOS arm64:
- All 24 communication tests passed, built directly against the communication sources and GoogleTest.
- 13 focused error/table formatting tests passed with AddressSanitizer and UndefinedBehaviorSanitizer, repeated 20 times.
- Before the fix, AddressSanitizer reproduced both stack-buffer overflows and the table append's exact-capacity heap overflow.
- C++11 smoke build of the production helper and `git diff --check` passed.

Coverage includes ordinary messages, truncation boundaries, expanded format widths, long and repeated table appends, empty output, null-terminator capacity, and size-overflow rejection. The full Trick GUI/simulation and broader DPX suites were not run.
